### PR TITLE
[Track] hf-safety-metrics: hf_peak/hf_sar Cassarà TI carrier-exposure metrics

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,64 @@
+"""Numeric tests for the Cassarà carrier safety metrics (tit.fields)."""
+
+import numpy as np
+import pytest
+
+from tit.fields import hf_peak, hf_sar
+
+
+class TestHfPeak:
+    """hf_peak = max(|E1+E2|, |E1-E2|) — the true peak carrier field."""
+
+    def test_parallel_aligned(self):
+        # aligned same direction: |E1+E2| = |E1|+|E2| dominates
+        e1 = np.array([[1.0, 0, 0]])
+        e2 = np.array([[0.5, 0, 0]])
+        assert hf_peak(e1, e2)[0] == pytest.approx(1.5)
+
+    def test_antiparallel_uses_difference(self):
+        # opposed: |E1+E2| = 0.5 but |E1-E2| = 1.5 -> the max captures the real peak
+        e1 = np.array([[1.0, 0, 0]])
+        e2 = np.array([[-0.5, 0, 0]])
+        assert hf_peak(e1, e2)[0] == pytest.approx(1.5)
+
+    def test_orthogonal(self):
+        e1 = np.array([[1.0, 0, 0]])
+        e2 = np.array([[0.0, 1.0, 0]])
+        assert hf_peak(e1, e2)[0] == pytest.approx(np.sqrt(2))
+
+    def test_bounded_by_magnitude_and_amplitude_sum(self):
+        # |E1+E2| <= hf_peak <= |E1|+|E2| for arbitrary fields
+        rng = np.random.default_rng(0)
+        e1 = rng.normal(size=(200, 3))
+        e2 = rng.normal(size=(200, 3))
+        peak = hf_peak(e1, e2)
+        assert np.all(peak >= np.linalg.norm(e1 + e2, axis=1) - 1e-9)
+        assert np.all(
+            peak <= np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1) + 1e-9
+        )
+
+
+class TestHfSar:
+    """hf_sar = |E1|^2 + |E2|^2 — heating driver (incoherent, angle-independent)."""
+
+    def test_sum_of_squares(self):
+        e1 = np.array([[3.0, 0, 0]])
+        e2 = np.array([[0.0, 4.0, 0]])
+        assert hf_sar(e1, e2)[0] == pytest.approx(25.0)
+
+    def test_independent_of_relative_orientation(self):
+        e1 = np.array([[1.0, 0, 0]])
+        for e2 in (
+            np.array([[1.0, 0, 0]]),
+            np.array([[-1.0, 0, 0]]),
+            np.array([[0.0, 1.0, 0]]),
+        ):
+            assert hf_sar(e1, e2)[0] == pytest.approx(2.0)
+
+    def test_not_equal_to_amplitude_sum_squared(self):
+        # Cassarà: heating ∝ |E1|^2+|E2|^2, NOT (|E1|+|E2|)^2 (over-estimates up to 2x)
+        e1 = np.array([[1.0, 0, 0]])
+        e2 = np.array([[1.0, 0, 0]])
+        assert hf_sar(e1, e2)[0] == pytest.approx(2.0)
+        amp_sum_sq = (np.linalg.norm(e1) + np.linalg.norm(e2)) ** 2
+        assert amp_sum_sq == pytest.approx(4.0)  # the over-estimate we avoid

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -33,14 +33,14 @@ class TestFsavgMapConfig:
         from tit.source import FsavgMapConfig
 
         cfg = FsavgMapConfig()
-        assert cfg.fields == ("TI_max", "TI_normal", "magnitude", "hf_max")
+        assert cfg.fields == ("TI_max", "TI_normal", "hf_peak", "hf_sar")
         assert cfg.fsaverage_spacing == 5
 
-    def test_hf_max_is_a_valid_field(self):
+    def test_hf_fields_are_valid(self):
         from tit.source import FsavgMapConfig
 
