### PR TITLE
Fix 3D visual exporter deleting cortical region files after export

### DIFF
--- a/tit/gui/extensions/visual_exporter.py
+++ b/tit/gui/extensions/visual_exporter.py
@@ -1045,15 +1045,14 @@ class VisualExporterWidget(QtWidgets.QWidget):
                 central_surface = self.pm.ti_central_surface(
                     subject_id, simulation_name
                 )
-                # Build commands for all formats (STL/PLY/MSH)
-                self._prune_infos = []
-                # Store selected region names once
+                # Build commands for all formats (STL/PLY/MSH).
+                # The exporter writes only these regions, so no post-pruning
+                # is needed.
                 selected = [
                     self.cort_regions_list.item(i).text()
                     for i in range(self.cort_regions_list.count())
                     if self.cort_regions_list.item(i).isSelected()
                 ]
-                self._selected_regions = selected
 
                 # Always export STL via config dataclass
                 stl_config = RegionConfig(
@@ -1072,15 +1071,6 @@ class VisualExporterWidget(QtWidgets.QWidget):
                 commands.append(
                     (["simnibs_python", "-m", "tit.blender", stl_config_path], None)
                 )
-                stl_dir = os.path.join(out_base, "stl")
-                self._prune_infos.append(
-                    {
-                        "format": "stl",
-                        "mode_dir": stl_dir,
-                        "include_whole": True,
-                        "simulation": simulation_name,
-                    }
-                )
 
                 # Always export PLY via config dataclass
                 ply_config = RegionConfig(
@@ -1098,15 +1088,6 @@ class VisualExporterWidget(QtWidgets.QWidget):
                 )
                 commands.append(
                     (["simnibs_python", "-m", "tit.blender", ply_config_path], None)
-                )
-                ply_dir = os.path.join(out_base, "ply")
-                self._prune_infos.append(
-                    {
-                        "format": "ply",
-                        "mode_dir": ply_dir,
-                        "include_whole": True,
-                        "simulation": simulation_name,
-                    }
                 )
 
             elif self.rb_vec.isChecked():
@@ -1353,45 +1334,6 @@ class VisualExporterWidget(QtWidgets.QWidget):
         self._update_output("\n========================================", "success")
         self._update_output("EXPORT COMPLETE", "success")
         self._update_output("========================================", "success")
-        # Post-process: keep only selected cortical regions for each generated format
-        try:
-            infos = getattr(self, "_prune_infos", []) or []
-            sel_list = getattr(self, "_selected_regions", None)
-            if not sel_list:
-                return
-            sel = set(sel_list)
-            for info in infos:
-                if info["format"] == "stl":
-                    regions_dir = os.path.join(
-                        info["mode_dir"], "cortical_stls", "regions"
-                    )
-                    if os.path.isdir(regions_dir):
-                        for f in os.listdir(regions_dir):
-                            if f.lower().endswith(".stl"):
-                                name = os.path.splitext(f)[0]
-                                if name not in sel:
-                                    try:
-                                        os.remove(os.path.join(regions_dir, f))
-                                    except OSError:
-                                        # File may be in use or already deleted
-                                        pass
-                else:
-                    regions_dir = os.path.join(
-                        info["mode_dir"], "cortical_plys", "regions"
-                    )
-                    if os.path.isdir(regions_dir):
-                        for f in os.listdir(regions_dir):
-                            if f.lower().endswith(".ply"):
-                                name = os.path.splitext(f)[0]
-                                if name not in sel:
-                                    try:
-                                        os.remove(os.path.join(regions_dir, f))
-                                    except OSError:
-                                        # File may be in use or already deleted
-                                        pass
-        except Exception:
-            # Directory cleanup may fail if files are in use
-            pass
 
     def _on_error(self, err):
         self.action_buttons.enable_run()


### PR DESCRIPTION
## Problem

When exporting cortical regions in the **3D Visual Exporter** GUI tool, the `.ply`/`.stl` files were written and then immediately deleted, leaving an empty output.

## Root cause

The post-export prune step in `_on_finished` deleted any region file whose name wasn't in the user's selection. But the two sides used different name formats:

- The GUI region list stores **bare** names (e.g. `insula`) — `atlas2subject` hemi dicts are merged without prefixes.
- The exporter writes files **hemisphere-prefixed** (e.g. `lh.insula.stl`, `rh.insula.stl`) via `_resolve_selected`.

So `"lh.insula" not in {"insula"}` was always true and every just-written file was removed.

## Fix

The exporter already restricts output to the selected regions through `RegionConfig.regions`, so the GUI prune was redundant *and* destructive. This PR removes it entirely, along with the `_prune_infos` / `_selected_regions` bookkeeping that fed it. The config dataclass is now the single source of truth for which regions get written.

Net: **+3 / −61 lines**, one file.

## Testing

- File parses cleanly; no dangling references remain.
- Selection logic still enforced in `region_exporter.py` (`skip_regions=not bool(selected)`, `regions=selected`).