### PR TITLE
montage_visualizer: connection arcs always curve toward cap center

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -43,7 +43,9 @@ class TestSaveFigOptions:
     def test_custom_values(self):
         from tit.plotting._common import SaveFigOptions
 
-        opts = SaveFigOptions(dpi=300, bbox_inches="standard", facecolor="black", edgecolor="red")
+        opts = SaveFigOptions(
+            dpi=300, bbox_inches="standard", facecolor="black", edgecolor="red"
+        )
         assert opts.dpi == 300
         assert opts.bbox_inches == "standard"
         assert opts.facecolor == "black"
@@ -145,7 +147,9 @@ class TestSavefigClose:
         from tit.plotting._common import SaveFigOptions, savefig_close
 
         fig = MagicMock()
-        opts = SaveFigOptions(dpi=300, bbox_inches="standard", facecolor="black", edgecolor="red")
+        opts = SaveFigOptions(
+            dpi=300, bbox_inches="standard", facecolor="black", edgecolor="red"
+        )
         result = savefig_close(fig, "/tmp/test.png", fmt="png", opts=opts)
 
         fig.savefig.assert_called_once_with(
@@ -469,6 +473,7 @@ class TestGenerateStaticOverlayImages:
         yield
         import matplotlib.pyplot as plt
         import nibabel as nib
+
         plt.savefig.side_effect = None
         plt.savefig.reset_mock()
         nib.load.side_effect = None
@@ -824,7 +829,7 @@ class TestPlotPermutationNullDistribution:
         null_dist = np.random.rand(200) * 10
         observed = [
             {"stat_value": 15.0},  # No p_value, > threshold => significant
-            {"stat_value": 3.0},   # No p_value, < threshold => non-significant
+            {"stat_value": 3.0},  # No p_value, < threshold => non-significant
         ]
         output_file = str(tmp_path / "null_no_p.pdf")
 
@@ -854,8 +859,8 @@ class TestPlotPermutationNullDistribution:
         observed = [
             {"stat_value": 15.0, "p_value": 0.01},  # sig #1 - gets label
             {"stat_value": 12.0, "p_value": 0.02},  # sig #2 - no label
-            {"stat_value": 3.0, "p_value": 0.10},   # non-sig #1 - gets label
-            {"stat_value": 2.0, "p_value": 0.50},   # non-sig #2 - no label
+            {"stat_value": 3.0, "p_value": 0.10},  # non-sig #1 - gets label
+            {"stat_value": 2.0, "p_value": 0.50},  # non-sig #2 - no label
         ]
         output_file = str(tmp_path / "multi.pdf")
 
@@ -871,7 +876,11 @@ class TestPlotPermutationNullDistribution:
         assert mock_ax.axvline.call_count == 5
 
         # Check that only the first sig and first non-sig got labels
-        label_calls = [c for c in mock_ax.axvline.call_args_list if c.kwargs.get("label") is not None]
+        label_calls = [
+            c
+            for c in mock_ax.axvline.call_args_list
+            if c.kwargs.get("label") is not None
+        ]
         # Should have exactly 2 labeled axvline calls (plus the threshold which has a label)
         # Actually threshold also has label, so 3 labeled calls total
         # But we check cluster labels only (not the threshold one)
@@ -923,7 +932,9 @@ class TestPlotClusterSizeMassCorrelation:
         output_file = str(tmp_path / "corr.pdf")
 
         with patch("scipy.stats.pearsonr", return_value=(0.95, 0.001)):
-            result = plot_cluster_size_mass_correlation(sizes, masses, output_file, dpi=150)
+            result = plot_cluster_size_mass_correlation(
+                sizes, masses, output_file, dpi=150
+            )
 
         assert result == output_file
         mock_fig.savefig.assert_called_once()
@@ -1108,7 +1119,9 @@ class TestPlotIntensityVsFocality:
         # Scatter should be called with composite coloring
         mock_ax.scatter.assert_called_once()
         scatter_kwargs = mock_ax.scatter.call_args
-        assert scatter_kwargs.kwargs.get("c") == [0.5, 0.6, 0.7] or scatter_kwargs[1].get("c") == [0.5, 0.6, 0.7]
+        assert scatter_kwargs.kwargs.get("c") == [0.5, 0.6, 0.7] or scatter_kwargs[
+            1
+        ].get("c") == [0.5, 0.6, 0.7]
         # Colorbar should be added
         mock_fig.colorbar.assert_called_once()
 
@@ -1197,3 +1210,67 @@ class TestPlottingPackageExports:
         assert callable(plot_cluster_size_mass_correlation)
         assert callable(plot_montage_distributions)
         assert callable(plot_intensity_vs_focality)
+
+
+# ============================================================================
+# nilearn/surface.py — fsaverage surface rendering
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestRenderFsaverageMap:
+    """tit.plotting.nilearn.surface.render_fsaverage_map / render_surface_stats_result."""
+
+    def _mock_subplots(self):
+        # 2x2 object array of axes mocks + a figure mock, matching plt.subplots.
+        axes = np.empty((2, 2), dtype=object)
+        for i in range(2):
+            for j in range(2):
+                axes[i, j] = MagicMock()
+        fig = MagicMock()
+        sys.modules["matplotlib.pyplot"].subplots = MagicMock(return_value=(fig, axes))
+        return fig
+
+    def test_wrong_length_raises(self):
+        from tit.plotting.nilearn.surface import render_fsaverage_map
+
+        with pytest.raises(ValueError):
+            render_fsaverage_map(np.zeros(100), spacing=5)
+
+    def test_paints_four_panels(self):
+        from tit.plotting.nilearn import surface
+        from tit.source.fsaverage import _FSAVG_NODES
+
+        self._mock_subplots()
+        plotting = sys.modules["nilearn.plotting"]
+        plotting.plot_surf_stat_map = MagicMock()
+
+        fig = surface.render_fsaverage_map(np.zeros(_FSAVG_NODES[5]), spacing=5)
+        # 2 hemispheres x 2 views = 4 surface panels.
+        assert plotting.plot_surf_stat_map.call_count == 4
+        assert fig is not None
+
+    def test_stats_result_renders_effect_and_clusters(self, tmp_path, monkeypatch):
+        from tit.plotting.nilearn import surface
+        from tit.source.fsaverage import _FSAVG_NODES
+
+        n = _FSAVG_NODES[5]
+        npz = tmp_path / "surface_maps.npz"
+        np.savez_compressed(
+            npz,
+            r=np.zeros(n),
+            t=np.zeros(n),
+            p=np.ones(n),
+            sig_mask=np.concatenate([np.ones(10), np.zeros(n - 10)]),
+        )
+        calls = []
+        monkeypatch.setattr(
+            surface,
+            "render_fsaverage_map",
+            lambda values, spacing=5, **kw: calls.append(kw.get("title"))
+            or kw.get("out_path"),
+        )
+        written = surface.render_surface_stats_result(str(npz), str(tmp_path / "out"))
+        # effect (r) map + significant-cluster map.
+        assert len(written) == 2
+        assert "r map" in calls and "significant clusters" in calls

--- a/tests/test_sim_config.py
+++ b/tests/test_sim_config.py
@@ -263,7 +263,7 @@ class TestSimulationConfig:
         assert config.map_to_surf is True
         assert config.map_to_vol is False
         assert config.map_to_mni is False
-        assert config.map_to_fsavg is False
+        assert config.map_to_fsavg is True  # on by default: auto fsaverage projection
 
     def test_custom_electrode_fields(self):
         config = SimulationConfig(

--- a/tests/test_sim_utils.py
+++ b/tests/test_sim_utils.py
@@ -570,3 +570,60 @@ class TestRunMontageVisualization:
             logger=logger,
         )
         logger.warning.assert_not_called()
+
+
+# ============================================================================
+# Automatic fsaverage projection hook
+# ============================================================================
+
+
+class TestProjectMontageToFsaverage:
+    """``map_to_fsavg`` hook: TI projects, mTI skips, errors never abort the sim."""
+
+    def _montage(self, mode, name="M1"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(simulation_mode=mode, name=name)
+
+    def test_ti_montage_projects(self, monkeypatch):
+        from tit.sim import utils
+
+        calls = []
+        monkeypatch.setattr(
+            "tit.source.fsaverage.project_subject",
+            lambda sid, sim, cfg: calls.append((sid, sim)) or (sid, "ok", "done"),
+        )
+        config = SimulationConfig(subject_id="001", montages=[])
+        utils._project_montage_to_fsaverage(
+            config, self._montage(SimulationMode.TI, "TI_sim"), MagicMock()
+        )
+        assert calls == [("001", "TI_sim")]
+
+    def test_mti_montage_skipped(self, monkeypatch):
+        from tit.sim import utils
+
+        calls = []
+        monkeypatch.setattr(
+            "tit.source.fsaverage.project_subject",
+            lambda *a: calls.append(a) or ("x", "ok", ""),
+        )
+        config = SimulationConfig(subject_id="001", montages=[])
+        utils._project_montage_to_fsaverage(
+            config, self._montage(SimulationMode.MTI), MagicMock()
+        )
+        assert calls == []
+
+    def test_projection_error_is_non_fatal(self, monkeypatch):
+        from tit.sim import utils
+
+        def boom(*a):
+            raise RuntimeError("morph blew up")
+
+        monkeypatch.setattr("tit.source.fsaverage.project_subject", boom)
+        logger = MagicMock()
+        config = SimulationConfig(subject_id="001", montages=[])
+        # Must not raise.
+        utils._project_montage_to_fsaverage(
+            config, self._montage(SimulationMode.TI), logger
+        )
+        assert logger.warning.called

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -135,7 +135,9 @@ class TestFsavgHelpers:
         e2 = np.array([[-1.0, 0.0, 0.0]])
         monkeypatch.setattr(fsaverage, "_carrier_overlays", lambda *a: ("p1", "p2"))
         monkeypatch.setattr(
-            fsaverage, "_read_surface_vector", lambda p: e1 if p == "p1" else e2
+            fsaverage,
+            "_read_carrier_fields",
+            lambda p: (np.array([1.0]), e1) if p == "p1" else (np.array([1.0]), e2),
         )
         monkeypatch.setattr(fsaverage, "_hemisphere_node_counts", lambda sf: (1, 0))
         monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
@@ -156,6 +158,39 @@ class TestFsavgHelpers:
         )
         assert out["hf_max"][0] == pytest.approx(2.0)
         assert out["magnitude"][0] == pytest.approx(0.0)
+
+    def test_hf_max_works_without_vector_e_magnitude_skipped(self, monkeypatch):
+        """When the overlay has only magnE (no vector E): hf_max ok, magnitude skipped."""
+        import numpy as np
+
+        from tit.source import fsaverage
+        from tit.source.config import FsavgMapConfig
+
+        monkeypatch.setattr(fsaverage, "_carrier_overlays", lambda *a: ("p1", "p2"))
+        # magnE-only overlays: magnitude present, vector None.
+        monkeypatch.setattr(
+            fsaverage,
+            "_read_carrier_fields",
+            lambda p: (np.array([0.6]), None) if p == "p1" else (np.array([0.4]), None),
+        )
+        monkeypatch.setattr(fsaverage, "_hemisphere_node_counts", lambda sf: (1, 0))
+        monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
+        monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
+
+        import sys
+        from unittest.mock import MagicMock
+
+        sys.modules["simnibs.utils.file_finder"].SubjectFiles = lambda **kw: MagicMock(
+            hemispheres=("lh",)
+        )
+        sys.modules["simnibs.utils.transformations"].cross_subject_map = (
+            lambda *a, **kw: {}
+        )
+        out = fsaverage._compute_fields(
+            MagicMock(), "001", "TI_sim", FsavgMapConfig(fields=("hf_max", "magnitude"))
+        )
+        assert out["hf_max"][0] == pytest.approx(1.0)  # 0.6 + 0.4
+        assert "magnitude" not in out  # can't do |E1+E2| without vectors
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -72,9 +72,12 @@ class TestForwardPaths:
         expected = init_pm.sub("001") + "/forward"
         assert init_pm.forward("001").replace("//", "/") == expected.replace("//", "/")
 
-    def test_forward_fsaverage_nested_under_forward(self, init_pm):
-        assert init_pm.forward_fsaverage("001").startswith(init_pm.forward("001"))
-        assert init_pm.forward_fsaverage("001").endswith("forward/fsaverage")
+    def test_sim_fsaverage_nested_under_simulation(self, init_pm):
+        path = init_pm.sim_fsaverage("001", "Thalamus")
+        assert path.startswith(init_pm.simulation("001", "Thalamus"))
+        assert path.endswith("Simulations/Thalamus/fsaverage")
+        # Must NOT live under the EEG source-forward directory.
+        assert "/forward/" not in path
 
     def test_forward_distinct_from_leadfields(self, init_pm):
         assert init_pm.forward("001") != init_pm.leadfields("001")
@@ -102,7 +105,7 @@ class TestFsavgHelpers:
 
         path = fsaverage._output_path(init_pm, "001", "TI_sim", 5)
         assert path.name == "sub-001_sim-TI_sim_space-fsaverage5_fields.npz"
-        assert str(path.parent).endswith("forward/fsaverage")
+        assert str(path.parent).endswith("Simulations/TI_sim/fsaverage")
 
     def test_carrier_volume_meshes_skips_central_overlays(self, tmp_path):
         """Locate the per-pair VOLUME meshes, not the *_central.msh overlays."""

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,6 +1,7 @@
 """Tests for the ``tit.source`` EEG forward / fsaverage-map module."""
 
 import json
+from unittest.mock import MagicMock as _MagicMock
 
 import pytest
 
@@ -103,28 +104,38 @@ class TestFsavgHelpers:
         assert path.name == "sub-001_sim-TI_sim_space-fsaverage5_fields.npz"
         assert str(path.parent).endswith("forward/fsaverage")
 
-    @pytest.mark.parametrize("overlay_subdir", ["subject_overlays", "surface_overlays"])
-    def test_carrier_overlays_found_in_either_layout(self, tmp_path, overlay_subdir):
-        """The glob must resolve overlays both before and after file organization."""
+    def test_carrier_volume_meshes_skips_central_overlays(self, tmp_path):
+        """Locate the per-pair VOLUME meshes, not the *_central.msh overlays."""
         from types import SimpleNamespace
 
         from tit.source import fsaverage
 
         sim_dir = tmp_path / "TI_sim"
-        overlays = sim_dir / "TI" / overlay_subdir
+        vol_dir = sim_dir / "high_Frequency" / "mesh"
+        vol_dir.mkdir(parents=True)
+        overlays = sim_dir / "TI" / "surface_overlays"
         overlays.mkdir(parents=True)
         for pair in (1, 2):
+            (vol_dir / f"001_TDCS_{pair}_scalar.msh").write_text("")
+            # Central overlays must NOT be picked up as the volume mesh.
             (overlays / f"001_TDCS_{pair}_scalar_central.msh").write_text("")
-        # The TI overlay must NOT be mistaken for a carrier overlay.
-        (overlays / "TI_sim_TI_central.msh").write_text("")
 
         pm = SimpleNamespace(simulation=lambda sid, sim: str(sim_dir))
-        p1, p2 = fsaverage._carrier_overlays(pm, "001", "TI_sim")
-        assert p1.name == "001_TDCS_1_scalar_central.msh"
-        assert p2.name == "001_TDCS_2_scalar_central.msh"
+        v1, v2 = fsaverage._carrier_volume_meshes(pm, "001", "TI_sim")
+        assert v1.name == "001_TDCS_1_scalar.msh"
+        assert v2.name == "001_TDCS_2_scalar.msh"
 
-    def test_hf_max_is_sum_of_carrier_magnitudes(self, monkeypatch):
-        """hf_max = |E1| + |E2| (sum of magnitudes), not |E1 + E2|."""
+    def test_carrier_volume_meshes_missing_raises(self, tmp_path):
+        from types import SimpleNamespace
+
+        from tit.source import fsaverage
+
+        pm = SimpleNamespace(simulation=lambda sid, sim: str(tmp_path))
+        with pytest.raises(FileNotFoundError):
+            fsaverage._carrier_volume_meshes(pm, "001", "TI_sim")
+
+    def test_hf_max_and_magnitude_from_carrier_vectors(self, monkeypatch):
+        """hf_max = |E1|+|E2|, magnitude = |E1+E2|, from the interpolated vectors."""
         import numpy as np
 
         from tit.source import fsaverage
@@ -133,64 +144,69 @@ class TestFsavgHelpers:
         # Two anti-parallel carriers: |E1|+|E2| = 2, but |E1+E2| = 0.
         e1 = np.array([[1.0, 0.0, 0.0]])
         e2 = np.array([[-1.0, 0.0, 0.0]])
-        monkeypatch.setattr(fsaverage, "_carrier_overlays", lambda *a: ("p1", "p2"))
+        monkeypatch.setattr(
+            fsaverage, "_carrier_volume_meshes", lambda *a: ("v1", "v2")
+        )
         monkeypatch.setattr(
             fsaverage,
-            "_read_carrier_fields",
-            lambda p: (np.array([1.0]), e1) if p == "p1" else (np.array([1.0]), e2),
+            "_carrier_vectors_on_central",
+            lambda vol, central, hemis: e1 if vol == "v1" else e2,
         )
-        monkeypatch.setattr(fsaverage, "_hemisphere_node_counts", lambda sf: (1, 0))
         monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
         monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
 
-        import sys
-        from unittest.mock import MagicMock
-
-        sys.modules["simnibs.utils.file_finder"].SubjectFiles = lambda **kw: MagicMock(
-            hemispheres=("lh",)
-        )
-        sys.modules["simnibs.utils.transformations"].cross_subject_map = (
-            lambda *a, **kw: {}
-        )
-        pm = MagicMock()
+        self._mock_simnibs_core(monkeypatch)
         out = fsaverage._compute_fields(
-            pm, "001", "TI_sim", FsavgMapConfig(fields=("hf_max", "magnitude"))
+            _MagicMock(),
+            "001",
+            "TI_sim",
+            FsavgMapConfig(fields=("hf_max", "magnitude")),
         )
         assert out["hf_max"][0] == pytest.approx(2.0)
         assert out["magnitude"][0] == pytest.approx(0.0)
 
-    def test_hf_max_works_without_vector_e_magnitude_skipped(self, monkeypatch):
-        """When the overlay has only magnE (no vector E): hf_max ok, magnitude skipped."""
+    def test_carrier_failure_keeps_ti_fields(self, monkeypatch):
+        """A carrier read failure drops hf_max/magnitude but keeps TI_max/TI_normal."""
         import numpy as np
 
         from tit.source import fsaverage
         from tit.source.config import FsavgMapConfig
 
-        monkeypatch.setattr(fsaverage, "_carrier_overlays", lambda *a: ("p1", "p2"))
-        # magnE-only overlays: magnitude present, vector None.
+        def _boom(*a):
+            raise FileNotFoundError("no volume mesh")
+
+        monkeypatch.setattr(fsaverage, "_carrier_volume_meshes", _boom)
         monkeypatch.setattr(
-            fsaverage,
-            "_read_carrier_fields",
-            lambda p: (np.array([0.6]), None) if p == "p1" else (np.array([0.4]), None),
+            fsaverage, "_read_surface_scalar", lambda path, name: np.array([0.5])
         )
-        monkeypatch.setattr(fsaverage, "_hemisphere_node_counts", lambda sf: (1, 0))
+        monkeypatch.setattr(fsaverage, "_ti_max_overlay", lambda *a: "ti")
+        monkeypatch.setattr(fsaverage, "_ti_normal_overlay", lambda *a: "tn")
         monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
         monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
 
-        import sys
-        from unittest.mock import MagicMock
+        self._mock_simnibs_core(monkeypatch)
+        out = fsaverage._compute_fields(_MagicMock(), "001", "TI_sim", FsavgMapConfig())
+        assert "TI_max" in out and "TI_normal" in out
+        assert "hf_max" not in out and "magnitude" not in out
 
-        sys.modules["simnibs.utils.file_finder"].SubjectFiles = lambda **kw: MagicMock(
+    @staticmethod
+    def _mock_simnibs_core(monkeypatch):
+        """Stub SubjectFiles / cross_subject_map / load_subject_surfaces (1 lh node)."""
+        import sys
+        from types import SimpleNamespace
+
+        sys.modules["simnibs.utils.file_finder"].SubjectFiles = lambda **kw: _MagicMock(
             hemispheres=("lh",)
         )
         sys.modules["simnibs.utils.transformations"].cross_subject_map = (
             lambda *a, **kw: {}
         )
-        out = fsaverage._compute_fields(
-            MagicMock(), "001", "TI_sim", FsavgMapConfig(fields=("hf_max", "magnitude"))
+        sys.modules["simnibs.mesh_tools"].mesh_io.load_subject_surfaces = (
+            lambda sf, kind: {
+                "lh": SimpleNamespace(nodes=SimpleNamespace(nr=1)),
+                "rh": SimpleNamespace(nodes=SimpleNamespace(nr=0)),
+            }
         )
-        assert out["hf_max"][0] == pytest.approx(1.0)  # 0.6 + 0.4
-        assert "magnitude" not in out  # can't do |E1+E2| without vectors
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -134,24 +134,25 @@ class TestFsavgHelpers:
         with pytest.raises(FileNotFoundError):
             fsaverage._carrier_volume_meshes(pm, "001", "TI_sim")
 
-    def test_hf_max_and_magnitude_from_carrier_vectors(self, monkeypatch):
-        """hf_max = |E1|+|E2|, magnitude = |E1+E2|, from the interpolated vectors."""
+    def test_hf_max_from_magne_magnitude_from_vector(self, monkeypatch):
+        """hf_max = magnE1+magnE2 (scalar); magnitude = |E1+E2| (vector)."""
         import numpy as np
 
         from tit.source import fsaverage
         from tit.source.config import FsavgMapConfig
 
-        # Two anti-parallel carriers: |E1|+|E2| = 2, but |E1+E2| = 0.
-        e1 = np.array([[1.0, 0.0, 0.0]])
-        e2 = np.array([[-1.0, 0.0, 0.0]])
         monkeypatch.setattr(
             fsaverage, "_carrier_volume_meshes", lambda *a: ("v1", "v2")
         )
-        monkeypatch.setattr(
-            fsaverage,
-            "_carrier_vectors_on_central",
-            lambda vol, central, hemis: e1 if vol == "v1" else e2,
-        )
+        monkeypatch.setattr(fsaverage, "_load_carrier_mesh", lambda vol: (vol, "gm"))
+
+        def _interp(mesh, gm, name, central, hemis):
+            if name == "magnE":
+                return np.array([1.0])  # each carrier |E| = 1  -> hf_max = 2
+            # name == "E": anti-parallel carriers -> |E1 + E2| = 0
+            return np.array([[1.0, 0.0, 0.0]] if mesh == "v1" else [[-1.0, 0.0, 0.0]])
+
+        monkeypatch.setattr(fsaverage, "_interp_to_central", _interp)
         monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
         monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
 
@@ -164,6 +165,37 @@ class TestFsavgHelpers:
         )
         assert out["hf_max"][0] == pytest.approx(2.0)
         assert out["magnitude"][0] == pytest.approx(0.0)
+
+    def test_hf_max_survives_when_vector_interp_fails(self, monkeypatch):
+        """A vector-E interpolation failure skips magnitude but keeps hf_max."""
+        import numpy as np
+
+        from tit.source import fsaverage
+        from tit.source.config import FsavgMapConfig
+
+        monkeypatch.setattr(
+            fsaverage, "_carrier_volume_meshes", lambda *a: ("v1", "v2")
+        )
+        monkeypatch.setattr(fsaverage, "_load_carrier_mesh", lambda vol: (vol, "gm"))
+
+        def _interp(mesh, gm, name, central, hemis):
+            if name == "magnE":
+                return np.array([0.5])
+            raise ValueError("vector interpolation unsupported")
+
+        monkeypatch.setattr(fsaverage, "_interp_to_central", _interp)
+        monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
+        monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
+
+        self._mock_simnibs_core(monkeypatch)
+        out = fsaverage._compute_fields(
+            _MagicMock(),
+            "001",
+            "TI_sim",
+            FsavgMapConfig(fields=("hf_max", "magnitude")),
+        )
+        assert out["hf_max"][0] == pytest.approx(1.0)  # 0.5 + 0.5
+        assert "magnitude" not in out
 
     def test_carrier_failure_keeps_ti_fields(self, monkeypatch):
         """A carrier read failure drops hf_max/magnitude but keeps TI_max/TI_normal."""

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -32,8 +32,14 @@ class TestFsavgMapConfig:
         from tit.source import FsavgMapConfig
 
         cfg = FsavgMapConfig()
-        assert cfg.fields == ("TI_max", "TI_normal", "magnitude")
+        assert cfg.fields == ("TI_max", "TI_normal", "magnitude", "hf_max")
         assert cfg.fsaverage_spacing == 5
+
+    def test_hf_max_is_a_valid_field(self):
+        from tit.source import FsavgMapConfig
+
+        cfg = FsavgMapConfig(fields=("hf_max",))
+        assert cfg.fields == ("hf_max",)
 
     def test_unknown_field_raises(self):
         from tit.source import FsavgMapConfig
@@ -96,6 +102,60 @@ class TestFsavgHelpers:
         path = fsaverage._output_path(init_pm, "001", "TI_sim", 5)
         assert path.name == "sub-001_sim-TI_sim_space-fsaverage5_fields.npz"
         assert str(path.parent).endswith("forward/fsaverage")
+
+    @pytest.mark.parametrize("overlay_subdir", ["subject_overlays", "surface_overlays"])
+    def test_carrier_overlays_found_in_either_layout(self, tmp_path, overlay_subdir):
+        """The glob must resolve overlays both before and after file organization."""
+        from types import SimpleNamespace
+
+        from tit.source import fsaverage
+
+        sim_dir = tmp_path / "TI_sim"
+        overlays = sim_dir / "TI" / overlay_subdir
+        overlays.mkdir(parents=True)
+        for pair in (1, 2):
+            (overlays / f"001_TDCS_{pair}_scalar_central.msh").write_text("")
+        # The TI overlay must NOT be mistaken for a carrier overlay.
+        (overlays / "TI_sim_TI_central.msh").write_text("")
+
+        pm = SimpleNamespace(simulation=lambda sid, sim: str(sim_dir))
+        p1, p2 = fsaverage._carrier_overlays(pm, "001", "TI_sim")
+        assert p1.name == "001_TDCS_1_scalar_central.msh"
+        assert p2.name == "001_TDCS_2_scalar_central.msh"
+
+    def test_hf_max_is_sum_of_carrier_magnitudes(self, monkeypatch):
+        """hf_max = |E1| + |E2| (sum of magnitudes), not |E1 + E2|."""
+        import numpy as np
+
+        from tit.source import fsaverage
+        from tit.source.config import FsavgMapConfig
+
+        # Two anti-parallel carriers: |E1|+|E2| = 2, but |E1+E2| = 0.
+        e1 = np.array([[1.0, 0.0, 0.0]])
+        e2 = np.array([[-1.0, 0.0, 0.0]])
+        monkeypatch.setattr(fsaverage, "_carrier_overlays", lambda *a: ("p1", "p2"))
+        monkeypatch.setattr(
+            fsaverage, "_read_surface_vector", lambda p: e1 if p == "p1" else e2
+        )
+        monkeypatch.setattr(fsaverage, "_hemisphere_node_counts", lambda sf: (1, 0))
+        monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
+        monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
+
+        import sys
+        from unittest.mock import MagicMock
+
+        sys.modules["simnibs.utils.file_finder"].SubjectFiles = lambda **kw: MagicMock(
+            hemispheres=("lh",)
+        )
+        sys.modules["simnibs.utils.transformations"].cross_subject_map = (
+            lambda *a, **kw: {}
+        )
+        pm = MagicMock()
+        out = fsaverage._compute_fields(
+            pm, "001", "TI_sim", FsavgMapConfig(fields=("hf_max", "magnitude"))
+        )
+        assert out["hf_max"][0] == pytest.approx(2.0)
+        assert out["magnitude"][0] == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -113,12 +113,16 @@ class TestFsavgHelpers:
         sim_dir = tmp_path / "TI_sim"
         vol_dir = sim_dir / "high_Frequency" / "mesh"
         vol_dir.mkdir(parents=True)
-        overlays = sim_dir / "TI" / "surface_overlays"
-        overlays.mkdir(parents=True)
+        # Central overlays in both layouts must NOT be picked as the volume mesh:
+        # under high_Frequency/subject_overlays/ (pre-organize) and TI/ (post).
+        pre_overlays = sim_dir / "high_Frequency" / "subject_overlays"
+        post_overlays = sim_dir / "TI" / "surface_overlays"
+        pre_overlays.mkdir(parents=True)
+        post_overlays.mkdir(parents=True)
         for pair in (1, 2):
             (vol_dir / f"001_TDCS_{pair}_scalar.msh").write_text("")
-            # Central overlays must NOT be picked up as the volume mesh.
-            (overlays / f"001_TDCS_{pair}_scalar_central.msh").write_text("")
+            (pre_overlays / f"001_TDCS_{pair}_scalar_central.msh").write_text("")
+            (post_overlays / f"001_TDCS_{pair}_scalar_central.msh").write_text("")
 
         pm = SimpleNamespace(simulation=lambda sid, sim: str(sim_dir))
         v1, v2 = fsaverage._carrier_volume_meshes(pm, "001", "TI_sim")
@@ -134,25 +138,25 @@ class TestFsavgHelpers:
         with pytest.raises(FileNotFoundError):
             fsaverage._carrier_volume_meshes(pm, "001", "TI_sim")
 
-    def test_hf_max_from_magne_magnitude_from_vector(self, monkeypatch):
-        """hf_max = magnE1+magnE2 (scalar); magnitude = |E1+E2| (vector)."""
+    def test_hf_max_and_magnitude_from_carrier_e(self, monkeypatch):
+        """Both derive from the interpolated vector E: hf_max=|E1|+|E2|, mag=|E1+E2|."""
         import numpy as np
 
         from tit.source import fsaverage
         from tit.source.config import FsavgMapConfig
 
+        # Anti-parallel carriers: |E1|+|E2| = 2, but |E1+E2| = 0.
         monkeypatch.setattr(
             fsaverage, "_carrier_volume_meshes", lambda *a: ("v1", "v2")
         )
         monkeypatch.setattr(fsaverage, "_load_carrier_mesh", lambda vol: (vol, "gm"))
-
-        def _interp(mesh, gm, name, central, hemis):
-            if name == "magnE":
-                return np.array([1.0])  # each carrier |E| = 1  -> hf_max = 2
-            # name == "E": anti-parallel carriers -> |E1 + E2| = 0
-            return np.array([[1.0, 0.0, 0.0]] if mesh == "v1" else [[-1.0, 0.0, 0.0]])
-
-        monkeypatch.setattr(fsaverage, "_interp_to_central", _interp)
+        monkeypatch.setattr(
+            fsaverage,
+            "_interp_to_central",
+            lambda mesh, gm, name, central, hemis: (
+                np.array([[1.0, 0.0, 0.0]] if mesh == "v1" else [[-1.0, 0.0, 0.0]])
+            ),
+        )
         monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
         monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
 
@@ -166,36 +170,33 @@ class TestFsavgHelpers:
         assert out["hf_max"][0] == pytest.approx(2.0)
         assert out["magnitude"][0] == pytest.approx(0.0)
 
-    def test_hf_max_survives_when_vector_interp_fails(self, monkeypatch):
-        """A vector-E interpolation failure skips magnitude but keeps hf_max."""
+    def test_carrier_interp_failure_keeps_ti_fields(self, monkeypatch):
+        """A carrier E-interpolation failure skips hf_max/magnitude, keeps TI."""
         import numpy as np
 
         from tit.source import fsaverage
         from tit.source.config import FsavgMapConfig
 
+        def _boom(*a):
+            raise ValueError("interp failed")
+
         monkeypatch.setattr(
             fsaverage, "_carrier_volume_meshes", lambda *a: ("v1", "v2")
         )
         monkeypatch.setattr(fsaverage, "_load_carrier_mesh", lambda vol: (vol, "gm"))
-
-        def _interp(mesh, gm, name, central, hemis):
-            if name == "magnE":
-                return np.array([0.5])
-            raise ValueError("vector interpolation unsupported")
-
-        monkeypatch.setattr(fsaverage, "_interp_to_central", _interp)
+        monkeypatch.setattr(fsaverage, "_interp_to_central", _boom)
+        monkeypatch.setattr(
+            fsaverage, "_read_surface_scalar", lambda path, name: np.array([0.5])
+        )
+        monkeypatch.setattr(fsaverage, "_ti_max_overlay", lambda *a: "ti")
+        monkeypatch.setattr(fsaverage, "_ti_normal_overlay", lambda *a: "tn")
         monkeypatch.setattr(fsaverage, "_morph_split", lambda v, *a: v)
         monkeypatch.setattr(fsaverage, "_FSAVG_NODES", {5: 1})
 
         self._mock_simnibs_core(monkeypatch)
-        out = fsaverage._compute_fields(
-            _MagicMock(),
-            "001",
-            "TI_sim",
-            FsavgMapConfig(fields=("hf_max", "magnitude")),
-        )
-        assert out["hf_max"][0] == pytest.approx(1.0)  # 0.5 + 0.5
-        assert "magnitude" not in out
+        out = fsaverage._compute_fields(_MagicMock(), "001", "TI_sim", FsavgMapConfig())
+        assert "TI_max" in out and "TI_normal" in out
+        assert "hf_max" not in out and "magnitude" not in out
 
     def test_carrier_failure_keeps_ti_fields(self, monkeypatch):
         """A carrier read failure drops hf_max/magnitude but keeps TI_max/TI_normal."""

--- a/tests/test_stats_surface.py
+++ b/tests/test_stats_surface.py
@@ -130,6 +130,83 @@ class TestLoadGroupSurfaceData:
 # ---------------------------------------------------------------------------
 
 
+class TestSurfaceClusterMath:
+    """Pure-numpy cluster conventions (no scipy needed)."""
+
+    def test_max_cluster_stat_excludes_singletons(self):
+        from tit.stats import surface
+
+        # cluster 1: size 2 (verts 1,2), cluster 2: singleton (vert 3, big mass).
+        labels = np.array([0, 1, 1, 2, 0])
+        t = np.array([0.0, 1.0, 2.0, 5.0, 0.0])
+        # mass: singleton's 5.0 is ignored; cluster 1 mass = 3.0.
+        assert surface._max_cluster_stat(labels, 2, t, "mass") == 3.0
+        assert surface._max_cluster_stat(labels, 2, t, "size") == 2.0
+
+    def test_max_cluster_stat_all_singletons_is_zero(self):
+        from tit.stats import surface
+
+        labels = np.array([0, 1, 2, 3])
+        t = np.array([0.0, 9.0, 9.0, 9.0])
+        assert surface._max_cluster_stat(labels, 3, t, "mass") == 0.0
+
+    def test_cluster_sizes_masses_alignment(self):
+        from tit.stats import surface
+
+        labels = np.array([0, 1, 1, 2])
+        t = np.array([0.0, 1.0, 2.0, 4.0])
+        sizes, masses = surface._cluster_sizes_masses(labels, 2, t)
+        assert list(sizes) == [2, 1]
+        assert list(masses) == [3.0, 4.0]
+
+    def test_null_threshold_matches_engine_formula(self):
+        from tit.stats import surface
+
+        null = np.array([1.0, 5.0, 3.0, 2.0, 4.0])
+        # sorted desc [5,4,3,2,1]; ti = max(1, min(int(0.4*5)=2, 5)) = 2 -> idx 1 -> 4.
+        assert surface._null_threshold(null, 0.4, 5) == 4.0
+
+    def test_null_threshold_empty_is_zero(self):
+        from tit.stats import surface
+
+        assert surface._null_threshold(np.array([]), 0.05, 0) == 0.0
+
+
+class TestEnumCoercion:
+    """Fix: string config fields (from the GUI) coerce to enums so .value works."""
+
+    def test_group_string_fields_coerced(self):
+        cfg = GroupComparisonConfig(
+            analysis_name="a",
+            subjects=[
+                GroupComparisonConfig.Subject("1", "s", 1),
+                GroupComparisonConfig.Subject("2", "s", 0),
+            ],
+            test_type="paired",
+            cluster_stat="size",
+            alternative="greater",
+            space="mni",
+        )
+        assert cfg.test_type.value == "paired"
+        assert cfg.cluster_stat.value == "size"
+        assert cfg.alternative.value == "greater"
+        assert cfg.space.value == "mni"
+
+    def test_correlation_string_fields_coerced(self):
+        cfg = CorrelationConfig(
+            analysis_name="a",
+            subjects=[
+                CorrelationConfig.Subject("1", "s", 1.0),
+                CorrelationConfig.Subject("2", "s", 2.0),
+                CorrelationConfig.Subject("3", "s", 3.0),
+            ],
+            correlation_type="spearman",
+            cluster_stat="mass",
+        )
+        assert cfg.correlation_type.value == "spearman"
+        assert cfg.cluster_stat.value == "mass"
+
+
 class TestSurfaceDispatch:
     def test_correlation_dispatches_to_surface(self, monkeypatch):
         from tit.stats import permutation

--- a/tests/test_stats_surface.py
+++ b/tests/test_stats_surface.py
@@ -1,0 +1,176 @@
+"""Tests for the fsaverage surface stats backend (``tit.stats.surface``).
+
+scipy / nilearn are mocked in this environment, so the adjacency build and
+permutation clustering can't run numerically here -- those are exercised in the
+container.  What's covered: config wiring for the ``space`` option, the npz
+loader (real numpy), and the runner dispatch from ``tit.stats.permutation``.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# tit.stats.__init__ -> permutation -> engine imports scipy submodules the global
+# conftest doesn't mock.  Inject them (numpy stays REAL so the loader test runs).
+for _mod in ("scipy.ndimage", "scipy.stats", "scipy.sparse", "scipy.sparse.csgraph"):
+    sys.modules.setdefault(_mod, MagicMock())
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from tit.stats.config import CorrelationConfig, GroupComparisonConfig  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Config: space option
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceConfig:
+    def _corr_subjects(self):
+        return [
+            CorrelationConfig.Subject("001", "TI_sim", 1.0),
+            CorrelationConfig.Subject("002", "TI_sim", 2.0),
+            CorrelationConfig.Subject("003", "TI_sim", 3.0),
+        ]
+
+    def test_default_space_is_mni(self):
+        cfg = CorrelationConfig(analysis_name="a", subjects=self._corr_subjects())
+        assert cfg.space == CorrelationConfig.AnalysisSpace.MNI
+
+    def test_fsaverage_space_accepts_valid_field(self):
+        cfg = CorrelationConfig(
+            analysis_name="a",
+            subjects=self._corr_subjects(),
+            space=CorrelationConfig.AnalysisSpace.FSAVERAGE,
+            fsaverage_field="hf_max",
+        )
+        assert cfg.fsaverage_field == "hf_max"
+
+    def test_fsaverage_space_rejects_unknown_field(self):
+        with pytest.raises(ValueError):
+            CorrelationConfig(
+                analysis_name="a",
+                subjects=self._corr_subjects(),
+                space=CorrelationConfig.AnalysisSpace.FSAVERAGE,
+                fsaverage_field="bogus",
+            )
+
+    def test_fsaverage_space_rejects_bad_spacing(self):
+        with pytest.raises(ValueError):
+            GroupComparisonConfig(
+                analysis_name="a",
+                subjects=[
+                    GroupComparisonConfig.Subject("001", "TI_sim", 1),
+                    GroupComparisonConfig.Subject("002", "TI_sim", 0),
+                ],
+                space=GroupComparisonConfig.AnalysisSpace.FSAVERAGE,
+                fsaverage_spacing=4,
+            )
+
+    def test_mni_space_ignores_field_validation(self):
+        # In MNI space the fsaverage_field is irrelevant and not validated.
+        cfg = CorrelationConfig(
+            analysis_name="a", subjects=self._corr_subjects(), fsaverage_field="bogus"
+        )
+        assert cfg.space == CorrelationConfig.AnalysisSpace.MNI
+
+
+# ---------------------------------------------------------------------------
+# Loader (real numpy)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadGroupSurfaceData:
+    def _write_cache(self, pm, sid, sim, spacing, **fields):
+        from tit.source.fsaverage import _output_path
+
+        path = _output_path(pm, sid, sim, spacing)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(path, subject_id=sid, simulation=sim, **fields)
+        return path
+
+    def test_stacks_subjects_in_order(self, init_pm):
+        from tit.source.fsaverage import _FSAVG_NODES
+        from tit.stats import surface
+
+        n = _FSAVG_NODES[5]
+        self._write_cache(init_pm, "001", "TI_sim", 5, TI_max=np.full(n, 1.0))
+        self._write_cache(init_pm, "002", "TI_sim", 5, TI_max=np.full(n, 2.0))
+
+        data, ids = surface.load_group_surface_data(
+            [("001", "TI_sim"), ("002", "TI_sim")], "TI_max", 5
+        )
+        assert data.shape == (n, 2)
+        assert ids == ["001", "002"]
+        assert data[0, 0] == 1.0 and data[0, 1] == 2.0
+
+    def test_missing_cache_raises(self, init_pm):
+        from tit.stats import surface
+
+        with pytest.raises(FileNotFoundError):
+            surface.load_group_surface_data([("999", "TI_sim")], "TI_max", 5)
+
+    def test_missing_field_raises(self, init_pm):
+        from tit.source.fsaverage import _FSAVG_NODES
+        from tit.stats import surface
+
+        self._write_cache(init_pm, "001", "TI_sim", 5, TI_max=np.zeros(_FSAVG_NODES[5]))
+        with pytest.raises(KeyError):
+            surface.load_group_surface_data([("001", "TI_sim")], "hf_max", 5)
+
+    def test_wrong_node_count_raises(self, init_pm):
+        from tit.stats import surface
+
+        self._write_cache(init_pm, "001", "TI_sim", 5, TI_max=np.zeros(10))
+        with pytest.raises(ValueError):
+            surface.load_group_surface_data([("001", "TI_sim")], "TI_max", 5)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch from the public runners
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceDispatch:
+    def test_correlation_dispatches_to_surface(self, monkeypatch):
+        from tit.stats import permutation
+
+        captured = {}
+        monkeypatch.setattr(
+            "tit.stats.surface.run_surface_correlation",
+            lambda cfg, cb, stop: captured.__setitem__("cfg", cfg) or "SURFACE",
+        )
+        cfg = CorrelationConfig(
+            analysis_name="a",
+            subjects=[
+                CorrelationConfig.Subject("001", "TI_sim", 1.0),
+                CorrelationConfig.Subject("002", "TI_sim", 2.0),
+                CorrelationConfig.Subject("003", "TI_sim", 3.0),
+            ],
+            space=CorrelationConfig.AnalysisSpace.FSAVERAGE,
+        )
+        assert permutation.run_correlation(cfg) == "SURFACE"
+        assert captured["cfg"] is cfg
+
+    def test_group_comparison_dispatches_to_surface(self, monkeypatch):
+        from tit.stats import permutation
+
+        # The MNI path is wrapped in telemetry; make track_operation a no-op CM.
+        import contextlib
+
+        monkeypatch.setattr(
+            "tit.telemetry.track_operation",
+            lambda *a, **k: contextlib.nullcontext(),
+        )
+        monkeypatch.setattr(
+            "tit.stats.surface.run_surface_group_comparison",
+            lambda cfg, cb, stop: "SURFACE_GROUP",
+        )
+        cfg = GroupComparisonConfig(
+            analysis_name="a",
+            subjects=[
+                GroupComparisonConfig.Subject("001", "TI_sim", 1),
+                GroupComparisonConfig.Subject("002", "TI_sim", 0),
+            ],
+            space=GroupComparisonConfig.AnalysisSpace.FSAVERAGE,
+        )
+        assert permutation.run_group_comparison(cfg) == "SURFACE_GROUP"

--- a/tit/constants.py
+++ b/tit/constants.py
@@ -153,6 +153,12 @@ FIELD_TI_MAX = "TI_max"  # TI field name in 2-pair simulation meshes
 FIELD_MTI_MAX = "TI_Max"  # mTI field name in 4-pair simulation meshes
 FIELD_TI_NORMAL = "TI_normal"  # Normal component field name
 
+# fsaverage total node counts (both hemispheres) per subdivision factor.
+# ico5/6/7 surfaces: 10242/40962/163842 vertices per hemisphere, doubled.
+# Lives here (a leaf module) so surface/stats/plotting can share it without
+# importing tit.source, which would pull in mne via tit.source.forward.
+FSAVG_NODES = {5: 20484, 6: 81924, 7: 327684}
+
 # Default analysis parameters
 DEFAULT_PERCENTILES = [95, 99, 99.9]
 DEFAULT_FOCALITY_CUTOFFS = [50, 75, 90, 95]

--- a/tit/gui/extensions/cbp.py
+++ b/tit/gui/extensions/cbp.py
@@ -376,6 +376,26 @@ class ClusterPermutationWidget(QtWidgets.QWidget):
         self.config_layout.addWidget(self.nifti_pattern_edit, row, 3)
         row += 1
 
+        # Analysis space: MNI volume (default) or fsaverage cortical surface.
+        self.config_layout.addWidget(QtWidgets.QLabel("Space:"), row, 0)
+        self.space_combo = QtWidgets.QComboBox()
+        self.space_combo.addItems(["MNI (volume)", "fsaverage (surface)"])
+        self.space_combo.setToolTip(
+            "MNI: voxelwise stats on NIfTI volumes (NIfTI Pattern above).\n"
+            "fsaverage: vertexwise stats on the cortical surface, using the "
+            "per-subject fsaverage field caches written at simulation time."
+        )
+        self.config_layout.addWidget(self.space_combo, row, 1)
+
+        self.config_layout.addWidget(QtWidgets.QLabel("Surface Field:"), row, 2)
+        self.fsavg_field_combo = QtWidgets.QComboBox()
+        self.fsavg_field_combo.addItems(["TI_max", "TI_normal", "magnitude", "hf_max"])
+        self.fsavg_field_combo.setToolTip(
+            "Which fsaverage field to analyze (ignored when Space is MNI)."
+        )
+        self.config_layout.addWidget(self.fsavg_field_combo, row, 3)
+        row += 1
+
         if mode == "classification":
             # Test type
             self.config_layout.addWidget(QtWidgets.QLabel("Test Type:"), row, 0)
@@ -772,6 +792,10 @@ class ClusterPermutationWidget(QtWidgets.QWidget):
             "alpha": self.alpha_spin.value(),
             "n_jobs": int(self.n_jobs_edit.text()) if self.n_jobs_edit.text() else 1,
             "nifti_file_pattern": self.nifti_pattern_edit.text(),
+            "space": (
+                "fsaverage" if "fsaverage" in self.space_combo.currentText() else "mni"
+            ),
+            "fsaverage_field": self.fsavg_field_combo.currentText(),
         }
 
         if mode == "classification":
@@ -1143,6 +1167,8 @@ class AnalysisThread(QtCore.QThread):
                     alpha=float(self.config.get("alpha", 0.05)),
                     n_jobs=int(self.config.get("n_jobs", -1)),
                     nifti_file_pattern=pattern,
+                    space=self.config.get("space", "mni"),
+                    fsaverage_field=self.config.get("fsaverage_field", "TI_max"),
                 )
                 result = run_group_comparison(
                     typed_config,
@@ -1170,6 +1196,8 @@ class AnalysisThread(QtCore.QThread):
                     n_jobs=int(self.config.get("n_jobs", -1)),
                     use_weights=bool(self.config.get("use_weights", True)),
                     nifti_file_pattern=pattern,
+                    space=self.config.get("space", "mni"),
+                    fsaverage_field=self.config.get("fsaverage_field", "TI_max"),
                 )
                 result = run_correlation(
                     typed_config,

--- a/tit/gui/extensions/source.py
+++ b/tit/gui/extensions/source.py
@@ -112,9 +112,15 @@ class SourceWidget(QtWidgets.QWidget):
         self.field_ti_max = QtWidgets.QCheckBox("TI_max")
         self.field_ti_normal = QtWidgets.QCheckBox("TI_normal")
         self.field_magnitude = QtWidgets.QCheckBox("magnitude")
+        self.field_hf_max = QtWidgets.QCheckBox("hf_max")
         self.field_ti_max.setChecked(True)
         self.field_ti_normal.setChecked(True)
-        for cb in (self.field_ti_max, self.field_ti_normal, self.field_magnitude):
+        for cb in (
+            self.field_ti_max,
+            self.field_ti_normal,
+            self.field_magnitude,
+            self.field_hf_max,
+        ):
             fields_layout.addWidget(cb)
         fields_layout.addStretch()
         fsavg_form.addRow("Fields:", fields_widget)
@@ -202,6 +208,8 @@ class SourceWidget(QtWidgets.QWidget):
             fields.append("TI_normal")
         if self.field_magnitude.isChecked():
             fields.append("magnitude")
+        if self.field_hf_max.isChecked():
+            fields.append("hf_max")
         return fields
 
     def _confirm_overwrite(self, paths):
@@ -223,7 +231,9 @@ class SourceWidget(QtWidgets.QWidget):
             return
         net = self.net_combo.currentText()
         if not net:
-            self.update_output("No EEG net available for the selected subject.", "error")
+            self.update_output(
+                "No EEG net available for the selected subject.", "error"
+            )
             return
         if not self._confirm_overwrite([self.pm.forward(sid) for sid in subjects]):
             return
@@ -244,14 +254,16 @@ class SourceWidget(QtWidgets.QWidget):
             return
         sim = self.sim_combo.currentText()
         if not sim:
-            self.update_output("No simulation available for the selected subject.", "error")
+            self.update_output(
+                "No simulation available for the selected subject.", "error"
+            )
             return
         fields = self._selected_fields()
         if not fields:
             self.update_output("Select at least one field to project.", "error")
             return
         if not self._confirm_overwrite(
-            [self.pm.forward_fsaverage(sid) for sid in subjects]
+            [self.pm.sim_fsaverage(sid, sim) for sid in subjects]
         ):
             return
         config = {

--- a/tit/paths.py
+++ b/tit/paths.py
@@ -318,15 +318,6 @@ class PathManager:
         """
         return os.path.join(self.sub(sid), "forward")
 
-    def forward_fsaverage(self, sid: str) -> str:
-        """Path to the fsaverage field-map cache for *sid*.
-
-        ``derivatives/SimNIBS/sub-{sid}/forward/fsaverage/`` -- holds the
-        per-simulation ``.npz`` field projections produced by
-        :func:`tit.source.project_fields_to_fsaverage`.
-        """
-        return os.path.join(self.forward(sid), "fsaverage")
-
     def simulations(self, sid: str) -> str:
         """Path to ``Simulations/`` for *sid*."""
         return os.path.join(self.sub(sid), "Simulations")
@@ -386,6 +377,18 @@ class PathManager:
     def simulation(self, sid: str, sim: str) -> str:
         """Path to a named simulation directory for *sid*."""
         return os.path.join(self.simulations(sid), sim)
+
+    def sim_fsaverage(self, sid: str, sim: str) -> str:
+        """Path to the fsaverage field-map cache for a simulation.
+
+        ``derivatives/SimNIBS/sub-{sid}/Simulations/{sim}/fsaverage/`` -- holds
+        the ``.npz`` field projection produced by
+        :func:`tit.source.project_fields_to_fsaverage`.  Co-located with the
+        simulation it derives from (and mirroring SimNIBS's native
+        ``map_to_fsavg`` layout), a sibling of ``TI/`` and ``high_Frequency/`` --
+        distinct from :meth:`forward`, which is EEG source reconstruction.
+        """
+        return os.path.join(self.simulation(sid, sim), "fsaverage")
 
     def ti_mesh(self, sid: str, sim: str) -> str:
         """Path to the TI mesh file (``{sim}_TI.msh``)."""

--- a/tit/plotting/nilearn/__init__.py
+++ b/tit/plotting/nilearn/__init__.py
@@ -33,6 +33,7 @@ from .img_glass import (
     create_glass_brain_entry_point_group,
 )
 from .html_report import create_html_entry_point
+from .surface import render_fsaverage_map, render_surface_stats_result
 
 __all__ = [
     "NilearnVisualizer",
@@ -41,4 +42,6 @@ __all__ = [
     "create_glass_brain_entry_point",
     "create_glass_brain_entry_point_group",
     "create_html_entry_point",
+    "render_fsaverage_map",
+    "render_surface_stats_result",
 ]

--- a/tit/plotting/nilearn/surface.py
+++ b/tit/plotting/nilearn/surface.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env simnibs_python
+"""Render fsaverage surface field/stat maps on the inflated cortex.
+
+The :class:`~tit.plotting.nilearn.visualizer.NilearnVisualizer` renders MNI
+*volumes* (optionally projected onto a surface).  This module is the missing
+counterpart: it paints a per-vertex fsaverage array -- a group-mean field, a
+t/r map, or a thresholded significant-cluster mask -- directly on the
+fsaverage inflated surface (lateral + medial, both hemispheres), the layout
+used for cortical group figures.
+
+Inputs are the ``(n_vertices,)`` arrays produced by
+:func:`tit.source.project_fields_to_fsaverage` (per-subject field caches) and by
+:mod:`tit.stats.surface` (group ``surface_maps.npz``).  The vertex order is
+``[lh; rh]``, matching nilearn's left/right hemispheres.
+
+See Also
+--------
+tit.plotting.nilearn.visualizer.NilearnVisualizer : Volume / volume-to-surface.
+tit.stats.surface : Produces the surface stats ``.npz`` rendered here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+from tit.plotting._common import ensure_headless_matplotlib_backend
+from tit.source.fsaverage import _FSAVG_NODES
+
+_VIEWS = ("lateral", "medial")
+_HEMIS = ("left", "right")
+
+
+def render_fsaverage_map(
+    values,
+    spacing: int = 5,
+    *,
+    title: str | None = None,
+    threshold: float | None = None,
+    cmap: str = "cold_hot",
+    symmetric_cbar="auto",
+    out_path: str | None = None,
+):
+    """Paint a ``(n_vertices,)`` fsaverage map on the inflated cortex.
+
+    Parameters
+    ----------
+    values : array-like
+        Per-vertex values in ``[lh; rh]`` order, length ``_FSAVG_NODES[spacing]``.
+    spacing : int
+        fsaverage subdivision factor (5, 6, or 7).
+    title : str, optional
+        Figure suptitle.
+    threshold : float, optional
+        Hide ``|value| < threshold`` (e.g. to show only significant vertices).
+    cmap : str
+        Matplotlib/nilearn colormap.  ``cold_hot`` suits signed t/r maps;
+        use a sequential map (e.g. ``"inferno"``) for magnitude fields.
+    symmetric_cbar : bool or "auto"
+        Passed to nilearn; keep signed maps symmetric about zero.
+    out_path : str, optional
+        If given, save the figure there and return the path; else return the
+        Matplotlib figure.
+
+    Returns
+    -------
+    str or matplotlib.figure.Figure
+        The saved path (when *out_path* is given) or the figure.
+    """
+    ensure_headless_matplotlib_backend()
+    import matplotlib.pyplot as plt
+    from nilearn import datasets, plotting
+
+    n_total = _FSAVG_NODES[spacing]
+    values = np.asarray(values, dtype=float).reshape(-1)
+    if values.shape[0] != n_total:
+        raise ValueError(
+            f"expected {n_total} fsaverage{spacing} vertices, got {values.shape[0]}"
+        )
+    n_lh = n_total // 2
+
+    fs = datasets.fetch_surf_fsaverage(f"fsaverage{spacing}")
+    hemi_data = {
+        "left": (values[:n_lh], fs["infl_left"], fs["sulc_left"]),
+        "right": (values[n_lh:], fs["infl_right"], fs["sulc_right"]),
+    }
+
+    fig, axes = plt.subplots(2, 2, figsize=(11, 9), subplot_kw={"projection": "3d"})
+    for col, hemi in enumerate(_HEMIS):
+        stat_map, mesh, bg_map = hemi_data[hemi]
+        for row, view in enumerate(_VIEWS):
+            plotting.plot_surf_stat_map(
+                mesh,
+                stat_map,
+                bg_map=bg_map,
+                hemi=hemi,
+                view=view,
+                threshold=threshold,
+                cmap=cmap,
+                colorbar=(row == 0 and col == 1),
+                symmetric_cbar=symmetric_cbar,
+                axes=axes[row, col],
+                figure=fig,
+            )
+            axes[row, col].set_title(f"{hemi} {view}")
+
+    if title:
+        fig.suptitle(title)
+    if out_path is None:
+        return fig
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def render_surface_stats_result(npz_path: str, out_dir: str, spacing: int = 5):
+    """Render a :mod:`tit.stats.surface` ``surface_maps.npz`` to PDFs.
+
+    Paints the effect map (signed ``r`` if present, else ``t``) and the
+    thresholded significant-cluster mask onto the inflated cortex.
+
+    Returns
+    -------
+    list of str
+        Paths of the figures written into *out_dir*.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    written: list[str] = []
+    with np.load(npz_path) as data:
+        effect_key = "r" if "r" in data.files else "t"
+        effect = np.asarray(data[effect_key], dtype=float)
+        sig_mask = (
+            np.asarray(data["sig_mask"], dtype=float)
+            if "sig_mask" in data.files
+            else None
+        )
+
+    effect_pdf = os.path.join(out_dir, f"surface_{effect_key}_map.pdf")
+    render_fsaverage_map(
+        effect, spacing, title=f"{effect_key} map", out_path=effect_pdf
+    )
+    written.append(effect_pdf)
+
+    if sig_mask is not None and float(sig_mask.sum()) > 0:
+        sig_pdf = os.path.join(out_dir, "surface_significant_clusters.pdf")
+        render_fsaverage_map(
+            effect * sig_mask,
+            spacing,
+            title="significant clusters",
+            threshold=1e-9,
+            out_path=sig_pdf,
+        )
+        written.append(sig_pdf)
+    return written

--- a/tit/plotting/nilearn/surface.py
+++ b/tit/plotting/nilearn/surface.py
@@ -25,8 +25,8 @@ import os
 
 import numpy as np
 
+from tit.constants import FSAVG_NODES as _FSAVG_NODES
 from tit.plotting._common import ensure_headless_matplotlib_backend
-from tit.source.fsaverage import _FSAVG_NODES
 
 _VIEWS = ("lateral", "medial")
 _HEMIS = ("left", "right")
@@ -39,7 +39,7 @@ def render_fsaverage_map(
     title: str | None = None,
     threshold: float | None = None,
     cmap: str = "cold_hot",
-    symmetric_cbar="auto",
+    symmetric_cbar: bool | str = "auto",
     out_path: str | None = None,
 ):
     """Paint a ``(n_vertices,)`` fsaverage map on the inflated cortex.
@@ -85,6 +85,9 @@ def render_fsaverage_map(
         "left": (values[:n_lh], fs["infl_left"], fs["sulc_left"]),
         "right": (values[n_lh:], fs["infl_right"], fs["sulc_right"]),
     }
+    # Shared color scale so the single colorbar is valid across all four panels
+    # (nilearn otherwise auto-scales vmax per hemisphere).
+    vmax = float(np.nanmax(np.abs(values))) or None
 
     fig, axes = plt.subplots(2, 2, figsize=(11, 9), subplot_kw={"projection": "3d"})
     for col, hemi in enumerate(_HEMIS):
@@ -98,6 +101,7 @@ def render_fsaverage_map(
                 view=view,
                 threshold=threshold,
                 cmap=cmap,
+                vmax=vmax,
                 colorbar=(row == 0 and col == 1),
                 symmetric_cbar=symmetric_cbar,
                 axes=axes[row, col],
@@ -114,11 +118,14 @@ def render_fsaverage_map(
     return out_path
 
 
-def render_surface_stats_result(npz_path: str, out_dir: str, spacing: int = 5):
+def render_surface_stats_result(
+    npz_path: str, out_dir: str, spacing: int | None = None
+):
     """Render a :mod:`tit.stats.surface` ``surface_maps.npz`` to PDFs.
 
     Paints the effect map (signed ``r`` if present, else ``t``) and the
-    thresholded significant-cluster mask onto the inflated cortex.
+    thresholded significant-cluster mask onto the inflated cortex.  *spacing* is
+    inferred from the array length when not given.
 
     Returns
     -------
@@ -135,6 +142,14 @@ def render_surface_stats_result(npz_path: str, out_dir: str, spacing: int = 5):
             if "sig_mask" in data.files
             else None
         )
+
+    if spacing is None:
+        by_nodes = {n: s for s, n in _FSAVG_NODES.items()}
+        spacing = by_nodes.get(effect.shape[0])
+        if spacing is None:
+            raise ValueError(
+                f"cannot infer fsaverage spacing from {effect.shape[0]} vertices"
+            )
 
     effect_pdf = os.path.join(out_dir, f"surface_{effect_key}_map.pdf")
     render_fsaverage_map(

--- a/tit/sim/__main__.py
+++ b/tit/sim/__main__.py
@@ -50,7 +50,7 @@ def main() -> None:
         map_to_surf=data.get("map_to_surf", True),
         map_to_vol=data.get("map_to_vol", False),
         map_to_mni=data.get("map_to_mni", False),
-        map_to_fsavg=data.get("map_to_fsavg", False),
+        map_to_fsavg=data.get("map_to_fsavg", True),
         open_in_gmsh=data.get("open_in_gmsh", False),
         tissues_in_niftis=data.get("tissues_in_niftis", "all"),
         aniso_maxratio=data.get("aniso_maxratio", 10.0),

--- a/tit/sim/config.py
+++ b/tit/sim/config.py
@@ -206,7 +206,10 @@ class SimulationConfig:
     map_to_mni : bool
         Reserved; not currently passed to SimNIBS.
     map_to_fsavg : bool
-        Reserved; not currently passed to SimNIBS.
+        After each TI montage finishes, project its surface fields
+        (``TI_max``, ``TI_normal``, ``magnitude``, ``hf_max``) onto fsaverage5
+        for group surface analysis.  On by default; set ``False`` to skip.
+        Failures are logged and never abort the simulation.
     open_in_gmsh : bool
         Open results in Gmsh after simulation.
     tissues_in_niftis : str
@@ -245,7 +248,7 @@ class SimulationConfig:
     # These are kept for documentation/serialization but are not passed to SimNIBS.
     map_to_vol: bool = False
     map_to_mni: bool = False
-    map_to_fsavg: bool = False
+    map_to_fsavg: bool = True
     open_in_gmsh: bool = False
     tissues_in_niftis: str = "all"
     aniso_maxratio: float = 10.0

--- a/tit/sim/utils.py
+++ b/tit/sim/utils.py
@@ -887,7 +887,9 @@ def _validate_simulation_inputs(config: SimulationConfig) -> None:
         else:
             if not montage.eeg_net:
                 raise ValueError(f"Montage {montage.name!r} requires an EEG net file.")
-            eeg_path = os.path.join(pm.eeg_positions(config.subject_id), montage.eeg_net)
+            eeg_path = os.path.join(
+                pm.eeg_positions(config.subject_id), montage.eeg_net
+            )
             if not os.path.isfile(eeg_path):
                 raise ValueError(
                     f"EEG net file not found for montage {montage.name!r}: {eeg_path}"
@@ -957,8 +959,10 @@ def _project_montage_to_fsaverage(config: SimulationConfig, montage, logger) -> 
     from tit.source.fsaverage import project_subject
 
     try:
+        # overwrite=True: this montage's overlays were just (re)written, so any
+        # cached projection from a prior run of the same montage name is stale.
         _, status, msg = project_subject(
-            config.subject_id, montage.name, FsavgMapConfig()
+            config.subject_id, montage.name, FsavgMapConfig(overwrite=True)
         )
         logger.info("fsaverage projection [%s] %s: %s", status, montage.name, msg)
     except Exception as exc:  # noqa: BLE001 - auxiliary step, never fatal

--- a/tit/sim/utils.py
+++ b/tit/sim/utils.py
@@ -930,9 +930,39 @@ def _run_simulation_inner(
             else mTISimulation
         )
         results.append(cls(config, montage, logger).run(simulation_dir))
+        if config.map_to_fsavg:
+            _project_montage_to_fsaverage(config, montage, logger)
     if progress_callback:
         progress_callback(total, total, "Complete")
     return results
+
+
+def _project_montage_to_fsaverage(config: SimulationConfig, montage, logger) -> None:
+    """Project a finished TI montage's surface fields onto fsaverage5.
+
+    Auxiliary step driven by ``config.map_to_fsavg``; runs in the same
+    ``simnibs_python`` process right after the montage completes, so the central
+    overlays it reads are already on disk.
+
+    ponytail: best-effort -- a projection failure logs a warning and never aborts
+    the simulation. mTI overlays are not yet supported, so mTI montages are
+    skipped explicitly rather than failing the carrier/central-surface lookups.
+    """
+    if montage.simulation_mode != SimulationMode.TI:
+        logger.info(
+            "fsaverage projection: skipping %s (mTI not yet supported)", montage.name
+        )
+        return
+    from tit.source.config import FsavgMapConfig
+    from tit.source.fsaverage import project_subject
+
+    try:
+        _, status, msg = project_subject(
+            config.subject_id, montage.name, FsavgMapConfig()
+        )
+        logger.info("fsaverage projection [%s] %s: %s", status, montage.name, msg)
+    except Exception as exc:  # noqa: BLE001 - auxiliary step, never fatal
+        logger.warning("fsaverage projection failed for %s: %r", montage.name, exc)
 
 
 def _make_file_logger(

--- a/tit/source/config.py
+++ b/tit/source/config.py
@@ -21,7 +21,11 @@ from dataclasses import dataclass, field
 
 #: Field quantities that :func:`tit.source.fsaverage.project_fields_to_fsaverage`
 #: knows how to compute on the subject central surface before morphing.
-VALID_FSAVG_FIELDS: tuple[str, ...] = ("TI_max", "TI_normal", "magnitude")
+#:
+#: ``hf_max`` is the peak instantaneous carrier exposure ``|E1| + |E2|`` (sum of
+#: carrier magnitudes) -- distinct from ``magnitude`` = ``|E1 + E2|`` (the
+#: coherent vector sum); both derive from the same two carrier overlays.
+VALID_FSAVG_FIELDS: tuple[str, ...] = ("TI_max", "TI_normal", "magnitude", "hf_max")
 
 #: fsaverage subdivision factors accepted by SimNIBS ``prepare_eeg_forward`` and
 #: ``cross_subject_map`` (5 -> 10242, 6 -> 40962, 7 -> 163842 nodes per hemi).
@@ -68,7 +72,7 @@ class FsavgMapConfig:
     fields : tuple of str
         Which field quantities to project.  Any of
         :data:`VALID_FSAVG_FIELDS` (``"TI_max"``, ``"TI_normal"``,
-        ``"magnitude"``).
+        ``"magnitude"``, ``"hf_max"``).
     fsaverage_spacing : int
         fsaverage subdivision factor (5, 6, or 7) to morph onto.
     workers : int

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -68,9 +68,12 @@ def _carrier_volume_meshes(pm, subject_id: str, sim: str) -> tuple[Path, Path]:
     sim_dir = Path(pm.simulation(subject_id, sim))
 
     def _find(pair: int) -> Path:
+        # The carrier volume mesh always lives under high_Frequency/ (directly
+        # before file organization, in mesh/ after); restrict to that subtree so
+        # no surface overlay elsewhere under the sim dir can be picked instead.
         matches = sorted(
             p
-            for p in sim_dir.glob(f"**/*_TDCS_{pair}_*.msh")
+            for p in sim_dir.glob(f"high_Frequency/**/*_TDCS_{pair}_*.msh")
             if not p.name.startswith("._") and not p.name.endswith("_central.msh")
         )
         if not matches:
@@ -133,18 +136,24 @@ def _ti_normal_overlay(pm, subject_id: str, sim: str) -> Path:
 def _morph_split(
     values: np.ndarray, n_lh: int, n_rh: int, morph, hemispheres
 ) -> np.ndarray:
-    """Split an [lh; rh] central-surface scalar and morph each hemi to fsaverage."""
+    """Split a per-hemisphere central-surface scalar and morph each to fsaverage.
+
+    The values are concatenated in ``hemispheres`` order, so we split in that
+    same order (rather than assuming lh first) -- keeping the split aligned with
+    however :func:`_interp_to_central` / the central overlay were concatenated.
+    """
     if values.shape[0] != n_lh + n_rh:
         raise ValueError(
             f"overlay has {values.shape[0]} nodes, expected {n_lh + n_rh} (lh+rh)"
         )
-    split = {"lh": values[:n_lh], "rh": values[n_lh:]}
-    return np.concatenate(
-        [
-            np.asarray(morph[hemi].resample(split[hemi]), dtype=float)
-            for hemi in hemispheres
-        ]
-    )
+    counts = {"lh": n_lh, "rh": n_rh}
+    out: list[np.ndarray] = []
+    offset = 0
+    for hemi in hemispheres:
+        n = counts[hemi]
+        out.append(np.asarray(morph[hemi].resample(values[offset : offset + n]), float))
+        offset += n
+    return np.concatenate(out)
 
 
 def _compute_fields(
@@ -199,30 +208,21 @@ def _compute_fields(
             vol1, vol2 = _carrier_volume_meshes(pm, subject_id, sim)
             m1, gm1 = _load_carrier_mesh(vol1)
             m2, gm2 = _load_carrier_mesh(vol2)
-        except Exception as exc:  # noqa: BLE001 - loading is shared; skip both
+            # The full vector E is always present on the FEM volume mesh (unlike
+            # the surface overlays, which some builds fill with only E_normal), so
+            # both carrier fields derive from it -- interpolate it once per carrier.
+            e1 = _interp_to_central(m1, gm1, "E", central, hemispheres).reshape(-1, 3)
+            e2 = _interp_to_central(m2, gm2, "E", central, hemispheres).reshape(-1, 3)
+        except Exception as exc:  # noqa: BLE001 - shared carrier read; skip both
             errors.append(f"carriers: {exc!r}")
         else:
-            # hf_max = |E1| + |E2| peak instantaneous exposure, from the scalar
-            # magnE (interpolated like TI_max). magnitude = |E1 + E2| coherent sum
-            # needs the vector E. Kept separate so a vector-interp issue can't take
-            # down hf_max, the field that actually quantifies carrier exposure.
+            # hf_max = |E1| + |E2| peak instantaneous exposure (the upper bound);
+            # magnitude = |E1 + E2| coherent vector sum. Both the full field.
             _project(
                 "hf_max",
-                lambda: _interp_to_central(m1, gm1, "magnE", central, hemispheres)
-                + _interp_to_central(m2, gm2, "magnE", central, hemispheres),
+                lambda: np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1),
             )
-            _project(
-                "magnitude",
-                lambda: np.linalg.norm(
-                    _interp_to_central(m1, gm1, "E", central, hemispheres).reshape(
-                        -1, 3
-                    )
-                    + _interp_to_central(m2, gm2, "E", central, hemispheres).reshape(
-                        -1, 3
-                    ),
-                    axis=1,
-                ),
-            )
+            _project("magnitude", lambda: np.linalg.norm(e1 + e2, axis=1))
 
     if not out:
         raise ValueError(

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -15,6 +15,10 @@ central-surface overlays and morphs the requested scalar fields to fsaverage:
 * ``hf_max``    -- peak instantaneous carrier exposure |E1| + |E2| (the upper
   bound the tissue sees; distinct from ``magnitude``)
 
+``TI_max`` / ``TI_normal`` are read from the pipeline's central-surface overlays;
+``magnitude`` / ``hf_max`` are interpolated from the carrier **volume** meshes
+(the surface overlays only reliably carry ``E_normal`` on some SimNIBS builds).
+
 Unlike SimNIBS's native ``map_to_fsavg`` (which only runs at simulation time and
 only emits ``TI_max``), this works *post-hoc* on any finished simulation and on
 the derived ``TI_normal`` / ``magnitude`` quantities.
@@ -54,35 +58,54 @@ def _read_surface_scalar(path: Path, field_name: str) -> np.ndarray:
     return np.asarray(mesh.field[field_name].value, dtype=float).reshape(-1)
 
 
-def _read_surface_vector(path: Path, field_name: str = "E") -> np.ndarray:
-    """Read a node vector field (n, 3) from a central-surface overlay mesh."""
-    from simnibs.mesh_tools import mesh_io
+def _carrier_volume_meshes(pm, subject_id: str, sim: str) -> tuple[Path, Path]:
+    """Locate the two per-pair carrier VOLUME meshes for a simulation.
 
-    mesh = mesh_io.read_msh(str(path))
-    if field_name not in mesh.field:
-        raise ValueError(f"{path} has no field {field_name!r}")
-    return np.asarray(mesh.field[field_name].value, dtype=float).reshape(-1, 3)
+    Unlike the central-surface overlays -- which some SimNIBS builds fill with
+    only ``E_normal`` -- the high-frequency volume meshes always carry the full
+    vector ``E``, so ``magnitude`` / ``hf_max`` can be derived reliably from them.
+    """
+    sim_dir = Path(pm.simulation(subject_id, sim))
+
+    def _find(pair: int) -> Path:
+        matches = sorted(
+            p
+            for p in sim_dir.glob(f"**/*_TDCS_{pair}_*.msh")
+            if not p.name.startswith("._") and not p.name.endswith("_central.msh")
+        )
+        if not matches:
+            raise FileNotFoundError(
+                f"No carrier volume mesh for TDCS_{pair} under {sim_dir}"
+            )
+        return matches[0]
+
+    return _find(1), _find(2)
 
 
-def _read_carrier_fields(path: Path) -> tuple[np.ndarray, np.ndarray | None]:
-    """Return ``(|E| per node, E vector or None)`` for a carrier central overlay.
+def _carrier_vectors_on_central(vol_path: Path, central, hemispheres) -> np.ndarray:
+    """Interpolate a carrier's volume ``E`` onto the ``[lh; rh]`` central surface.
 
-    SimNIBS surface overlays don't always carry the full vector ``E`` -- some
-    versions map only the scalar magnitude ``magnE`` and the normal component
-    ``E_normal``.  ``hf_max`` (|E1| + |E2|) needs only the magnitude, so it works
-    from ``magnE`` alone; ``magnitude`` (|E1 + E2|) needs the vector and is
-    skipped when it is absent.
+    Mirrors the pipeline's (and sleepTI's) volume->central interpolation for
+    ``TI_max``: crop to brain tissue, interpolate the GM field to each central
+    hemisphere, and return the concatenated ``(n_lh + n_rh, 3)`` vector.
     """
     from simnibs.mesh_tools import mesh_io
+    from simnibs.mesh_tools.mesh_io import ElementTags
 
-    mesh = mesh_io.read_msh(str(path))
-    if "E" in mesh.field:
-        vec = np.asarray(mesh.field["E"].value, dtype=float).reshape(-1, 3)
-        return np.linalg.norm(vec, axis=1), vec
-    if "magnE" in mesh.field:
-        mag = np.asarray(mesh.field["magnE"].value, dtype=float).reshape(-1)
-        return mag, None
-    raise ValueError(f"{path} has neither 'E' nor 'magnE' (only E_normal?)")
+    mesh = mesh_io.read_msh(str(vol_path)).crop_mesh(
+        tags=[ElementTags.WM, ElementTags.GM, ElementTags.CSF]
+    )
+    gm_th = mesh.elm.get_tags(ElementTags.GM, return_element_numbers=True)
+    field = mesh.field["E"]
+    return np.concatenate(
+        [
+            np.asarray(
+                field.interpolate_to_surface(central[hemi], th_indices=gm_th).value,
+                dtype=float,
+            ).reshape(-1, 3)
+            for hemi in hemispheres
+        ]
+    )
 
 
 def _ti_max_overlay(pm, subject_id: str, sim: str) -> Path:
@@ -100,36 +123,6 @@ def _ti_normal_overlay(pm, subject_id: str, sim: str) -> Path:
     if not candidates:
         raise FileNotFoundError(f"No TI_normal overlay (*_normal.msh) in {mesh_dir}")
     return candidates[0]
-
-
-def _carrier_overlays(pm, subject_id: str, sim: str) -> tuple[Path, Path]:
-    """Locate the two per-pair central E-field overlays for a simulation."""
-    sim_dir = Path(pm.simulation(subject_id, sim))
-
-    # ponytail: match the overlays wherever they live -- SimNIBS writes them under
-    # `subject_overlays/`, but the sim pipeline moves them to `surface_overlays/`.
-    # The `_TDCS_{pair}_..._central` stem is specific enough to skip the TI overlay.
-    def _find(pair: int) -> Path:
-        matches = sorted(
-            p
-            for p in sim_dir.glob(f"**/*_TDCS_{pair}_*_central.msh")
-            if not p.name.startswith("._")
-        )
-        if not matches:
-            raise FileNotFoundError(
-                f"No per-pair central overlay for TDCS_{pair} under {sim_dir}"
-            )
-        return matches[0]
-
-    return _find(1), _find(2)
-
-
-def _hemisphere_node_counts(subject_files) -> tuple[int, int]:
-    """Return (n_lh, n_rh) central-surface node counts for splitting overlays."""
-    from simnibs.mesh_tools import mesh_io
-
-    central = mesh_io.load_subject_surfaces(subject_files, "central")
-    return central["lh"].nodes.nr, central["rh"].nodes.nr
 
 
 def _morph_split(
@@ -153,6 +146,7 @@ def _compute_fields(
     pm, subject_id: str, sim: str, cfg: FsavgMapConfig
 ) -> dict[str, np.ndarray]:
     """Project the requested fields for one (subject, simulation) to fsaverage."""
+    from simnibs.mesh_tools import mesh_io
     from simnibs.utils.file_finder import SubjectFiles
     from simnibs.utils.transformations import cross_subject_map
 
@@ -161,8 +155,9 @@ def _compute_fields(
     morph = cross_subject_map(
         subject_files, "fsaverage", subsampling_to=cfg.fsaverage_spacing
     )
-    n_lh, n_rh = _hemisphere_node_counts(subject_files)
+    central = mesh_io.load_subject_surfaces(subject_files, "central")
     hemispheres = subject_files.hemispheres
+    n_lh, n_rh = central["lh"].nodes.nr, central["rh"].nodes.nr
 
     # Each field is projected independently so one bad input (e.g. a missing
     # carrier overlay) drops only that field, not the others.
@@ -196,21 +191,20 @@ def _compute_fields(
     )
     if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
         try:
-            pair1, pair2 = _carrier_overlays(pm, subject_id, sim)
-            mag1, vec1 = _read_carrier_fields(pair1)
-            mag2, vec2 = _read_carrier_fields(pair2)
+            vol1, vol2 = _carrier_volume_meshes(pm, subject_id, sim)
+            e1 = _carrier_vectors_on_central(vol1, central, hemispheres)
+            e2 = _carrier_vectors_on_central(vol2, central, hemispheres)
         except Exception as exc:  # noqa: BLE001 - both carrier fields share this
             errors.append(f"carriers: {exc!r}")
         else:
-            # hf_max = |E1| + |E2| peak instantaneous exposure (works from |E| or
-            # magnE); magnitude = |E1 + E2| coherent sum needs the vectors.
-            _project("hf_max", lambda: mag1 + mag2)
-            if vec1 is not None and vec2 is not None:
-                _project("magnitude", lambda: np.linalg.norm(vec1 + vec2, axis=1))
-            elif "magnitude" in cfg.fields:
-                errors.append(
-                    "magnitude: needs vector 'E' (overlay has only magnE/E_normal)"
-                )
+            # hf_max = |E1| + |E2| peak instantaneous exposure (the upper bound);
+            # magnitude = |E1 + E2| coherent vector sum. Both from the central-
+            # surface E interpolated from the volume, so both are the full field.
+            _project(
+                "hf_max",
+                lambda: np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1),
+            )
+            _project("magnitude", lambda: np.linalg.norm(e1 + e2, axis=1))
 
     if not out:
         raise ValueError(

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -11,7 +11,9 @@ central-surface overlays and morphs the requested scalar fields to fsaverage:
 
 * ``TI_max``    -- orientation-maximized TI envelope |E| (central overlay)
 * ``TI_normal`` -- directional TI envelope along the cortical normal
-* ``magnitude`` -- combined carrier exposure |E1 + E2| on the central surface
+* ``magnitude`` -- coherent carrier exposure |E1 + E2| on the central surface
+* ``hf_max``    -- peak instantaneous carrier exposure |E1| + |E2| (the upper
+  bound the tissue sees; distinct from ``magnitude``)
 
 Unlike SimNIBS's native ``map_to_fsavg`` (which only runs at simulation time and
 only emits ``TI_max``), this works *post-hoc* on any finished simulation and on
@@ -85,10 +87,13 @@ def _carrier_overlays(pm, subject_id: str, sim: str) -> tuple[Path, Path]:
     """Locate the two per-pair central E-field overlays for a simulation."""
     sim_dir = Path(pm.simulation(subject_id, sim))
 
+    # ponytail: match the overlays wherever they live -- SimNIBS writes them under
+    # `subject_overlays/`, but the sim pipeline moves them to `surface_overlays/`.
+    # The `_TDCS_{pair}_..._central` stem is specific enough to skip the TI overlay.
     def _find(pair: int) -> Path:
         matches = sorted(
             p
-            for p in sim_dir.glob(f"**/subject_overlays/*_TDCS_{pair}_*_central.msh")
+            for p in sim_dir.glob(f"**/*_TDCS_{pair}_*_central.msh")
             if not p.name.startswith("._")
         )
         if not matches:
@@ -149,11 +154,18 @@ def _compute_fields(
             _ti_normal_overlay(pm, subject_id, sim), "TI_normal"
         )
         out["TI_normal"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
-    if "magnitude" in cfg.fields:
+    if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
         pair1, pair2 = _carrier_overlays(pm, subject_id, sim)
-        e_sum = _read_surface_vector(pair1) + _read_surface_vector(pair2)
-        values = np.linalg.norm(e_sum, axis=1)
-        out["magnitude"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
+        e1 = _read_surface_vector(pair1)
+        e2 = _read_surface_vector(pair2)
+        if "magnitude" in cfg.fields:
+            values = np.linalg.norm(e1 + e2, axis=1)  # |E1 + E2| coherent sum
+            out["magnitude"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
+        if "hf_max" in cfg.fields:
+            # |E1| + |E2|: peak instantaneous carrier exposure (both carriers at
+            # crest), the upper bound -- not the cancellation-prone vector sum.
+            values = np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1)
+            out["hf_max"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
 
     expected = _FSAVG_NODES[cfg.fsaverage_spacing]
     for name, arr in out.items():

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -82,13 +82,8 @@ def _carrier_volume_meshes(pm, subject_id: str, sim: str) -> tuple[Path, Path]:
     return _find(1), _find(2)
 
 
-def _carrier_vectors_on_central(vol_path: Path, central, hemispheres) -> np.ndarray:
-    """Interpolate a carrier's volume ``E`` onto the ``[lh; rh]`` central surface.
-
-    Mirrors the pipeline's (and sleepTI's) volume->central interpolation for
-    ``TI_max``: crop to brain tissue, interpolate the GM field to each central
-    hemisphere, and return the concatenated ``(n_lh + n_rh, 3)`` vector.
-    """
+def _load_carrier_mesh(vol_path: Path):
+    """Read a carrier volume mesh cropped to brain tissue, with its GM elements."""
     from simnibs.mesh_tools import mesh_io
     from simnibs.mesh_tools.mesh_io import ElementTags
 
@@ -96,13 +91,23 @@ def _carrier_vectors_on_central(vol_path: Path, central, hemispheres) -> np.ndar
         tags=[ElementTags.WM, ElementTags.GM, ElementTags.CSF]
     )
     gm_th = mesh.elm.get_tags(ElementTags.GM, return_element_numbers=True)
-    field = mesh.field["E"]
+    return mesh, gm_th
+
+
+def _interp_to_central(mesh, gm_th, field_name, central, hemispheres) -> np.ndarray:
+    """Interpolate a named GM field onto the ``[lh; rh]`` central surface.
+
+    Mirrors the pipeline's (and sleepTI's) volume->central interpolation for
+    ``TI_max``.  Returns ``(n_lh + n_rh,)`` for a scalar field (e.g. ``magnE``)
+    or ``(n_lh + n_rh, 3)`` for a vector field (e.g. ``E``).
+    """
+    field = mesh.field[field_name]
     return np.concatenate(
         [
             np.asarray(
                 field.interpolate_to_surface(central[hemi], th_indices=gm_th).value,
                 dtype=float,
-            ).reshape(-1, 3)
+            )
             for hemi in hemispheres
         ]
     )
@@ -192,19 +197,32 @@ def _compute_fields(
     if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
         try:
             vol1, vol2 = _carrier_volume_meshes(pm, subject_id, sim)
-            e1 = _carrier_vectors_on_central(vol1, central, hemispheres)
-            e2 = _carrier_vectors_on_central(vol2, central, hemispheres)
-        except Exception as exc:  # noqa: BLE001 - both carrier fields share this
+            m1, gm1 = _load_carrier_mesh(vol1)
+            m2, gm2 = _load_carrier_mesh(vol2)
+        except Exception as exc:  # noqa: BLE001 - loading is shared; skip both
             errors.append(f"carriers: {exc!r}")
         else:
-            # hf_max = |E1| + |E2| peak instantaneous exposure (the upper bound);
-            # magnitude = |E1 + E2| coherent vector sum. Both from the central-
-            # surface E interpolated from the volume, so both are the full field.
+            # hf_max = |E1| + |E2| peak instantaneous exposure, from the scalar
+            # magnE (interpolated like TI_max). magnitude = |E1 + E2| coherent sum
+            # needs the vector E. Kept separate so a vector-interp issue can't take
+            # down hf_max, the field that actually quantifies carrier exposure.
             _project(
                 "hf_max",
-                lambda: np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1),
+                lambda: _interp_to_central(m1, gm1, "magnE", central, hemispheres)
+                + _interp_to_central(m2, gm2, "magnE", central, hemispheres),
             )
-            _project("magnitude", lambda: np.linalg.norm(e1 + e2, axis=1))
+            _project(
+                "magnitude",
+                lambda: np.linalg.norm(
+                    _interp_to_central(m1, gm1, "E", central, hemispheres).reshape(
+                        -1, 3
+                    )
+                    + _interp_to_central(m2, gm2, "E", central, hemispheres).reshape(
+                        -1, 3
+                    ),
+                    axis=1,
+                ),
+            )
 
     if not out:
         raise ValueError(

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -37,13 +37,11 @@ from pathlib import Path
 
 import numpy as np
 
+from tit.constants import FSAVG_NODES as _FSAVG_NODES
 from tit.paths import get_path_manager
 from tit.source.config import FsavgMapConfig
 
 logger = logging.getLogger(__name__)
-
-# fsaverage total node counts (both hemispheres) per subdivision factor.
-_FSAVG_NODES = {5: 20484, 6: 81924, 7: 327684}
 
 
 def _read_surface_scalar(path: Path, field_name: str) -> np.ndarray:
@@ -145,35 +143,63 @@ def _compute_fields(
     n_lh, n_rh = _hemisphere_node_counts(subject_files)
     hemispheres = subject_files.hemispheres
 
+    # Each field is projected independently so one bad input (e.g. a missing
+    # carrier overlay) drops only that field, not the others.
     out: dict[str, np.ndarray] = {}
-    if "TI_max" in cfg.fields:
-        values = _read_surface_scalar(_ti_max_overlay(pm, subject_id, sim), "TI_max")
-        out["TI_max"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
-    if "TI_normal" in cfg.fields:
-        values = _read_surface_scalar(
-            _ti_normal_overlay(pm, subject_id, sim), "TI_normal"
-        )
-        out["TI_normal"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
-    if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
-        pair1, pair2 = _carrier_overlays(pm, subject_id, sim)
-        e1 = _read_surface_vector(pair1)
-        e2 = _read_surface_vector(pair2)
-        if "magnitude" in cfg.fields:
-            values = np.linalg.norm(e1 + e2, axis=1)  # |E1 + E2| coherent sum
-            out["magnitude"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
-        if "hf_max" in cfg.fields:
-            # |E1| + |E2|: peak instantaneous carrier exposure (both carriers at
-            # crest), the upper bound -- not the cancellation-prone vector sum.
-            values = np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1)
-            out["hf_max"] = _morph_split(values, n_lh, n_rh, morph, hemispheres)
-
+    errors: list[str] = []
     expected = _FSAVG_NODES[cfg.fsaverage_spacing]
-    for name, arr in out.items():
-        if arr.shape[0] != expected:
-            raise ValueError(
-                f"{name}: expected {expected} fsaverage{cfg.fsaverage_spacing} "
-                f"nodes, got {arr.shape[0]}"
+
+    def _project(name: str, compute) -> None:
+        if name not in cfg.fields:
+            return
+        try:
+            arr = _morph_split(compute(), n_lh, n_rh, morph, hemispheres)
+            if arr.shape[0] != expected:
+                raise ValueError(
+                    f"expected {expected} fsaverage{cfg.fsaverage_spacing} nodes, "
+                    f"got {arr.shape[0]}"
+                )
+            out[name] = arr
+        except Exception as exc:  # noqa: BLE001 - per-field, keep the rest
+            errors.append(f"{name}: {exc!r}")
+
+    _project(
+        "TI_max",
+        lambda: _read_surface_scalar(_ti_max_overlay(pm, subject_id, sim), "TI_max"),
+    )
+    _project(
+        "TI_normal",
+        lambda: _read_surface_scalar(
+            _ti_normal_overlay(pm, subject_id, sim), "TI_normal"
+        ),
+    )
+    if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
+        try:
+            pair1, pair2 = _carrier_overlays(pm, subject_id, sim)
+            e1 = _read_surface_vector(pair1)
+            e2 = _read_surface_vector(pair2)
+        except Exception as exc:  # noqa: BLE001 - both carrier fields share this
+            errors.append(f"carriers: {exc!r}")
+        else:
+            # |E1 + E2| coherent sum vs |E1| + |E2| peak instantaneous exposure
+            # (the upper bound, not the cancellation-prone vector sum).
+            _project("magnitude", lambda: np.linalg.norm(e1 + e2, axis=1))
+            _project(
+                "hf_max",
+                lambda: np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1),
             )
+
+    if not out:
+        raise ValueError(
+            f"no fields projected for {subject_id}/{sim}: " + "; ".join(errors)
+        )
+    if errors:
+        logger.warning(
+            "partial fsaverage projection for %s/%s: %s",
+            subject_id,
+            sim,
+            "; ".join(errors),
+        )
     return out
 
 

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -64,6 +64,27 @@ def _read_surface_vector(path: Path, field_name: str = "E") -> np.ndarray:
     return np.asarray(mesh.field[field_name].value, dtype=float).reshape(-1, 3)
 
 
+def _read_carrier_fields(path: Path) -> tuple[np.ndarray, np.ndarray | None]:
+    """Return ``(|E| per node, E vector or None)`` for a carrier central overlay.
+
+    SimNIBS surface overlays don't always carry the full vector ``E`` -- some
+    versions map only the scalar magnitude ``magnE`` and the normal component
+    ``E_normal``.  ``hf_max`` (|E1| + |E2|) needs only the magnitude, so it works
+    from ``magnE`` alone; ``magnitude`` (|E1 + E2|) needs the vector and is
+    skipped when it is absent.
+    """
+    from simnibs.mesh_tools import mesh_io
+
+    mesh = mesh_io.read_msh(str(path))
+    if "E" in mesh.field:
+        vec = np.asarray(mesh.field["E"].value, dtype=float).reshape(-1, 3)
+        return np.linalg.norm(vec, axis=1), vec
+    if "magnE" in mesh.field:
+        mag = np.asarray(mesh.field["magnE"].value, dtype=float).reshape(-1)
+        return mag, None
+    raise ValueError(f"{path} has neither 'E' nor 'magnE' (only E_normal?)")
+
+
 def _ti_max_overlay(pm, subject_id: str, sim: str) -> Path:
     path = Path(pm.ti_central_surface(subject_id, sim))
     if not path.exists():
@@ -176,18 +197,20 @@ def _compute_fields(
     if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
         try:
             pair1, pair2 = _carrier_overlays(pm, subject_id, sim)
-            e1 = _read_surface_vector(pair1)
-            e2 = _read_surface_vector(pair2)
+            mag1, vec1 = _read_carrier_fields(pair1)
+            mag2, vec2 = _read_carrier_fields(pair2)
         except Exception as exc:  # noqa: BLE001 - both carrier fields share this
             errors.append(f"carriers: {exc!r}")
         else:
-            # |E1 + E2| coherent sum vs |E1| + |E2| peak instantaneous exposure
-            # (the upper bound, not the cancellation-prone vector sum).
-            _project("magnitude", lambda: np.linalg.norm(e1 + e2, axis=1))
-            _project(
-                "hf_max",
-                lambda: np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1),
-            )
+            # hf_max = |E1| + |E2| peak instantaneous exposure (works from |E| or
+            # magnE); magnitude = |E1 + E2| coherent sum needs the vectors.
+            _project("hf_max", lambda: mag1 + mag2)
+            if vec1 is not None and vec2 is not None:
+                _project("magnitude", lambda: np.linalg.norm(vec1 + vec2, axis=1))
+            elif "magnitude" in cfg.fields:
+                errors.append(
+                    "magnitude: needs vector 'E' (overlay has only magnE/E_normal)"
+                )
 
     if not out:
         raise ValueError(

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -239,7 +239,7 @@ def _compute_fields(
 
 
 def _output_path(pm, subject_id: str, sim: str, spacing: int) -> Path:
-    out_dir = Path(pm.forward_fsaverage(subject_id))
+    out_dir = Path(pm.sim_fsaverage(subject_id, sim))
     return out_dir / f"sub-{subject_id}_sim-{sim}_space-fsaverage{spacing}_fields.npz"
 
 

--- a/tit/stats/__main__.py
+++ b/tit/stats/__main__.py
@@ -56,6 +56,9 @@ def _run_group_comparison(data: dict) -> None:
         ),
         n_permutations=data.get("n_permutations", 1000),
         tissue_type=GroupComparisonConfig.TissueType(data.get("tissue_type", "grey")),
+        space=GroupComparisonConfig.AnalysisSpace(data.get("space", "mni")),
+        fsaverage_field=data.get("fsaverage_field", "TI_max"),
+        fsaverage_spacing=data.get("fsaverage_spacing", 5),
     )
     result = run_group_comparison(config)
     sys.exit(0 if result.n_significant_clusters >= 0 else 1)
@@ -74,6 +77,9 @@ def _run_correlation(data: dict) -> None:
         cluster_stat=CorrelationConfig.ClusterStat(data.get("cluster_stat", "mass")),
         n_permutations=data.get("n_permutations", 1000),
         effect_metric=data.get("effect_metric", ""),
+        space=CorrelationConfig.AnalysisSpace(data.get("space", "mni")),
+        fsaverage_field=data.get("fsaverage_field", "TI_max"),
+        fsaverage_spacing=data.get("fsaverage_spacing", 5),
     )
     result = run_correlation(config)
     sys.exit(0 if result.n_significant_clusters >= 0 else 1)

--- a/tit/stats/config.py
+++ b/tit/stats/config.py
@@ -36,6 +36,33 @@ class _TissueType(StrEnum):
     ALL = "all"
 
 
+class _AnalysisSpace(StrEnum):
+    """Where the group statistics run: MNI volume or fsaverage surface."""
+
+    MNI = "mni"
+    FSAVERAGE = "fsaverage"
+
+
+#: Surface field quantities the fsaverage stats path can load (mirrors
+#: :data:`tit.source.config.VALID_FSAVG_FIELDS`).
+_VALID_FSAVG_FIELDS = ("TI_max", "TI_normal", "magnitude", "hf_max")
+_VALID_FSAVG_SPACINGS = (5, 6, 7)
+
+
+def _validate_surface_options(space, field, spacing) -> None:
+    """Shared fsaverage-option validation for both config classes."""
+    if space != _AnalysisSpace.FSAVERAGE:
+        return
+    if field not in _VALID_FSAVG_FIELDS:
+        raise ValueError(
+            f"fsaverage_field must be one of {_VALID_FSAVG_FIELDS}, got {field!r}"
+        )
+    if spacing not in _VALID_FSAVG_SPACINGS:
+        raise ValueError(
+            f"fsaverage_spacing must be one of {_VALID_FSAVG_SPACINGS}, got {spacing}"
+        )
+
+
 # ── Private helper ────────────────────────────────────────────────────────
 
 
@@ -104,6 +131,7 @@ class GroupComparisonConfig:
     # ── Nested types ──────────────────────────────────────────────────
     ClusterStat = _ClusterStat
     TissueType = _TissueType
+    AnalysisSpace = _AnalysisSpace
 
     class TestType(StrEnum):
         """Type of statistical test for group comparison."""
@@ -153,6 +181,13 @@ class GroupComparisonConfig:
     tissue_type: TissueType = _TissueType.GREY
     nifti_file_pattern: str | None = None
 
+    # Analysis space: MNI volume (default) or fsaverage surface. When
+    # ``fsaverage``, the per-subject ``fsaverage_field`` caches are used and the
+    # NIfTI/tissue options are ignored.
+    space: AnalysisSpace = _AnalysisSpace.MNI
+    fsaverage_field: str = "TI_max"
+    fsaverage_spacing: int = 5
+
     # Labels
     group1_name: str = "Responders"
     group2_name: str = "Non-Responders"
@@ -164,6 +199,9 @@ class GroupComparisonConfig:
     def __post_init__(self) -> None:
         if self.nifti_file_pattern is None:
             self.nifti_file_pattern = _nifti_pattern_for_tissue(self.tissue_type)
+        _validate_surface_options(
+            self.space, self.fsaverage_field, self.fsaverage_spacing
+        )
 
         responders = [s for s in self.subjects if s.response == 1]
         non_responders = [s for s in self.subjects if s.response == 0]
@@ -269,6 +307,7 @@ class CorrelationConfig:
     # ── Nested types ──────────────────────────────────────────────────
     ClusterStat = _ClusterStat
     TissueType = _TissueType
+    AnalysisSpace = _AnalysisSpace
 
     class CorrelationType(StrEnum):
         """Type of correlation coefficient to compute."""
@@ -315,6 +354,13 @@ class CorrelationConfig:
     tissue_type: TissueType = _TissueType.GREY
     nifti_file_pattern: str | None = None
 
+    # Analysis space: MNI volume (default) or fsaverage surface. When
+    # ``fsaverage``, the per-subject ``fsaverage_field`` caches are used and the
+    # NIfTI/tissue options are ignored.
+    space: AnalysisSpace = _AnalysisSpace.MNI
+    fsaverage_field: str = "TI_max"
+    fsaverage_spacing: int = 5
+
     # Labels
     effect_metric: str = "Effect Size"
     field_metric: str = "Electric Field Magnitude"
@@ -325,6 +371,9 @@ class CorrelationConfig:
     def __post_init__(self) -> None:
         if self.nifti_file_pattern is None:
             self.nifti_file_pattern = _nifti_pattern_for_tissue(self.tissue_type)
+        _validate_surface_options(
+            self.space, self.fsaverage_field, self.fsaverage_spacing
+        )
 
         if len(self.subjects) < 3:
             raise ValueError(

--- a/tit/stats/config.py
+++ b/tit/stats/config.py
@@ -197,6 +197,14 @@ class GroupComparisonConfig:
     atlas_files: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        # Coerce strings (e.g. from the GUI) to enum members so downstream
+        # ``.value`` reads never crash; idempotent for members.
+        self.test_type = self.TestType(self.test_type)
+        self.alternative = self.Alternative(self.alternative)
+        self.cluster_stat = self.ClusterStat(self.cluster_stat)
+        self.tissue_type = self.TissueType(self.tissue_type)
+        self.space = self.AnalysisSpace(self.space)
+
         if self.nifti_file_pattern is None:
             self.nifti_file_pattern = _nifti_pattern_for_tissue(self.tissue_type)
         _validate_surface_options(
@@ -369,6 +377,13 @@ class CorrelationConfig:
     atlas_files: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        # Coerce strings (e.g. from the GUI) to enum members so downstream
+        # ``.value`` reads never crash; idempotent for members.
+        self.correlation_type = self.CorrelationType(self.correlation_type)
+        self.cluster_stat = self.ClusterStat(self.cluster_stat)
+        self.tissue_type = self.TissueType(self.tissue_type)
+        self.space = self.AnalysisSpace(self.space)
+
         if self.nifti_file_pattern is None:
             self.nifti_file_pattern = _nifti_pattern_for_tissue(self.tissue_type)
         _validate_surface_options(

--- a/tit/stats/permutation.py
+++ b/tit/stats/permutation.py
@@ -107,6 +107,10 @@ def run_group_comparison(
     from tit import constants as _const
 
     with track_operation(_const.TELEMETRY_OP_STATS):
+        if config.space == GroupComparisonConfig.AnalysisSpace.FSAVERAGE:
+            from tit.stats.surface import run_surface_group_comparison
+
+            return run_surface_group_comparison(config, callback_handler, stop_callback)
         return _run_group_comparison_inner(config, callback_handler, stop_callback)
 
 
@@ -370,6 +374,11 @@ def run_correlation(
         KeyboardInterrupt: If ``stop_callback`` returns ``True`` during
             execution.
     """
+    if config.space == CorrelationConfig.AnalysisSpace.FSAVERAGE:
+        from tit.stats.surface import run_surface_correlation
+
+        return run_surface_correlation(config, callback_handler, stop_callback)
+
     t0 = time.time()
     output_dir = _resolve_output_dir(
         "correlation",

--- a/tit/stats/surface.py
+++ b/tit/stats/surface.py
@@ -1,0 +1,517 @@
+"""fsaverage surface backend for cluster-based permutation stats.
+
+The volumetric engine (:mod:`tit.stats.engine`) clusters voxels with
+``scipy.ndimage.label`` on a 3-D grid -- which has no meaning for surface
+vertices.  This module is the surface counterpart: it stacks the per-subject
+fsaverage field caches written by :func:`tit.source.project_fields_to_fsaverage`
+into a ``(n_vertices, n_subjects)`` matrix and runs the *same* statistics with
+the *same* cluster conventions, swapping the grid clustering for graph
+connected-components over the fsaverage triangle adjacency.
+
+It deliberately **reuses** the engine's space-agnostic kernels
+(:func:`~tit.stats.engine.correlation`, :func:`~tit.stats.engine.ttest_ind`,
+:func:`~tit.stats.engine.ttest_rel`, :func:`~tit.stats.engine.pval_from_histogram`)
+so the surface and volume paths give identical numbers on identical inputs; only
+the spatial layer differs.  The volumetric engine is left untouched --
+:mod:`tit.stats.permutation` dispatches here when ``config.space == "fsaverage"``.
+
+Cluster conventions mirror the engine exactly: a cluster is a connected set of
+vertices with ``p < cluster_threshold`` (sign-restricted for one-sided tests);
+singletons (size 1) are ignored; cluster *mass* is the signed sum of t over its
+vertices; the null is the per-permutation max cluster stat; per-cluster p-values
+come from :func:`~tit.stats.engine.pval_from_histogram`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+
+from tit.paths import get_path_manager
+from tit.source.config import VALID_FSAVG_FIELDS
+from tit.source.fsaverage import _FSAVG_NODES, _output_path
+
+from .config import CorrelationResult, GroupComparisonResult
+from .engine import correlation, pval_from_histogram, ttest_ind, ttest_rel
+
+logger = logging.getLogger(__name__)
+
+# fsaverage triangle adjacency is fixed per spacing; build it once.
+_ADJ_CACHE: dict[int, "object"] = {}
+
+
+# ─── data loading ──────────────────────────────────────────────────────────
+
+
+def load_group_surface_data(
+    subjects: list[tuple[str, str]], field: str, spacing: int
+) -> tuple[np.ndarray, list[str]]:
+    """Stack per-subject fsaverage field caches into ``(n_vertices, n_subjects)``.
+
+    Parameters
+    ----------
+    subjects : list of (str, str)
+        ``(subject_id, simulation_name)`` pairs (bare ids, no ``sub-`` prefix).
+    field : str
+        Which cached field to load -- one of :data:`VALID_FSAVG_FIELDS`.
+    spacing : int
+        fsaverage subdivision factor (5, 6, or 7).
+
+    Returns
+    -------
+    (numpy.ndarray, list of str)
+        The ``(n_vertices, n_subjects)`` data matrix and the subject ids in
+        column order.
+    """
+    if field not in VALID_FSAVG_FIELDS:
+        raise ValueError(f"Unknown field {field!r}; valid: {VALID_FSAVG_FIELDS}")
+    pm = get_path_manager()
+    expected = _FSAVG_NODES[spacing]
+    columns: list[np.ndarray] = []
+    ids: list[str] = []
+    for sid, sim in subjects:
+        npz_path = _output_path(pm, sid, sim, spacing)
+        if not npz_path.exists():
+            raise FileNotFoundError(
+                f"No fsaverage cache for {sid}/{sim}: {npz_path}. "
+                "Run the simulation with map_to_fsavg=True (default) first."
+            )
+        with np.load(npz_path) as data:
+            if field not in data:
+                raise KeyError(
+                    f"{npz_path.name} has no field {field!r}; "
+                    f"available: {[k for k in data.files if k in VALID_FSAVG_FIELDS]}"
+                )
+            arr = np.asarray(data[field], dtype=np.float64).reshape(-1)
+        if arr.shape[0] != expected:
+            raise ValueError(
+                f"{npz_path.name}: expected {expected} fsaverage{spacing} vertices, "
+                f"got {arr.shape[0]}"
+            )
+        columns.append(arr)
+        ids.append(sid)
+    return np.column_stack(columns), ids
+
+
+# ─── fsaverage adjacency ───────────────────────────────────────────────────
+
+
+def _faces_to_adjacency(faces: np.ndarray, n_nodes: int):
+    """Symmetric 0/1 vertex adjacency from triangle faces."""
+    from scipy import sparse
+
+    faces = np.asarray(faces)
+    edges = np.vstack([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [0, 2]]])
+    rows = np.concatenate([edges[:, 0], edges[:, 1]])
+    cols = np.concatenate([edges[:, 1], edges[:, 0]])
+    adj = sparse.coo_matrix(
+        (np.ones(rows.shape[0], dtype=np.int8), (rows, cols)),
+        shape=(n_nodes, n_nodes),
+    ).tocsr()
+    adj.data[:] = 1  # collapse duplicate edges to a single 1
+    return adj
+
+
+def build_fsaverage_adjacency(spacing: int):
+    """Block-diagonal lh+rh fsaverage vertex adjacency (cached per spacing).
+
+    No edges cross the hemisphere boundary, so a slow-wave cluster can never
+    bridge the two hemispheres through a spurious midline edge -- matching the
+    ``[lh; rh]`` node ordering the field caches are written in.
+    """
+    if spacing in _ADJ_CACHE:
+        return _ADJ_CACHE[spacing]
+    from nilearn import datasets, surface
+    from scipy import sparse
+
+    fs = datasets.fetch_surf_fsaverage(f"fsaverage{spacing}")
+    coords_l, faces_l = surface.load_surf_mesh(fs["pial_left"])
+    coords_r, faces_r = surface.load_surf_mesh(fs["pial_right"])
+    adj = sparse.block_diag(
+        [
+            _faces_to_adjacency(faces_l, len(coords_l)),
+            _faces_to_adjacency(faces_r, len(coords_r)),
+        ]
+    ).tocsr()
+    if adj.shape[0] != _FSAVG_NODES[spacing]:
+        raise ValueError(
+            f"fsaverage{spacing} adjacency has {adj.shape[0]} nodes, "
+            f"expected {_FSAVG_NODES[spacing]}"
+        )
+    _ADJ_CACHE[spacing] = adj
+    return adj
+
+
+def _label_graph(mask: np.ndarray, adjacency):
+    """Graph analogue of ``ndimage.label``: 1-based component labels (0 = none)."""
+    from scipy.sparse.csgraph import connected_components
+
+    labels = np.zeros(mask.shape[0], dtype=int)
+    idx = np.flatnonzero(mask)
+    if idx.size == 0:
+        return labels, 0
+    n_comp, comp = connected_components(adjacency[idx][:, idx], directed=False)
+    labels[idx] = comp + 1
+    return labels, n_comp
+
+
+def _cluster_sizes_masses(labels, n, t_full):
+    sizes = np.bincount(labels, minlength=n + 1)[1:]
+    masses = np.bincount(labels, weights=t_full, minlength=n + 1)[1:]
+    return sizes, masses
+
+
+def _max_cluster_stat(labels, n, t_full, cluster_stat):
+    """Max stat over multi-vertex clusters (singletons ignored, like the engine)."""
+    if n == 0:
+        return 0.0
+    sizes, masses = _cluster_sizes_masses(labels, n, t_full)
+    multi = sizes > 1
+    if not np.any(multi):
+        return 0.0
+    return (
+        float(sizes[multi].max())
+        if cluster_stat == "size"
+        else float(masses[multi].max())
+    )
+
+
+def _forming_mask(t_full, p_full, valid_mask, threshold, alternative):
+    mask = (p_full < threshold) & valid_mask
+    if alternative == "greater":
+        mask &= t_full > 0
+    elif alternative == "less":
+        mask &= t_full < 0
+    return mask
+
+
+def _identify_surface_clusters(
+    t_full,
+    p_full,
+    valid_mask,
+    adjacency,
+    threshold,
+    null_stats,
+    cluster_stat,
+    alpha,
+    alternative,
+    r_full=None,
+):
+    """Surface twin of engine._identify_significant_clusters."""
+    mask = _forming_mask(t_full, p_full, valid_mask, threshold, alternative)
+    labels, n = _label_graph(mask, adjacency)
+    sig_mask = np.zeros(t_full.shape[0], dtype=int)
+    if n == 0:
+        return sig_mask, [], []
+
+    sizes, masses = _cluster_sizes_masses(labels, n, t_full)
+    info = [
+        (
+            cid,
+            int(sizes[cid - 1]),
+            float(sizes[cid - 1]) if cluster_stat == "size" else float(masses[cid - 1]),
+        )
+        for cid in range(1, n + 1)
+        if sizes[cid - 1] > 1
+    ]
+    if not info:
+        return sig_mask, [], []
+
+    stat_values = np.array([sv for _, _, sv in info])
+    tail = {"greater": 1, "less": -1}.get(alternative, 0)
+    pvals = pval_from_histogram(stat_values, null_stats, tail=tail)
+
+    all_observed = [
+        {"id": cid, "size": size, "stat_value": sv, "p_value": float(p)}
+        for (cid, size, sv), p in zip(info[:10], pvals[:10])
+    ]
+    sig_clusters = []
+    for (cid, size, sv), p in zip(info, pvals):
+        if p < alpha:
+            verts = np.flatnonzero(labels == cid)
+            sig_mask[verts] = 1
+            entry = {
+                "id": cid,
+                "size": size,
+                "stat_value": sv,
+                "p_value": float(p),
+                "vertices": verts.tolist(),
+            }
+            if r_full is not None:
+                entry["peak_r"] = float(np.max(r_full[verts]))
+                entry["mean_r"] = float(np.mean(r_full[verts]))
+            sig_clusters.append(entry)
+    return sig_mask, sig_clusters, all_observed
+
+
+# ─── runners ───────────────────────────────────────────────────────────────
+
+
+def _output_dir_and_log(analysis_type, analysis_name, callback_handler):
+    # ponytail: reuse the proven helpers; lazy import avoids a module cycle
+    # (permutation imports this module to dispatch).
+    from .permutation import _resolve_output_dir, _setup_logger
+
+    output_dir = _resolve_output_dir(analysis_type, analysis_name)
+    log, log_file = _setup_logger(output_dir, analysis_type, callback_handler)
+    return output_dir, log, log_file
+
+
+def _save_surface_npz(output_dir, **maps):
+    path = os.path.join(output_dir, "surface_maps.npz")
+    np.savez_compressed(path, **maps)
+    return path
+
+
+def _write_clusters_csv(output_dir, clusters):
+    import csv
+
+    path = os.path.join(output_dir, "significant_clusters.csv")
+    keys = ["id", "size", "stat_value", "p_value", "peak_r", "mean_r"]
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=keys, extrasaction="ignore")
+        writer.writeheader()
+        for c in clusters:
+            writer.writerow(c)
+    return path
+
+
+def run_surface_correlation(
+    config, callback_handler=None, stop_callback=None
+) -> CorrelationResult:
+    """Vertexwise field-vs-response correlation on the fsaverage surface."""
+    import time
+
+    t0 = time.time()
+    output_dir, log, log_file = _output_dir_and_log(
+        "correlation", config.analysis_name, callback_handler
+    )
+    log.info(
+        "CLUSTER-BASED PERMUTATION TESTING - SURFACE CORRELATION (fsaverage%d)",
+        config.fsaverage_spacing,
+    )
+    log.info(
+        "field=%s  corr=%s  stat=%s  thr=%.3f  perms=%d  alpha=%.3f",
+        config.fsaverage_field,
+        config.correlation_type.value,
+        config.cluster_stat.value,
+        config.cluster_threshold,
+        config.n_permutations,
+        config.alpha,
+    )
+
+    pairs = [(s.subject_id, s.simulation_name) for s in config.subjects]
+    effect = np.array([float(s.effect_size) for s in config.subjects], dtype=np.float64)
+    weights = (
+        np.array([float(s.weight) for s in config.subjects], dtype=np.float64)
+        if config.use_weights
+        else None
+    )
+    data, ids = load_group_surface_data(
+        pairs, config.fsaverage_field, config.fsaverage_spacing
+    )
+    n_nodes = data.shape[0]
+    adjacency = build_fsaverage_adjacency(config.fsaverage_spacing)
+
+    valid_mask = np.any(data > 0, axis=1)
+    valid_idx = np.flatnonzero(valid_mask)
+    data_valid = data[valid_idx]
+    log.info("Subjects=%d  valid vertices=%d/%d", len(ids), valid_idx.size, n_nodes)
+
+    ctype = config.correlation_type.value
+    # Pre-rank once for Spearman so each permutation skips re-ranking.
+    if ctype == "spearman":
+        from scipy.stats import rankdata
+
+        data_valid = np.apply_along_axis(rankdata, 1, data_valid)
+        preranked = True
+    else:
+        preranked = False
+
+    def _maps(eff, w):
+        r, t, p = correlation(
+            data_valid,
+            eff,
+            correlation_type=ctype,
+            weights=w,
+            voxel_data_preranked=preranked,
+        )
+        r_full = np.zeros(n_nodes)
+        t_full = np.zeros(n_nodes)
+        p_full = np.ones(n_nodes)
+        r_full[valid_idx], t_full[valid_idx], p_full[valid_idx] = r, t, p
+        return r_full, t_full, p_full
+
+    r_full, t_full, p_full = _maps(effect, weights)
+
+    log.info("[null] %d permutations", config.n_permutations)
+    null = np.empty(config.n_permutations)
+    rng = np.random.default_rng()
+    for i in range(config.n_permutations):
+        if stop_callback and stop_callback():
+            raise KeyboardInterrupt("stopped")
+        order = rng.permutation(len(ids))
+        _, pt, pp = _maps(effect[order], None if weights is None else weights[order])
+        labels, n = _label_graph(
+            _forming_mask(pt, pp, valid_mask, config.cluster_threshold, "two-sided"),
+            adjacency,
+        )
+        null[i] = _max_cluster_stat(labels, n, pt, config.cluster_stat.value)
+
+    sig_mask, sig_clusters, observed = _identify_surface_clusters(
+        t_full,
+        p_full,
+        valid_mask,
+        adjacency,
+        config.cluster_threshold,
+        null,
+        config.cluster_stat.value,
+        config.alpha,
+        "two-sided",
+        r_full=r_full,
+    )
+    for obs in observed[:5]:
+        log.info(
+            "  cluster %d: %s=%.2f size=%d p=%.4f",
+            obs["id"],
+            config.cluster_stat.value,
+            obs["stat_value"],
+            obs["size"],
+            obs["p_value"],
+        )
+
+    npz_path = _save_surface_npz(
+        output_dir, r=r_full, t=t_full, p=p_full, sig_mask=sig_mask, null=null
+    )
+    _write_clusters_csv(output_dir, sig_clusters)
+    log.info("Saved surface maps -> %s", npz_path)
+
+    return CorrelationResult(
+        success=True,
+        output_dir=output_dir,
+        n_subjects=len(ids),
+        n_significant_voxels=int(sig_mask.sum()),
+        n_significant_clusters=len(sig_clusters),
+        cluster_threshold=config.cluster_threshold,
+        analysis_time=time.time() - t0,
+        clusters=sig_clusters,
+        log_file=log_file,
+    )
+
+
+def run_surface_group_comparison(
+    config, callback_handler=None, stop_callback=None
+) -> GroupComparisonResult:
+    """Responder-vs-non-responder t-test on the fsaverage surface."""
+    import time
+
+    t0 = time.time()
+    output_dir, log, log_file = _output_dir_and_log(
+        "group_comparison", config.analysis_name, callback_handler
+    )
+    log.info(
+        "CLUSTER-BASED PERMUTATION TESTING - SURFACE GROUP (fsaverage%d)",
+        config.fsaverage_spacing,
+    )
+
+    # Responders first, then non-responders, so column [:n_resp] are responders.
+    resp = [s for s in config.subjects if s.response == 1]
+    non = [s for s in config.subjects if s.response == 0]
+    ordered = resp + non
+    n_resp = len(resp)
+    pairs = [(s.subject_id, s.simulation_name) for s in ordered]
+    data, ids = load_group_surface_data(
+        pairs, config.fsaverage_field, config.fsaverage_spacing
+    )
+    n_nodes = data.shape[0]
+    n_total = data.shape[1]
+    adjacency = build_fsaverage_adjacency(config.fsaverage_spacing)
+
+    valid_mask = np.any(data > 0, axis=1)
+    valid_idx = np.flatnonzero(valid_mask)
+    data_valid = data[valid_idx]
+    paired = config.test_type.value == "paired"
+    alt = config.alternative.value
+    log.info(
+        "resp=%d  non=%d  valid vertices=%d  paired=%s",
+        n_resp,
+        len(non),
+        valid_idx.size,
+        paired,
+    )
+
+    def _maps(mat):
+        if paired:
+            t, p = ttest_rel(mat, n_resp, alternative=alt)
+        else:
+            t, p = ttest_ind(mat, n_resp, n_total - n_resp, alternative=alt)
+        t_full = np.zeros(n_nodes)
+        p_full = np.ones(n_nodes)
+        t_full[valid_idx], p_full[valid_idx] = t, p
+        return t_full, p_full
+
+    t_full, p_full = _maps(data_valid)
+
+    log.info("[null] %d permutations", config.n_permutations)
+    null = np.empty(config.n_permutations)
+    rng = np.random.default_rng()
+    for i in range(config.n_permutations):
+        if stop_callback and stop_callback():
+            raise KeyboardInterrupt("stopped")
+        if paired:
+            flips = rng.choice([-1.0, 1.0], size=n_resp)
+            mean = (data_valid[:, :n_resp] + data_valid[:, n_resp:]) / 2
+            diff = (data_valid[:, :n_resp] - data_valid[:, n_resp:]) / 2
+            perm = np.empty_like(data_valid)
+            perm[:, :n_resp] = mean + flips * diff
+            perm[:, n_resp:] = mean - flips * diff
+        else:
+            perm = data_valid[:, rng.permutation(n_total)]
+        pt, pp = _maps(perm)
+        labels, n = _label_graph(
+            _forming_mask(pt, pp, valid_mask, config.cluster_threshold, alt),
+            adjacency,
+        )
+        null[i] = _max_cluster_stat(labels, n, pt, config.cluster_stat.value)
+
+    sig_mask, sig_clusters, observed = _identify_surface_clusters(
+        t_full,
+        p_full,
+        valid_mask,
+        adjacency,
+        config.cluster_threshold,
+        null,
+        config.cluster_stat.value,
+        config.alpha,
+        alt,
+    )
+    for obs in observed[:5]:
+        log.info(
+            "  cluster %d: %s=%.2f size=%d p=%.4f",
+            obs["id"],
+            config.cluster_stat.value,
+            obs["stat_value"],
+            obs["size"],
+            obs["p_value"],
+        )
+
+    npz_path = _save_surface_npz(
+        output_dir, t=t_full, p=p_full, sig_mask=sig_mask, null=null
+    )
+    _write_clusters_csv(output_dir, sig_clusters)
+    log.info("Saved surface maps -> %s", npz_path)
+
+    return GroupComparisonResult(
+        success=True,
+        output_dir=output_dir,
+        n_responders=n_resp,
+        n_non_responders=len(non),
+        n_significant_voxels=int(sig_mask.sum()),
+        n_significant_clusters=len(sig_clusters),
+        cluster_threshold=config.cluster_threshold,
+        analysis_time=time.time() - t0,
+        clusters=sig_clusters,
+        log_file=log_file,
+    )

--- a/tit/stats/surface.py
+++ b/tit/stats/surface.py
@@ -42,6 +42,15 @@ logger = logging.getLogger(__name__)
 _ADJ_CACHE: dict[int, "object"] = {}
 
 
+def _enum_value(x):
+    """Return a StrEnum's value, or the value itself if already a plain string.
+
+    Configs built via the CLI carry StrEnum members; the GUI may pass raw
+    strings.  Accept both so the surface path never trips on a missing ``.value``.
+    """
+    return getattr(x, "value", x)
+
+
 # ─── data loading ──────────────────────────────────────────────────────────
 
 
@@ -295,8 +304,8 @@ def run_surface_correlation(
     log.info(
         "field=%s  corr=%s  stat=%s  thr=%.3f  perms=%d  alpha=%.3f",
         config.fsaverage_field,
-        config.correlation_type.value,
-        config.cluster_stat.value,
+        _enum_value(config.correlation_type),
+        _enum_value(config.cluster_stat),
         config.cluster_threshold,
         config.n_permutations,
         config.alpha,
@@ -320,7 +329,7 @@ def run_surface_correlation(
     data_valid = data[valid_idx]
     log.info("Subjects=%d  valid vertices=%d/%d", len(ids), valid_idx.size, n_nodes)
 
-    ctype = config.correlation_type.value
+    ctype = _enum_value(config.correlation_type)
     # Pre-rank once for Spearman so each permutation skips re-ranking.
     if ctype == "spearman":
         from scipy.stats import rankdata
@@ -358,7 +367,7 @@ def run_surface_correlation(
             _forming_mask(pt, pp, valid_mask, config.cluster_threshold, "two-sided"),
             adjacency,
         )
-        null[i] = _max_cluster_stat(labels, n, pt, config.cluster_stat.value)
+        null[i] = _max_cluster_stat(labels, n, pt, _enum_value(config.cluster_stat))
 
     sig_mask, sig_clusters, observed = _identify_surface_clusters(
         t_full,
@@ -367,7 +376,7 @@ def run_surface_correlation(
         adjacency,
         config.cluster_threshold,
         null,
-        config.cluster_stat.value,
+        _enum_value(config.cluster_stat),
         config.alpha,
         "two-sided",
         r_full=r_full,
@@ -376,7 +385,7 @@ def run_surface_correlation(
         log.info(
             "  cluster %d: %s=%.2f size=%d p=%.4f",
             obs["id"],
-            config.cluster_stat.value,
+            _enum_value(config.cluster_stat),
             obs["stat_value"],
             obs["size"],
             obs["p_value"],
@@ -432,8 +441,8 @@ def run_surface_group_comparison(
     valid_mask = np.any(data > 0, axis=1)
     valid_idx = np.flatnonzero(valid_mask)
     data_valid = data[valid_idx]
-    paired = config.test_type.value == "paired"
-    alt = config.alternative.value
+    paired = _enum_value(config.test_type) == "paired"
+    alt = _enum_value(config.alternative)
     log.info(
         "resp=%d  non=%d  valid vertices=%d  paired=%s",
         n_resp,
@@ -474,7 +483,7 @@ def run_surface_group_comparison(
             _forming_mask(pt, pp, valid_mask, config.cluster_threshold, alt),
             adjacency,
         )
-        null[i] = _max_cluster_stat(labels, n, pt, config.cluster_stat.value)
+        null[i] = _max_cluster_stat(labels, n, pt, _enum_value(config.cluster_stat))
 
     sig_mask, sig_clusters, observed = _identify_surface_clusters(
         t_full,
@@ -483,7 +492,7 @@ def run_surface_group_comparison(
         adjacency,
         config.cluster_threshold,
         null,
-        config.cluster_stat.value,
+        _enum_value(config.cluster_stat),
         config.alpha,
         alt,
     )
@@ -491,7 +500,7 @@ def run_surface_group_comparison(
         log.info(
             "  cluster %d: %s=%.2f size=%d p=%.4f",
             obs["id"],
-            config.cluster_stat.value,
+            _enum_value(config.cluster_stat),
             obs["stat_value"],
             obs["size"],
             obs["p_value"],

--- a/tit/stats/surface.py
+++ b/tit/stats/surface.py
@@ -29,9 +29,10 @@ import os
 
 import numpy as np
 
+from tit.constants import FSAVG_NODES as _FSAVG_NODES
 from tit.paths import get_path_manager
 from tit.source.config import VALID_FSAVG_FIELDS
-from tit.source.fsaverage import _FSAVG_NODES, _output_path
+from tit.source.fsaverage import _output_path
 
 from .config import CorrelationResult, GroupComparisonResult
 from .engine import correlation, pval_from_histogram, ttest_ind, ttest_rel
@@ -40,15 +41,6 @@ logger = logging.getLogger(__name__)
 
 # fsaverage triangle adjacency is fixed per spacing; build it once.
 _ADJ_CACHE: dict[int, "object"] = {}
-
-
-def _enum_value(x):
-    """Return a StrEnum's value, or the value itself if already a plain string.
-
-    Configs built via the CLI carry StrEnum members; the GUI may pass raw
-    strings.  Accept both so the surface path never trips on a missing ``.value``.
-    """
-    return getattr(x, "value", x)
 
 
 # ─── data loading ──────────────────────────────────────────────────────────
@@ -187,6 +179,15 @@ def _max_cluster_stat(labels, n, t_full, cluster_stat):
     )
 
 
+def _null_threshold(null, alpha, n_permutations):
+    """Null-derived cluster-statistic cutoff at *alpha* (mirrors the engine)."""
+    if null.size == 0:
+        return 0.0
+    sorted_null = np.sort(null)[::-1]
+    ti = max(1, min(int(alpha * n_permutations), len(sorted_null)))
+    return float(sorted_null[ti - 1])
+
+
 def _forming_mask(t_full, p_full, valid_mask, threshold, alternative):
     mask = (p_full < threshold) & valid_mask
     if alternative == "greater":
@@ -304,8 +305,8 @@ def run_surface_correlation(
     log.info(
         "field=%s  corr=%s  stat=%s  thr=%.3f  perms=%d  alpha=%.3f",
         config.fsaverage_field,
-        _enum_value(config.correlation_type),
-        _enum_value(config.cluster_stat),
+        config.correlation_type.value,
+        config.cluster_stat.value,
         config.cluster_threshold,
         config.n_permutations,
         config.alpha,
@@ -324,12 +325,14 @@ def run_surface_correlation(
     n_nodes = data.shape[0]
     adjacency = build_fsaverage_adjacency(config.fsaverage_spacing)
 
-    valid_mask = np.any(data > 0, axis=1)
+    # != 0 (not > 0): TI_normal is signed, so a consistently-inward vertex
+    # must stay in the analysis; background is exactly 0 for all fields.
+    valid_mask = np.any(data != 0, axis=1)
     valid_idx = np.flatnonzero(valid_mask)
     data_valid = data[valid_idx]
     log.info("Subjects=%d  valid vertices=%d/%d", len(ids), valid_idx.size, n_nodes)
 
-    ctype = _enum_value(config.correlation_type)
+    ctype = config.correlation_type.value
     # Pre-rank once for Spearman so each permutation skips re-ranking.
     if ctype == "spearman":
         from scipy.stats import rankdata
@@ -367,7 +370,7 @@ def run_surface_correlation(
             _forming_mask(pt, pp, valid_mask, config.cluster_threshold, "two-sided"),
             adjacency,
         )
-        null[i] = _max_cluster_stat(labels, n, pt, _enum_value(config.cluster_stat))
+        null[i] = _max_cluster_stat(labels, n, pt, config.cluster_stat.value)
 
     sig_mask, sig_clusters, observed = _identify_surface_clusters(
         t_full,
@@ -376,7 +379,7 @@ def run_surface_correlation(
         adjacency,
         config.cluster_threshold,
         null,
-        _enum_value(config.cluster_stat),
+        config.cluster_stat.value,
         config.alpha,
         "two-sided",
         r_full=r_full,
@@ -385,7 +388,7 @@ def run_surface_correlation(
         log.info(
             "  cluster %d: %s=%.2f size=%d p=%.4f",
             obs["id"],
-            _enum_value(config.cluster_stat),
+            config.cluster_stat.value,
             obs["stat_value"],
             obs["size"],
             obs["p_value"],
@@ -403,7 +406,7 @@ def run_surface_correlation(
         n_subjects=len(ids),
         n_significant_voxels=int(sig_mask.sum()),
         n_significant_clusters=len(sig_clusters),
-        cluster_threshold=config.cluster_threshold,
+        cluster_threshold=_null_threshold(null, config.alpha, config.n_permutations),
         analysis_time=time.time() - t0,
         clusters=sig_clusters,
         log_file=log_file,
@@ -438,11 +441,13 @@ def run_surface_group_comparison(
     n_total = data.shape[1]
     adjacency = build_fsaverage_adjacency(config.fsaverage_spacing)
 
-    valid_mask = np.any(data > 0, axis=1)
+    # != 0 (not > 0): TI_normal is signed, so a consistently-inward vertex
+    # must stay in the analysis; background is exactly 0 for all fields.
+    valid_mask = np.any(data != 0, axis=1)
     valid_idx = np.flatnonzero(valid_mask)
     data_valid = data[valid_idx]
-    paired = _enum_value(config.test_type) == "paired"
-    alt = _enum_value(config.alternative)
+    paired = config.test_type.value == "paired"
+    alt = config.alternative.value
     log.info(
         "resp=%d  non=%d  valid vertices=%d  paired=%s",
         n_resp,
@@ -483,7 +488,7 @@ def run_surface_group_comparison(
             _forming_mask(pt, pp, valid_mask, config.cluster_threshold, alt),
             adjacency,
         )
-        null[i] = _max_cluster_stat(labels, n, pt, _enum_value(config.cluster_stat))
+        null[i] = _max_cluster_stat(labels, n, pt, config.cluster_stat.value)
 
     sig_mask, sig_clusters, observed = _identify_surface_clusters(
         t_full,
@@ -492,7 +497,7 @@ def run_surface_group_comparison(
         adjacency,
         config.cluster_threshold,
         null,
-        _enum_value(config.cluster_stat),
+        config.cluster_stat.value,
         config.alpha,
         alt,
     )
@@ -500,7 +505,7 @@ def run_surface_group_comparison(
         log.info(
             "  cluster %d: %s=%.2f size=%d p=%.4f",
             obs["id"],
-            _enum_value(config.cluster_stat),
+            config.cluster_stat.value,
             obs["stat_value"],
             obs["size"],
             obs["p_value"],
@@ -519,7 +524,7 @@ def run_surface_group_comparison(
         n_non_responders=len(non),
         n_significant_voxels=int(sig_mask.sum()),
         n_significant_clusters=len(sig_clusters),
-        cluster_threshold=config.cluster_threshold,
+        cluster_threshold=_null_threshold(null, config.alpha, config.n_permutations),
         analysis_time=time.time() - t0,
         clusters=sig_clusters,
         log_file=log_file,

--- a/tit/tools/montage_visualizer.py
+++ b/tit/tools/montage_visualizer.py
@@ -106,8 +106,20 @@ def _overlay_ring(image: str, x: int, y: int, color: str, ring: str) -> None:
     )
 
 
-def _draw_arc(image: str, x1: int, y1: int, x2: int, y2: int, color: str) -> None:
-    """Draw a Bezier arc between two electrode positions on *image*."""
+def _draw_arc(
+    image: str,
+    x1: int,
+    y1: int,
+    x2: int,
+    y2: int,
+    color: str,
+    center: tuple[float, float],
+) -> None:
+    """Draw a Bezier arc between two electrode positions on *image*.
+
+    The arc always bulges toward *center* (the cap centre), so paired
+    connections consistently curve inward regardless of pair orientation.
+    """
     dx, dy = x2 - x1, y2 - y1
     dist = (dx**2 + dy**2) ** 0.5
     if dist == 0:
@@ -115,8 +127,13 @@ def _draw_arc(image: str, x1: int, y1: int, x2: int, y2: int, color: str) -> Non
     ux, uy = dx / dist, dy / dist
     sx, sy = x1 + ux * 15, y1 + uy * 15
     ex, ey = x2 - ux * 15, y2 - uy * 15
-    cx = (sx + ex) / 2 + (-dy / dist) * dist * 0.25
-    cy = (sy + ey) / 2 + (dx / dist) * dist * 0.25
+    # Unit normal to the line; flip it so it points toward the cap centre.
+    nx, ny = -dy / dist, dx / dist
+    mx, my = (sx + ex) / 2, (sy + ey) / 2
+    if nx * (center[0] - mx) + ny * (center[1] - my) < 0:
+        nx, ny = -nx, -ny
+    cx = mx + nx * dist * 0.25
+    cy = my + ny * dist * 0.25
     subprocess.run(
         [
             "convert",
@@ -180,6 +197,12 @@ def visualize_montage(
 
     coords = _load_coordinates(eeg_net)
 
+    # Cap centre used to orient connection arcs consistently inward.
+    center = (
+        sum(x for x, _ in coords.values()) / len(coords),
+        sum(y for _, y in coords.values()) / len(coords),
+    )
+
     template = os.path.join(_RESOURCES_DIR, "GSN-256.png")
     os.makedirs(output_dir, exist_ok=True)
 
@@ -204,4 +227,4 @@ def visualize_montage(
         if e2 in coords:
             _overlay_ring(out_image, *coords[e2], color, ring)
         if e1 in coords and e2 in coords:
-            _draw_arc(out_image, *coords[e1], *coords[e2], color)
+            _draw_arc(out_image, *coords[e1], *coords[e2], color, center)


### PR DESCRIPTION
## Problem

In montage visualizations, the arc connecting each electrode pair used a fixed perpendicular rotation of the line direction for its Bézier control point. This meant the bulge direction depended on each pair's orientation — sometimes curving inward toward the cap center, sometimes outward. In the example below, the left (blue F7↔P7) pair curved outward while the right (red F8↔P8) pair curved inward.

## Fix

`tit/tools/montage_visualizer.py`:
- Compute the cap centroid from the electrode coordinates.
- In `_draw_arc`, flip the perpendicular offset via a dot-product test so the control point always lands on the center-facing side. Arcs now consistently bulge inward regardless of pair orientation.

## Verification

Rendered the exact pairs from the reported example (F7↔P7, F8↔P8, GSN-HydroCel-256) inside the `simnibs_container`. Both arcs now curve inward toward the cap center, symmetrically.