-        cfg = FsavgMapConfig(fields=("hf_max",))
-        assert cfg.fields == ("hf_max",)
+        cfg = FsavgMapConfig(fields=("hf_peak", "hf_sar"))
+        assert cfg.fields == ("hf_peak", "hf_sar")
 
     def test_unknown_field_raises(self):
         from tit.source import FsavgMapConfig
@@ -141,14 +141,14 @@ class TestFsavgHelpers:
         with pytest.raises(FileNotFoundError):
             fsaverage._carrier_volume_meshes(pm, "001", "TI_sim")
 
-    def test_hf_max_and_magnitude_from_carrier_e(self, monkeypatch):
-        """Both derive from the interpolated vector E: hf_max=|E1|+|E2|, mag=|E1+E2|."""
+    def test_hf_peak_and_hf_sar_from_carrier_e(self, monkeypatch):
+        """Both derive from the interpolated vector E (Cassarà formulas)."""
         import numpy as np
 
         from tit.source import fsaverage
         from tit.source.config import FsavgMapConfig
 
-        # Anti-parallel carriers: |E1|+|E2| = 2, but |E1+E2| = 0.
+        # Anti-parallel carriers: |E1+E2|=0, |E1-E2|=2 -> hf_peak=2; hf_sar=1+1=2.
         monkeypatch.setattr(
             fsaverage, "_carrier_volume_meshes", lambda *a: ("v1", "v2")
         )
@@ -168,10 +168,10 @@ class TestFsavgHelpers:
             _MagicMock(),
             "001",
             "TI_sim",
-            FsavgMapConfig(fields=("hf_max", "magnitude")),
+            FsavgMapConfig(fields=("hf_peak", "hf_sar")),
         )
-        assert out["hf_max"][0] == pytest.approx(2.0)
-        assert out["magnitude"][0] == pytest.approx(0.0)
+        assert out["hf_peak"][0] == pytest.approx(2.0)
+        assert out["hf_sar"][0] == pytest.approx(2.0)
 
     def test_carrier_interp_failure_keeps_ti_fields(self, monkeypatch):
         """A carrier E-interpolation failure skips hf_max/magnitude, keeps TI."""
@@ -199,7 +199,7 @@ class TestFsavgHelpers:
         self._mock_simnibs_core(monkeypatch)
         out = fsaverage._compute_fields(_MagicMock(), "001", "TI_sim", FsavgMapConfig())
         assert "TI_max" in out and "TI_normal" in out
-        assert "hf_max" not in out and "magnitude" not in out
+        assert "hf_peak" not in out and "hf_sar" not in out
 
     def test_carrier_failure_keeps_ti_fields(self, monkeypatch):
         """A carrier read failure drops hf_max/magnitude but keeps TI_max/TI_normal."""
@@ -223,7 +223,7 @@ class TestFsavgHelpers:
         self._mock_simnibs_core(monkeypatch)
         out = fsaverage._compute_fields(_MagicMock(), "001", "TI_sim", FsavgMapConfig())
         assert "TI_max" in out and "TI_normal" in out
-        assert "hf_max" not in out and "magnitude" not in out
+        assert "hf_peak" not in out and "hf_sar" not in out
 
     @staticmethod
     def _mock_simnibs_core(monkeypatch):

--- a/tests/test_stats_surface.py
+++ b/tests/test_stats_surface.py
@@ -41,9 +41,9 @@ class TestSurfaceConfig:
             analysis_name="a",
             subjects=self._corr_subjects(),
             space=CorrelationConfig.AnalysisSpace.FSAVERAGE,
-            fsaverage_field="hf_max",
+            fsaverage_field="hf_peak",
         )
-        assert cfg.fsaverage_field == "hf_max"
+        assert cfg.fsaverage_field == "hf_peak"
 
     def test_fsaverage_space_rejects_unknown_field(self):
         with pytest.raises(ValueError):
@@ -115,7 +115,8 @@ class TestLoadGroupSurfaceData:
 
         self._write_cache(init_pm, "001", "TI_sim", 5, TI_max=np.zeros(_FSAVG_NODES[5]))
         with pytest.raises(KeyError):
-            surface.load_group_surface_data([("001", "TI_sim")], "hf_max", 5)
+            # hf_peak is a valid field but absent from this cache -> KeyError
+            surface.load_group_surface_data([("001", "TI_sim")], "hf_peak", 5)
 
     def test_wrong_node_count_raises(self, init_pm):
         from tit.stats import surface

--- a/tit/constants.py
+++ b/tit/constants.py
@@ -152,6 +152,8 @@ DOCKER_MOUNT_PREFIX = "/mnt"
 FIELD_TI_MAX = "TI_max"  # TI field name in 2-pair simulation meshes
 FIELD_MTI_MAX = "TI_Max"  # mTI field name in 4-pair simulation meshes
 FIELD_TI_NORMAL = "TI_normal"  # Normal component field name
+FIELD_HF_PEAK = "hf_peak"  # peak carrier field max(|E1+E2|,|E1-E2|) (Cassarà 2025)
+FIELD_HF_SAR = "hf_sar"  # carrier heating driver |E1|^2+|E2|^2 (∝ SAR)
 
 # fsaverage total node counts (both hemispheres) per subdivision factor.
 # ico5/6/7 surfaces: 10242/40962/163842 vertices per hemisphere, doubled.

--- a/tit/fields.py
+++ b/tit/fields.py
@@ -1,0 +1,79 @@
+"""Carrier-derived high-frequency field metrics — single source of truth.
+
+Safety-relevant quantities computed from the two carrier E-field vectors
+``E1``, ``E2`` (each electrode pair's field amplitude), following Cassarà et al.
+2025, *Safety Recommendations for Temporal Interference Stimulation in the
+Brain, Part I* (Bioelectromagnetics 46(2), doi:10.1002/bem.22542):
+
+``hf_peak`` — **peak carrier field** (Eq. 3)::
+
+    hf_peak = max(|E1 + E2|, |E1 - E2|)
+
+    The true peak of the instantaneous carrier field over one beat cycle
+    (worst-case in-phase superposition).  This is the physically-realized peak,
+    NOT the loose bound ``|E1| + |E2|`` — the latter is reached only where the
+    two carriers are exactly collinear.  For fields within 90 deg of each other
+    (the usual on-target case) it reduces to ``|E1 + E2|``.
+
+``hf_sar`` — **heating driver, proportional to SAR**::
+
+    hf_sar = |E1|^2 + |E2|^2
+
+    The carriers are at different frequencies (incoherent), so their SAR/power
+    adds rather than their amplitudes; tissue temperature rise is proportional
+    to ``|E1|^2 + |E2|^2``, *not* ``(|E1| + |E2|)^2``.  A field-domain proxy in
+    ``(V/m)^2``; the calibrated SAR is ``(sigma / 2 rho) * hf_sar`` (needs
+    per-tissue conductivity and density).
+
+These are distinct from the stimulation-relevant modulation envelope
+(``TI_max`` / ``TI_normal``), which lives in SimNIBS ``TI_utils`` and
+:mod:`tit.sim.TI`.
+
+See Also
+--------
+tit.sim.TI : Writes hf_peak / hf_sar as volume fields on the TI mesh.
+tit.source.fsaverage : Projects hf_peak / hf_sar onto fsaverage.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _norm(E: np.ndarray) -> np.ndarray:
+    """Per-row Euclidean norm of an ``(..., 3)`` vector array."""
+    return np.linalg.norm(np.asarray(E, dtype=float), axis=-1)
+
+
+def hf_peak(E1, E2) -> np.ndarray:
+    """Peak carrier field ``max(|E1 + E2|, |E1 - E2|)`` (Cassarà 2025, Eq. 3).
+
+    Parameters
+    ----------
+    E1, E2 : array-like, shape ``(..., 3)``
+        The two carrier E-field vectors (per element or per node).
+
+    Returns
+    -------
+    numpy.ndarray, shape ``(...,)``
+        The worst-case peak carrier field magnitude.
+    """
+    E1 = np.asarray(E1, dtype=float)
+    E2 = np.asarray(E2, dtype=float)
+    return np.maximum(_norm(E1 + E2), _norm(E1 - E2))
+
+
+def hf_sar(E1, E2) -> np.ndarray:
+    """Incoherent carrier heating driver ``|E1|^2 + |E2|^2`` (proportional to SAR).
+
+    Parameters
+    ----------
+    E1, E2 : array-like, shape ``(..., 3)``
+        The two carrier E-field vectors (per element or per node).
+
+    Returns
+    -------
+    numpy.ndarray, shape ``(...,)``
+        ``|E1|^2 + |E2|^2`` in ``(V/m)^2`` — proportional to tissue heating.
+    """
+    return _norm(E1) ** 2 + _norm(E2) ** 2

--- a/tit/gui/extensions/cbp.py
+++ b/tit/gui/extensions/cbp.py
@@ -389,7 +389,7 @@ class ClusterPermutationWidget(QtWidgets.QWidget):
 
         self.config_layout.addWidget(QtWidgets.QLabel("Surface Field:"), row, 2)
         self.fsavg_field_combo = QtWidgets.QComboBox()
-        self.fsavg_field_combo.addItems(["TI_max", "TI_normal", "magnitude", "hf_max"])
+        self.fsavg_field_combo.addItems(["TI_max", "TI_normal", "hf_peak", "hf_sar"])
         self.fsavg_field_combo.setToolTip(
             "Which fsaverage field to analyze (ignored when Space is MNI)."
         )

--- a/tit/gui/extensions/source.py
+++ b/tit/gui/extensions/source.py
@@ -111,15 +111,15 @@ class SourceWidget(QtWidgets.QWidget):
         fields_layout.setContentsMargins(0, 0, 0, 0)
         self.field_ti_max = QtWidgets.QCheckBox("TI_max")
         self.field_ti_normal = QtWidgets.QCheckBox("TI_normal")
-        self.field_magnitude = QtWidgets.QCheckBox("magnitude")
-        self.field_hf_max = QtWidgets.QCheckBox("hf_max")
+        self.field_hf_peak = QtWidgets.QCheckBox("hf_peak")
+        self.field_hf_sar = QtWidgets.QCheckBox("hf_sar")
         self.field_ti_max.setChecked(True)
         self.field_ti_normal.setChecked(True)
         for cb in (
             self.field_ti_max,
             self.field_ti_normal,
-            self.field_magnitude,
-            self.field_hf_max,
+            self.field_hf_peak,
+            self.field_hf_sar,
         ):
             fields_layout.addWidget(cb)
         fields_layout.addStretch()
@@ -206,10 +206,10 @@ class SourceWidget(QtWidgets.QWidget):
             fields.append("TI_max")
         if self.field_ti_normal.isChecked():
             fields.append("TI_normal")
-        if self.field_magnitude.isChecked():
-            fields.append("magnitude")
-        if self.field_hf_max.isChecked():
-            fields.append("hf_max")
+        if self.field_hf_peak.isChecked():
+            fields.append("hf_peak")
+        if self.field_hf_sar.isChecked():
+            fields.append("hf_sar")
         return fields
 
     def _confirm_overwrite(self, paths):

--- a/tit/sim/TI.py
+++ b/tit/sim/TI.py
@@ -30,6 +30,7 @@ from simnibs import mesh_io, sim_struct
 from simnibs.utils import TI_utils as TI
 
 from tit import constants as const
+from tit.fields import hf_peak, hf_sar
 from tit.sim.base import BaseSimulation
 from tit.sim.config import SimulationMode
 from tit.sim.utils import (
@@ -139,6 +140,11 @@ class TISimulation(BaseSimulation):
         mout = deepcopy(m1)
         mout.elmdata = []
         mout.add_element_field(TImax, "TI_max")
+        # Carrier-exposure safety maps (Cassarà 2025): peak carrier field and the
+        # heating driver. Written as volume fields so they flow to subject-/MNI-
+        # space NIfTIs alongside TI_max.
+        mout.add_element_field(hf_peak(ef1.value, ef2.value), const.FIELD_HF_PEAK)
+        mout.add_element_field(hf_sar(ef1.value, ef2.value), const.FIELD_HF_SAR)
 
         ti_path = os.path.join(dirs["ti_mesh"], f"{name}_TI.msh")
         mesh_io.write_msh(mout, ti_path)

--- a/tit/source/config.py
+++ b/tit/source/config.py
@@ -22,10 +22,9 @@ from dataclasses import dataclass, field
 #: Field quantities that :func:`tit.source.fsaverage.project_fields_to_fsaverage`
 #: knows how to compute on the subject central surface before morphing.
 #:
-#: ``hf_max`` is the peak instantaneous carrier exposure ``|E1| + |E2|`` (sum of
-#: carrier magnitudes) -- distinct from ``magnitude`` = ``|E1 + E2|`` (the
-#: coherent vector sum); both derive from the same two carrier overlays.
-VALID_FSAVG_FIELDS: tuple[str, ...] = ("TI_max", "TI_normal", "magnitude", "hf_max")
+#: ``hf_peak`` = ``max(|E1+E2|, |E1-E2|)`` is the peak carrier field and ``hf_sar``
+#: = ``|E1|^2 + |E2|^2`` the heating driver (Cassarà 2025); see :mod:`tit.fields`.
+VALID_FSAVG_FIELDS: tuple[str, ...] = ("TI_max", "TI_normal", "hf_peak", "hf_sar")
 
 #: fsaverage subdivision factors accepted by SimNIBS ``prepare_eeg_forward`` and
 #: ``cross_subject_map`` (5 -> 10242, 6 -> 40962, 7 -> 163842 nodes per hemi).
@@ -72,7 +71,7 @@ class FsavgMapConfig:
     fields : tuple of str
         Which field quantities to project.  Any of
         :data:`VALID_FSAVG_FIELDS` (``"TI_max"``, ``"TI_normal"``,
-        ``"magnitude"``, ``"hf_max"``).
+        ``"hf_peak"``, ``"hf_sar"``).
     fsaverage_spacing : int
         fsaverage subdivision factor (5, 6, or 7) to morph onto.
     workers : int

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -11,17 +11,17 @@ central-surface overlays and morphs the requested scalar fields to fsaverage:
 
 * ``TI_max``    -- orientation-maximized TI envelope |E| (central overlay)
 * ``TI_normal`` -- directional TI envelope along the cortical normal
-* ``magnitude`` -- coherent carrier exposure |E1 + E2| on the central surface
-* ``hf_max``    -- peak instantaneous carrier exposure |E1| + |E2| (the upper
-  bound the tissue sees; distinct from ``magnitude``)
+* ``hf_peak``   -- peak carrier field max(|E1+E2|, |E1-E2|) (Cassarà 2025, safety)
+* ``hf_sar``    -- carrier heating driver |E1|^2 + |E2|^2 (proportional to SAR)
 
 ``TI_max`` / ``TI_normal`` are read from the pipeline's central-surface overlays;
-``magnitude`` / ``hf_max`` are interpolated from the carrier **volume** meshes
-(the surface overlays only reliably carry ``E_normal`` on some SimNIBS builds).
+``hf_peak`` / ``hf_sar`` are interpolated from the carrier **volume** meshes (the
+surface overlays only reliably carry ``E_normal`` on some SimNIBS builds) using
+the same formulas as the volume output (:mod:`tit.fields`).
 
 Unlike SimNIBS's native ``map_to_fsavg`` (which only runs at simulation time and
 only emits ``TI_max``), this works *post-hoc* on any finished simulation and on
-the derived ``TI_normal`` / ``magnitude`` quantities.
+the derived ``TI_normal`` / ``hf_peak`` / ``hf_sar`` quantities.
 
 Runs under ``simnibs_python`` (reads SimNIBS meshes)::
 
@@ -42,6 +42,7 @@ from pathlib import Path
 import numpy as np
 
 from tit.constants import FSAVG_NODES as _FSAVG_NODES
+from tit.fields import hf_peak, hf_sar
 from tit.paths import get_path_manager
 from tit.source.config import FsavgMapConfig
 
@@ -63,7 +64,7 @@ def _carrier_volume_meshes(pm, subject_id: str, sim: str) -> tuple[Path, Path]:
 
     Unlike the central-surface overlays -- which some SimNIBS builds fill with
     only ``E_normal`` -- the high-frequency volume meshes always carry the full
-    vector ``E``, so ``magnitude`` / ``hf_max`` can be derived reliably from them.
+    vector ``E``, so ``hf_peak`` / ``hf_sar`` can be derived reliably from them.
     """
     sim_dir = Path(pm.simulation(subject_id, sim))
 
@@ -203,7 +204,7 @@ def _compute_fields(
             _ti_normal_overlay(pm, subject_id, sim), "TI_normal"
         ),
     )
-    if "magnitude" in cfg.fields or "hf_max" in cfg.fields:
+    if "hf_peak" in cfg.fields or "hf_sar" in cfg.fields:
         try:
             vol1, vol2 = _carrier_volume_meshes(pm, subject_id, sim)
             m1, gm1 = _load_carrier_mesh(vol1)
@@ -216,13 +217,9 @@ def _compute_fields(
         except Exception as exc:  # noqa: BLE001 - shared carrier read; skip both
             errors.append(f"carriers: {exc!r}")
         else:
-            # hf_max = |E1| + |E2| peak instantaneous exposure (the upper bound);
-            # magnitude = |E1 + E2| coherent vector sum. Both the full field.
-            _project(
-                "hf_max",
-                lambda: np.linalg.norm(e1, axis=1) + np.linalg.norm(e2, axis=1),
-            )
-            _project("magnitude", lambda: np.linalg.norm(e1 + e2, axis=1))
+            # Cassarà 2025 safety metrics (same formulas as the volume output).
+            _project("hf_peak", lambda: hf_peak(e1, e2))
+            _project("hf_sar", lambda: hf_sar(e1, e2))
 
     if not out:
         raise ValueError(

--- a/tit/stats/config.py
+++ b/tit/stats/config.py
@@ -45,7 +45,7 @@ class _AnalysisSpace(StrEnum):
 
 #: Surface field quantities the fsaverage stats path can load (mirrors
 #: :data:`tit.source.config.VALID_FSAVG_FIELDS`).
-_VALID_FSAVG_FIELDS = ("TI_max", "TI_normal", "magnitude", "hf_max")
+_VALID_FSAVG_FIELDS = ("TI_max", "TI_normal", "hf_peak", "hf_sar")
 _VALID_FSAVG_SPACINGS = (5, 6, 7)
 
 


### PR DESCRIPTION
## What

Adds the two carrier-exposure **safety metrics** from Cassarà et al. 2025 (*Safety Recommendations for TIS, Part I*, Bioelectromagnetics 46(2), doi:10.1002/bem.22542):

- `hf_peak = max(|E1+E2|, |E1-E2|)` — the peak carrier field (Eq. 3)
- `hf_sar  = |E1|² + |E2|²` — the heating driver (∝ SAR; carriers are incoherent, so power adds)

New `tit/fields.py` is the single source of truth. `TISimulation._post_process` writes both as volume element fields so they flow to subject-/MNI-space NIfTI safety maps alongside `TI_max`; the fsaverage projection, surface stats, and GUI extensions now offer `hf_peak`/`hf_sar` in place of the earlier loose `magnitude` (|E1+E2|) / `hf_max` (|E1|+|E2|).

## Why a fresh PR (supersedes #126)

The fsaverage-surface pipeline itself already landed on `main` via commit `4170f8fa` (merged as part of #127). PR #126 therefore conflicts and, merged whole, would **revert** the `montage_visualizer` arc work from #128. This branch is cut fresh from `main` and carries **only** the genuinely-new safety-metric delta (11 files), leaving `montage_visualizer.py` at main's current version. #126 will be closed in favour of this.

## Tests

Full suite: **1874 passed**, 7 skipped. The 3 `test_opt_flex.py::TestRunFlexSearch` failures are pre-existing (PathManager/flex env, unrelated to this change).