### PR TITLE
pre: fix DICOM scan crash on macOS junk files; add CT + NIfTI ingestion

### DIFF
--- a/tests/test_analyzer_full.py
+++ b/tests/test_analyzer_full.py
@@ -176,7 +176,7 @@ class TestCortexMesh:
         surface = _mock_surface(values)
         mock_load.return_value = surface
 
-        atlas_raw = ({"lh": {"V1": np.array([True, False, True, False])}})
+        atlas_raw = {"lh": {"V1": np.array([True, False, True, False])}}
         with patch(
             "simnibs.utils.transformations.atlas2subject", return_value=atlas_raw
         ):
@@ -635,12 +635,12 @@ class TestCombinedCortexMesh:
         surface = _mock_surface(values)
         mock_load.return_value = surface
 
-        atlas_raw = ({
+        atlas_raw = {
             "lh": {
                 "V1": np.array([True, False, False, False]),
                 "V2": np.array([False, False, True, False]),
             }
-        })
+        }
         with patch(
             "simnibs.utils.transformations.atlas2subject", return_value=atlas_raw
         ):
@@ -667,7 +667,7 @@ class TestCombinedCortexMesh:
         surface = _mock_surface(values)
         mock_load.return_value = surface
 
-        atlas_raw = ({
+        atlas_raw = {
             "lh": {
                 "lh.cuneus": np.array([True, False, False, False]),
                 "lh.precentral": np.array([False, False, True, False]),
@@ -676,7 +676,7 @@ class TestCombinedCortexMesh:
                 "rh.cuneus": np.array([False, True, False, False]),
                 "rh.precentral": np.array([False, False, False, True]),
             },
-        })
+        }
         with patch(
             "simnibs.utils.transformations.atlas2subject", return_value=atlas_raw
         ):
@@ -703,10 +703,10 @@ class TestCombinedCortexMesh:
         surface = _mock_surface(values)
         mock_load.return_value = surface
 
-        atlas_raw = ({
+        atlas_raw = {
             "lh": {"lh.cuneus": np.array([True, False])},
             "rh": {"rh.cuneus": np.array([False, True])},
-        })
+        }
         with patch(
             "simnibs.utils.transformations.atlas2subject", return_value=atlas_raw
         ):
@@ -727,10 +727,10 @@ class TestCombinedCortexMesh:
         surface = _mock_surface(np.array([1.0, 2.0]))
         mock_load.return_value = surface
 
-        atlas_raw = ({
+        atlas_raw = {
             "lh": {"lh.cuneus": np.array([True, False])},
             "rh": {"rh.cuneus": np.array([False, True])},
-        })
+        }
         with patch(
             "simnibs.utils.transformations.atlas2subject", return_value=atlas_raw
         ):
@@ -745,7 +745,7 @@ class TestCombinedCortexMesh:
         surface = _mock_surface(values)
         mock_load.return_value = surface
 
-        atlas_raw = ({"lh": {"V1": np.array([True, False, True, False])}})
+        atlas_raw = {"lh": {"V1": np.array([True, False, True, False])}}
         with patch(
             "simnibs.utils.transformations.atlas2subject", return_value=atlas_raw
         ):

--- a/tests/test_analyzer_group.py
+++ b/tests/test_analyzer_group.py
@@ -30,7 +30,6 @@ from tit.analyzer.group import (
     run_group_analysis,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helper: build a fake AnalysisResult
 # ---------------------------------------------------------------------------
@@ -186,6 +185,7 @@ class TestGenerateComparisonPlot:
     def test_returns_plot_path(self, tmp_path):
         """Plot path is output_dir / group_comparison.pdf."""
         import matplotlib.pyplot as plt
+
         # Reset any leaked side_effect from other test files
         plt.savefig.side_effect = None
         plt.savefig.reset_mock()
@@ -228,9 +228,9 @@ class TestAddStdLines:
         # Verify the y-values of the horizontal lines
         y_values = [c.kwargs["y"] for c in ax.axhline.call_args_list]
         assert pytest.approx(12.0) in y_values  # mean + 1*std
-        assert pytest.approx(8.0) in y_values   # mean - 1*std
+        assert pytest.approx(8.0) in y_values  # mean - 1*std
         assert pytest.approx(14.0) in y_values  # mean + 2*std
-        assert pytest.approx(6.0) in y_values   # mean - 2*std
+        assert pytest.approx(6.0) in y_values  # mean - 2*std
 
     def test_correct_colors_for_lines(self):
         ax = MagicMock()
@@ -407,8 +407,14 @@ class TestNumericCols:
 
     def test_all_numeric_cols_present(self):
         expected = {
-            "ROI_Mean", "ROI_Max", "ROI_Min", "ROI_Focality",
-            "GM_Mean", "GM_Max",
-            "Normal_Mean", "Normal_Max", "Normal_Focality",
+            "ROI_Mean",
+            "ROI_Max",
+            "ROI_Min",
+            "ROI_Focality",
+            "GM_Mean",
+            "GM_Max",
+            "Normal_Mean",
+            "Normal_Max",
+            "Normal_Focality",
         }
         assert set(_NUMERIC_COLS) == expected

--- a/tests/test_atlas_coverage.py
+++ b/tests/test_atlas_coverage.py
@@ -10,7 +10,6 @@ import pytest
 import numpy as np
 from unittest.mock import MagicMock, patch, mock_open
 
-
 # ============================================================================
 # overlap.py — check_and_resample_atlas
 # ============================================================================
@@ -23,6 +22,7 @@ class TestCheckAndResampleAtlas:
     def test_matching_dimensions_3d(self):
         """When atlas and reference shapes match (3D), return atlas data as int."""
         import sys
+
         sys.modules.setdefault("nibabel.processing", MagicMock())
         from tit.atlas.overlap import check_and_resample_atlas
 
@@ -42,6 +42,7 @@ class TestCheckAndResampleAtlas:
     def test_matching_dimensions_4d_atlas(self):
         """When shapes match but atlas is 4D, the 4th dim is sliced off."""
         import sys
+
         sys.modules.setdefault("nibabel.processing", MagicMock())
         from tit.atlas.overlap import check_and_resample_atlas
 
@@ -63,6 +64,7 @@ class TestCheckAndResampleAtlas:
     def test_matching_dimensions_returns_int_array(self):
         """Returned data should be integer dtype."""
         import sys
+
         sys.modules.setdefault("nibabel.processing", MagicMock())
         from tit.atlas.overlap import check_and_resample_atlas
 
@@ -188,6 +190,7 @@ class TestAtlasOverlapAnalysis:
     def _reset_nib_mock(self):
         """Reset nibabel mock state before each test to avoid leaks."""
         import sys
+
         nib_mock = sys.modules["nibabel"]
         nib_mock.load.side_effect = None
         nib_mock.load.reset_mock()
@@ -565,7 +568,10 @@ class TestVoxelAtlasManagerListAtlases:
         results = mgr.list_atlases()
 
         assert len(results) == 1
-        assert results[0] == ("labeling.nii.gz", os.path.join(str(seg_dir), "labeling.nii.gz"))
+        assert results[0] == (
+            "labeling.nii.gz",
+            os.path.join(str(seg_dir), "labeling.nii.gz"),
+        )
 
     def test_labeling_missing_not_included(self, tmp_path):
         """If labeling.nii.gz is absent, it is not in results."""
@@ -671,10 +677,7 @@ class TestVoxelAtlasManagerListRegions:
 
         atlas_path = str(tmp_path / "myatlas.nii.gz")
         labels_file = tmp_path / "myatlas_labels.txt"
-        labels_file.write_text(
-            "# header\n"
-            " 1   10   500   30.0  Thalamus\n"
-        )
+        labels_file.write_text("# header\n" " 1   10   500   30.0  Thalamus\n")
 
         mgr = VoxelAtlasManager()
         regions = mgr.list_regions(atlas_path)
@@ -692,10 +695,7 @@ class TestVoxelAtlasManagerListRegions:
 
         def fake_subprocess_run(cmd, check, capture_output):
             # Write labels file as mri_segstats would
-            labels_file.write_text(
-                "# header\n"
-                " 1   42   800   40.0  Putamen\n"
-            )
+            labels_file.write_text("# header\n" " 1   42   800   40.0  Putamen\n")
 
         with patch("tit.atlas.voxel.subprocess.run", side_effect=fake_subprocess_run):
             regions = mgr.list_regions(atlas_path)
@@ -745,10 +745,7 @@ class TestVoxelAtlasManagerListRegions:
         atlas_path = str(tmp_path / "partial.mgz")
         labels_file = tmp_path / "partial_labels.txt"
         labels_file.write_text(
-            "# header\n"
-            "short line\n"
-            " 1   10   500   30.0  ValidRegion\n"
-            "a b c\n"
+            "# header\n" "short line\n" " 1   10   500   30.0  ValidRegion\n" "a b c\n"
         )
 
         mgr = VoxelAtlasManager()
@@ -763,8 +760,7 @@ class TestVoxelAtlasManagerListRegions:
         atlas_path = str(tmp_path / "multi.mgz")
         labels_file = tmp_path / "multi_labels.txt"
         labels_file.write_text(
-            "# header\n"
-            " 1   99   500   30.0  Left Superior Temporal Gyrus\n"
+            "# header\n" " 1   99   500   30.0  Left Superior Temporal Gyrus\n"
         )
 
         mgr = VoxelAtlasManager()

--- a/tests/test_blender_config.py
+++ b/tests/test_blender_config.py
@@ -131,6 +131,7 @@ class TestMontageConfig:
         assert cfg.show_full_net is True
         assert cfg.electrode_diameter_mm == 10.0
         assert cfg.electrode_height_mm == 6.0
+
     def test_custom_values(self):
         cfg = _montage(
             output_dir="/out",

--- a/tests/test_blender_integration.py
+++ b/tests/test_blender_integration.py
@@ -282,7 +282,11 @@ class TestMainDispatch:
         mock_run.assert_called_once()
 
     def test_unknown_type_returns_error(self, tmp_path):
-        config_data = {"_type": "UnknownConfig", "project_dir": str(tmp_path), "foo": "bar"}
+        config_data = {
+            "_type": "UnknownConfig",
+            "project_dir": str(tmp_path),
+            "foo": "bar",
+        }
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config_data))
 

--- a/tests/test_electrode_overlay.py
+++ b/tests/test_electrode_overlay.py
@@ -264,9 +264,7 @@ def test_label_montage_resolves_from_eeg_positions_csv(tmp_path, monkeypatch):
         )
     )
 
-    assert simulation_config_has_xyz_electrodes(
-        config_path, eeg_positions_dir=eeg_dir
-    )
+    assert simulation_config_has_xyz_electrodes(config_path, eeg_positions_dir=eeg_dir)
     create_electrode_overlay_nifti(
         config_path,
         tmp_path / "reference.nii.gz",

--- a/tests/test_flex_manifest.py
+++ b/tests/test_flex_manifest.py
@@ -74,8 +74,12 @@ class TestSerializeROI:
 
     def test_serialize_roi_spherical_volumetric(self):
         roi = SphericalROI(
-            x=-24.0, y=-4.0, z=-20.0, radius=8.0,
-            volumetric=True, tissues="both",
+            x=-24.0,
+            y=-4.0,
+            z=-20.0,
+            radius=8.0,
+            volumetric=True,
+            tissues="both",
         )
         d = _serialize_roi(roi)
         assert d["type"] == "spherical"

--- a/tests/test_integration_flows.py
+++ b/tests/test_integration_flows.py
@@ -51,13 +51,10 @@ def test_dicom_archive_to_nifti_flow(tmp_project, monkeypatch):
     )
 
     assert (tmp_project / "sub-001" / "anat" / "sub-001_T1w.nii.gz").exists()
+    # Extraction is relative to the modality folder: an archive can sit
+    # directly in T1w/ with no dicom/ subfolder to extract into.
     assert (
-        modality_dir
-        / "dicom"
-        / "extracted_archives"
-        / "series.zip"
-        / "nested"
-        / "image001.dicom"
+        modality_dir / "extracted_archives" / "series.zip" / "nested" / "image001.dicom"
     ).exists()
 
 

--- a/tests/test_pre_dicom.py
+++ b/tests/test_pre_dicom.py
@@ -1,16 +1,25 @@
-"""Tests for tit.pre.dicom2nifti — DICOM to NIfTI conversion."""
+"""Tests for tit.pre.dicom2nifti — source-image ingestion to BIDS NIfTI."""
 
+import gzip
+import os
 import tarfile
 import zipfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tit.pre.dicom2nifti import (
-    _convert_modality,
+    MODALITIES,
+    _DICOM_SUFFIXES,
+    _NIFTI_SUFFIXES,
     _extract_archive,
-    _find_dicom_files,
-    _modality_dicom_dir,
+    _extract_archives,
+    _find_files,
+    _ingest_modality,
+    _iter_files,
+    _modality_source_dir,
+    _nifti_stem,
     run_dicom_to_nifti,
 )
 from tit.pre.utils import PreprocessError
@@ -18,60 +27,133 @@ from tit.pre.utils import PreprocessError
 MODULE = "tit.pre.dicom2nifti"
 
 
-class TestDicomDiscoveryAndArchives:
-    """Tests for recursive DICOM discovery and archive extraction."""
+def _eperm_stat(*bad_fragments):
+    """Return an ``os.stat`` replacement that raises EPERM for matching paths.
 
-    def test_finds_direct_dcm_and_dicom_files(self, tmp_path):
-        """Finds direct .dcm and .dicom files."""
-        dicom_dir = tmp_path / "dicom"
-        dicom_dir.mkdir()
-        dcm = dicom_dir / "scan.dcm"
-        dicom = dicom_dir / "scan2.dicom"
-        txt = dicom_dir / "notes.txt"
-        dcm.touch()
-        dicom.touch()
-        txt.touch()
+    Reproduces a macOS AppleDouble file on a Docker bind mount, where stat
+    fails with EPERM rather than the ENOENT that pathlib tolerates.
+    """
+    real_stat = os.stat
 
-        assert _find_dicom_files(dicom_dir) == [dcm, dicom]
+    def fake_stat(path, *args, **kwargs):
+        if any(fragment in str(path) for fragment in bad_fragments):
+            raise PermissionError(1, "Operation not permitted")
+        return real_stat(path, *args, **kwargs)
 
-    def test_finds_recursive_dicom_files(self, tmp_path):
-        """Finds DICOM files in nested folders."""
-        dicom_dir = tmp_path / "dicom"
-        nested = dicom_dir / "series" / "one"
+    return fake_stat
+
+
+class TestSafeScanning:
+    """Directory scanning must survive macOS/Docker junk files."""
+
+    def test_skips_dotfiles(self, tmp_path):
+        """Dotfiles are ignored: dcm2niix skips them and BIDS reserves them."""
+        (tmp_path / "scan.dcm").touch()
+        (tmp_path / ".DS_Store").touch()
+        (tmp_path / "._.DS_Store").touch()
+        (tmp_path / "._scan.dcm").touch()
+
+        assert [p.name for p in _iter_files(tmp_path)] == ["scan.dcm"]
+
+    def test_skips_dot_directories(self, tmp_path):
+        """Dot-directories are not descended into."""
+        hidden = tmp_path / ".AppleDouble"
+        hidden.mkdir()
+        (hidden / "scan.dcm").touch()
+        (tmp_path / "real.dcm").touch()
+
+        assert [p.name for p in _iter_files(tmp_path)] == ["real.dcm"]
+
+    def test_appledouble_eperm_does_not_abort_scan(self, tmp_path):
+        """Regression: '._.DS_Store' whose stat raises EPERM must not crash.
+
+        Python 3.11's Path.is_file() only swallows ENOENT/ENOTDIR/EBADF/ELOOP,
+        so EPERM propagated and aborted DICOM conversion entirely.
+        """
+        (tmp_path / "scan.dcm").touch()
+        (tmp_path / "._.DS_Store").touch()
+
+        with patch("os.stat", _eperm_stat("._")):
+            found = _find_files(tmp_path, _DICOM_SUFFIXES)
+
+        assert [p.name for p in found] == ["scan.dcm"]
+
+    def test_unreadable_entry_is_skipped_not_fatal(self, tmp_path):
+        """A non-dot entry that cannot be stat'd is skipped, not raised.
+
+        Covers filesystems reporting DT_UNKNOWN, where scandir must fall back
+        to a real stat syscall.
+        """
+        (tmp_path / "scan.dcm").touch()
+
+        with patch(
+            f"{MODULE}.os.scandir",
+            return_value=[
+                MagicMock(
+                    name="x", **{"is_dir.side_effect": PermissionError(1, "nope")}
+                )
+            ],
+        ):
+            assert list(_iter_files(tmp_path)) == []
+
+    def test_unreadable_directory_is_skipped(self, tmp_path):
+        """An unreadable directory does not abort the whole scan."""
+        (tmp_path / "good.dcm").touch()
+
+        with patch(f"{MODULE}.os.scandir", side_effect=PermissionError(1, "nope")):
+            assert list(_iter_files(tmp_path)) == []
+
+    def test_finds_files_recursively(self, tmp_path):
+        """DICOMs nested in series folders are found."""
+        nested = tmp_path / "series" / "one"
         nested.mkdir(parents=True)
-        scan = nested / "scan.DICOM"
-        scan.touch()
+        (nested / "scan.DICOM").touch()
 
-        assert _find_dicom_files(dicom_dir) == [scan]
+        assert [p.name for p in _find_files(tmp_path, _DICOM_SUFFIXES)] == [
+            "scan.DICOM"
+        ]
+
+    def test_ignores_non_dicom_files(self, tmp_path):
+        """Only .dcm/.dicom count as DICOM input."""
+        (tmp_path / "scan.dcm").touch()
+        (tmp_path / "notes.txt").touch()
+
+        assert [p.name for p in _find_files(tmp_path, _DICOM_SUFFIXES)] == ["scan.dcm"]
+
+    def test_matches_double_extension_nifti(self, tmp_path):
+        """'.nii.gz' is two suffixes, so Path.suffix alone would miss it."""
+        (tmp_path / "scan.nii.gz").touch()
+        (tmp_path / "scan.nii").touch()
+        (tmp_path / "notes.txt").touch()
+
+        found = [p.name for p in _find_files(tmp_path, _NIFTI_SUFFIXES)]
+        assert sorted(found) == ["scan.nii", "scan.nii.gz"]
+
+
+class TestArchives:
+    """Archive extraction feeds DICOM discovery."""
 
     def test_extracts_zip_archive(self, tmp_path):
-        """Safely extracts zip archives for later discovery."""
         archive = tmp_path / "dicoms.zip"
         with zipfile.ZipFile(archive, "w") as zf:
             zf.writestr("nested/scan.dcm", "dicom")
 
-        destination = tmp_path / "dicom" / "extracted_archives" / archive.name
-        extracted = _extract_archive(archive, destination)
-
-        assert extracted == 1
+        destination = tmp_path / "extracted_archives" / archive.name
+        assert _extract_archive(archive, destination) == 1
         assert (destination / "nested" / "scan.dcm").read_text() == "dicom"
 
     def test_extracts_tgz_archive(self, tmp_path):
-        """Safely extracts tgz archives for later discovery."""
         source = tmp_path / "scan.dicom"
         source.write_text("dicom")
         archive = tmp_path / "dicoms.tgz"
         with tarfile.open(archive, "w:gz") as tf:
             tf.add(source, arcname="series/scan.dicom")
 
-        destination = tmp_path / "dicom" / "extracted_archives" / archive.name
-        extracted = _extract_archive(archive, destination)
-
-        assert extracted == 1
+        destination = tmp_path / "extracted_archives" / archive.name
+        assert _extract_archive(archive, destination) == 1
         assert (destination / "series" / "scan.dicom").read_text() == "dicom"
 
     def test_rejects_unsafe_zip_member(self, tmp_path):
-        """Rejects zip members that would escape the extraction directory."""
         archive = tmp_path / "bad.zip"
         with zipfile.ZipFile(archive, "w") as zf:
             zf.writestr("../escape.dcm", "bad")
@@ -79,234 +161,303 @@ class TestDicomDiscoveryAndArchives:
         with pytest.raises(PreprocessError, match="Unsafe archive member"):
             _extract_archive(archive, tmp_path / "dest")
 
+    def test_extracts_archive_before_conversion(self, tmp_path):
+        """Archives anywhere in the modality folder are extracted first."""
+        modality_dir = tmp_path / "T1w"
+        (modality_dir / "dicom").mkdir(parents=True)
+        archive = modality_dir / "dicoms.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("series/scan.dcm", "dicom")
 
-class TestModalityDicomDir:
-    """Tests for the _modality_dicom_dir helper."""
+        runner = MagicMock()
+        runner.run.return_value = 0
 
-    def test_exact_folder_name(self, tmp_path):
-        dicom_dir = tmp_path / "dwi" / "dicom"
-        dicom_dir.mkdir(parents=True)
+        with patch(f"{MODULE}._check_dcm2niix_outputs", return_value=True):
+            assert _ingest_modality(
+                modality_dir, tmp_path / "out", "001", "T1w", MagicMock(), runner
+            )
+        assert (
+            modality_dir / "extracted_archives" / "dicoms.zip" / "series" / "scan.dcm"
+        ).exists()
 
-        assert _modality_dicom_dir(tmp_path, "dwi") == dicom_dir
+    def test_does_not_re_extract_own_output(self, tmp_path):
+        """An archive inside extracted_archives/ must not be extracted again."""
+        modality_dir = tmp_path / "T1w"
+        nested = modality_dir / "extracted_archives" / "outer.zip"
+        nested.mkdir(parents=True)
+        with zipfile.ZipFile(nested / "inner.zip", "w") as zf:
+            zf.writestr("scan.dcm", "dicom")
 
-    def test_case_insensitive_folder_name(self, tmp_path):
-        """Users name the folder DWI as often as dwi."""
-        dicom_dir = tmp_path / "DWI" / "dicom"
-        dicom_dir.mkdir(parents=True)
+        _extract_archives(modality_dir, MagicMock())
 
-        # On case-insensitive filesystems the default path already matches,
-        # so only assert the resolved dir reaches the DICOMs.
-        result = _modality_dicom_dir(tmp_path, "dwi")
-        assert result.exists()
-        assert result.parent.name.lower() == "dwi"
+        assert not (nested / "extracted_archives").exists()
 
-    def test_missing_folder_returns_default(self, tmp_path):
-        assert _modality_dicom_dir(tmp_path, "dwi") == tmp_path / "dwi" / "dicom"
-
-
-class TestConvertModality:
-    """Tests for the _convert_modality helper."""
-
-    def test_no_dicom_files_returns_false(self, tmp_path):
-        """Returns False when no .dcm/.dicom files are present."""
-        dicom_dir = tmp_path / "T1w" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
+    def test_bad_archive_warns_and_continues(self, tmp_path):
+        """A corrupt archive is reported, not fatal."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "broken.zip").write_text("not a zip")
         logger = MagicMock()
 
-        result = _convert_modality(dicom_dir, out_dir, "001", "T1w", logger, None)
+        _extract_archives(modality_dir, logger)
 
-        assert result is False
-        logger.info.assert_any_call(
-            f"No .dcm or .dicom files found under {dicom_dir}; skipping conversion"
+        assert "Could not extract" in str(logger.warning.call_args)
+
+
+class TestModalitySourceDir:
+    """Modality folders are matched case-insensitively."""
+
+    def test_exact_folder_name(self, tmp_path):
+        (tmp_path / "dwi").mkdir()
+        assert _modality_source_dir(tmp_path, "dwi") == tmp_path / "dwi"
+
+    def test_case_insensitive_folder_name(self, tmp_path):
+        """Users name the folder CT as often as ct."""
+        (tmp_path / "CT").mkdir()
+        result = _modality_source_dir(tmp_path, "ct")
+        assert result.exists()
+        assert result.name.lower() == "ct"
+
+    def test_missing_folder_returns_default(self, tmp_path):
+        assert _modality_source_dir(tmp_path, "dwi") == tmp_path / "dwi"
+
+
+class TestNiftiPassthrough:
+    """A modality folder holding a NIfTI is copied, not converted."""
+
+    def test_copies_gzipped_nifti(self, tmp_path):
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.nii.gz").write_bytes(b"volume")
+        out_dir = tmp_path / "anat"
+
+        with patch(f"{MODULE}._run_dcm2niix") as mock_convert:
+            assert _ingest_modality(
+                modality_dir, out_dir, "001", "T1w", MagicMock(), None
+            )
+
+        mock_convert.assert_not_called()
+        assert (out_dir / "sub-001_T1w.nii.gz").read_bytes() == b"volume"
+
+    def test_compresses_bare_nifti(self, tmp_path):
+        """A bare .nii is gzipped on the way, so the output is always .nii.gz."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.nii").write_bytes(b"volume")
+        out_dir = tmp_path / "anat"
+
+        assert _ingest_modality(modality_dir, out_dir, "001", "T1w", MagicMock(), None)
+
+        assert (
+            gzip.decompress((out_dir / "sub-001_T1w.nii.gz").read_bytes()) == b"volume"
+        )
+
+    def test_copies_bval_bvec_sidecars(self, tmp_path):
+        """QSIPrep rejects a DWI without its .bval/.bvec pair."""
+        modality_dir = tmp_path / "dwi"
+        modality_dir.mkdir()
+        (modality_dir / "scan.nii.gz").write_bytes(b"volume")
+        (modality_dir / "scan.bval").write_text("0 1000")
+        (modality_dir / "scan.bvec").write_text("0 1")
+        (modality_dir / "scan.json").write_text("{}")
+        out_dir = tmp_path / "dwi_out"
+
+        assert _ingest_modality(modality_dir, out_dir, "001", "dwi", MagicMock(), None)
+
+        assert (out_dir / "sub-001_dwi.bval").read_text() == "0 1000"
+        assert (out_dir / "sub-001_dwi.bvec").read_text() == "0 1"
+        assert (out_dir / "sub-001_dwi.json").read_text() == "{}"
+
+    def test_dicom_wins_over_nifti(self, tmp_path):
+        """DICOMs carry the metadata, so a stray NIfTI must not shadow them."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
+        (modality_dir / "stray.nii.gz").write_bytes(b"volume")
+        out_dir = tmp_path / "anat"
+
+        with patch(f"{MODULE}._run_dcm2niix", return_value=True) as mock_convert:
+            assert _ingest_modality(
+                modality_dir, out_dir, "001", "T1w", MagicMock(), None
+            )
+
+        mock_convert.assert_called_once()
+        assert not (out_dir / "sub-001_T1w.nii.gz").exists()
+
+    def test_nifti_stem_strips_double_extension(self):
+        assert _nifti_stem(Path("scan.nii.gz")) == "scan"
+        assert _nifti_stem(Path("scan.nii")) == "scan"
+
+
+class TestIngestModality:
+    """Conversion behaviour for a single modality."""
+
+    def test_no_inputs_returns_false(self, tmp_path):
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+
+        assert not _ingest_modality(
+            modality_dir, tmp_path / "out", "001", "T1w", MagicMock(), None
         )
 
     def test_existing_output_raises(self, tmp_path):
-        """Raises PreprocessError when output already exists."""
-        dicom_dir = tmp_path / "T1w" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        (dicom_dir / "scan.dcm").touch()
-
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
         out_dir = tmp_path / "out"
         out_dir.mkdir()
         (out_dir / "sub-001_T1w.nii.gz").touch()
 
         with pytest.raises(PreprocessError, match="already exists"):
-            _convert_modality(dicom_dir, out_dir, "001", "T1w", MagicMock(), None)
+            _ingest_modality(modality_dir, out_dir, "001", "T1w", MagicMock(), None)
 
     @patch(f"{MODULE}.subprocess.run")
     def test_subprocess_success(self, mock_run, tmp_path):
-        """Returns True on successful subprocess conversion."""
-        dicom_dir = tmp_path / "T1w" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        (dicom_dir / "scan.dcm").touch()
-
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
-
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
         mock_run.return_value = MagicMock(returncode=0)
-        logger = MagicMock()
 
-        result = _convert_modality(dicom_dir, out_dir, "001", "T1w", logger, None)
-
-        assert result is True
+        with patch(f"{MODULE}._check_dcm2niix_outputs", return_value=True):
+            assert _ingest_modality(
+                modality_dir, tmp_path / "out", "001", "T1w", MagicMock(), None
+            )
         mock_run.assert_called_once()
 
     @patch(f"{MODULE}.subprocess.run")
     def test_subprocess_failure(self, mock_run, tmp_path):
-        """Returns False on subprocess failure."""
-        dicom_dir = tmp_path / "T1w" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        (dicom_dir / "scan.dcm").touch()
-
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
-
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
         mock_run.return_value = MagicMock(returncode=1)
-        logger = MagicMock()
 
-        result = _convert_modality(dicom_dir, out_dir, "001", "T1w", logger, None)
+        assert not _ingest_modality(
+            modality_dir, tmp_path / "out", "001", "T1w", MagicMock(), None
+        )
 
-        assert result is False
-
-    def test_with_runner_success(self, tmp_path):
-        """Uses runner when provided."""
-        dicom_dir = tmp_path / "T1w" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        (dicom_dir / "scan.dicom").touch()
-
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
-
+    def test_runner_command_shape(self, tmp_path):
+        """dcm2niix recursion is -d (max 9); -r would rename instead of convert."""
+        modality_dir = tmp_path / "dwi"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
+        out_dir = tmp_path / "sub-001" / "dwi"
         runner = MagicMock()
         runner.run.return_value = 0
-        logger = MagicMock()
 
-        result = _convert_modality(dicom_dir, out_dir, "001", "T1w", logger, runner)
+        with patch(f"{MODULE}._check_dcm2niix_outputs", return_value=True):
+            assert _ingest_modality(
+                modality_dir, out_dir, "001", "dwi", MagicMock(), runner
+            )
 
-        assert result is True
-        runner.run.assert_called_once()
         cmd = runner.run.call_args.args[0]
         assert "-r" not in cmd
-        assert cmd[cmd.index("-f") + 1] == "sub-001_T1w"
-
-    def test_with_runner_failure(self, tmp_path):
-        """Returns False on runner failure."""
-        dicom_dir = tmp_path / "T1w" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        (dicom_dir / "scan.dcm").touch()
-
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
-
-        runner = MagicMock()
-        runner.run.return_value = 1
-        logger = MagicMock()
-
-        result = _convert_modality(dicom_dir, out_dir, "001", "T1w", logger, runner)
-
-        assert result is False
-
-    def test_dwi_uses_bids_name_and_creates_output_dir(self, tmp_path):
-        """dcm2niix writes .bval/.bvec next to the NIfTI using the -f name,
-        so sub-{id}_dwi makes outputs match QSIPrep's *_dwi.nii*/.bval/.bvec globs."""
-        dicom_dir = tmp_path / "dwi" / "dicom"
-        dicom_dir.mkdir(parents=True)
-        (dicom_dir / "scan.dcm").touch()
-
-        out_dir = tmp_path / "sub-001" / "dwi"
-
-        runner = MagicMock()
-        runner.run.return_value = 0
-
-        result = _convert_modality(
-            dicom_dir, out_dir, "001", "dwi", MagicMock(), runner
-        )
-
-        assert result is True
-        assert out_dir.is_dir()
-        cmd = runner.run.call_args.args[0]
+        assert cmd[cmd.index("-d") + 1] == "9"
         assert cmd[cmd.index("-f") + 1] == "sub-001_dwi"
         assert cmd[cmd.index("-o") + 1] == str(out_dir)
+        assert cmd[-1] == str(modality_dir)
+        assert out_dir.is_dir()
 
-    def test_extracts_modality_archive_before_conversion(self, tmp_path):
-        """Archives in modality folders are extracted before conversion."""
+    def test_missing_expected_output_returns_false(self, tmp_path):
+        """A zero exit code with no matching NIfTI is still a failure."""
         modality_dir = tmp_path / "T1w"
-        dicom_dir = modality_dir / "dicom"
-        dicom_dir.mkdir(parents=True)
-        archive = modality_dir / "dicoms.zip"
-        with zipfile.ZipFile(archive, "w") as zf:
-            zf.writestr("series/scan.dcm", "dicom")
-
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
         runner = MagicMock()
         runner.run.return_value = 0
+        logger = MagicMock()
 
-        result = _convert_modality(
-            dicom_dir, out_dir, "001", "T1w", MagicMock(), runner
+        assert not _ingest_modality(
+            modality_dir, tmp_path / "out", "001", "T1w", logger, runner
         )
+        assert "produced no" in str(logger.warning.call_args)
 
-        assert result is True
-        assert (
-            dicom_dir / "extracted_archives" / "dicoms.zip" / "series" / "scan.dcm"
-        ).exists()
+    def test_extra_series_is_warned_about(self, tmp_path):
+        """dcm2niix appends a bare letter per extra series (sub-001_T1wa)."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
+        out_dir = tmp_path / "out"
+        logger = MagicMock()
+
+        def fake_run(cmd, logger=None):
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "sub-001_T1w.nii.gz").touch()
+            (out_dir / "sub-001_T1wa.nii.gz").touch()
+            return 0
+
+        runner = MagicMock()
+        runner.run.side_effect = fake_run
+
+        assert _ingest_modality(modality_dir, out_dir, "001", "T1w", logger, runner)
+        assert "sub-001_T1wa.nii.gz" in str(logger.warning.call_args)
 
 
 class TestRunDicomToNifti:
-    """Tests for run_dicom_to_nifti."""
+    """Top-level modality dispatch."""
 
-    @patch(f"{MODULE}.get_path_manager")
-    @patch(f"{MODULE}._convert_modality")
-    def test_converts_all_modalities(self, mock_convert, mock_gpm, tmp_path):
-        """Processes T1w, T2w, and dwi modalities."""
+    def _path_manager(self, tmp_path):
         pm = MagicMock()
         pm.sourcedata_subject.return_value = str(tmp_path / "sourcedata" / "sub-001")
-        pm.bids_anat.return_value = str(tmp_path / "sub-001" / "anat")
-        pm.bids_dwi.return_value = str(tmp_path / "sub-001" / "dwi")
-        mock_gpm.return_value = pm
-
-        mock_convert.return_value = True
-        logger = MagicMock()
-
-        run_dicom_to_nifti("/proj", "001", logger=logger)
-
-        assert mock_convert.call_count == 3
-        modalities = [call.args[3] for call in mock_convert.call_args_list]
-        assert modalities == ["T1w", "T2w", "dwi"]
+        pm.bids_datatype.side_effect = lambda sid, datatype: str(
+            tmp_path / f"sub-{sid}" / datatype
+        )
+        return pm
 
     @patch(f"{MODULE}.get_path_manager")
-    @patch(f"{MODULE}._convert_modality")
-    def test_dwi_converts_to_bids_dwi_dir(self, mock_convert, mock_gpm, tmp_path):
-        """DWI output goes to sub-{id}/dwi/ where QSIPrep expects it."""
-        pm = MagicMock()
+    @patch(f"{MODULE}._ingest_modality")
+    def test_converts_every_present_modality(self, mock_ingest, mock_gpm, tmp_path):
+        """T1w, T2w, ct and dwi are all ingested when present."""
         sourcedata = tmp_path / "sourcedata" / "sub-001"
-        (sourcedata / "dwi" / "dicom").mkdir(parents=True)
-        pm.sourcedata_subject.return_value = str(sourcedata)
-        pm.bids_anat.return_value = str(tmp_path / "sub-001" / "anat")
-        pm.bids_dwi.return_value = str(tmp_path / "sub-001" / "dwi")
-        mock_gpm.return_value = pm
-
-        mock_convert.return_value = True
+        for modality, _ in MODALITIES:
+            (sourcedata / modality).mkdir(parents=True)
+        mock_gpm.return_value = self._path_manager(tmp_path)
+        mock_ingest.return_value = True
 
         run_dicom_to_nifti("/proj", "001", logger=MagicMock())
 
-        dwi_call = mock_convert.call_args_list[2]
-        assert dwi_call.args[0] == sourcedata / "dwi" / "dicom"
-        assert dwi_call.args[1] == tmp_path / "sub-001" / "dwi"
+        assert [call.args[3] for call in mock_ingest.call_args_list] == [
+            "T1w",
+            "T2w",
+            "ct",
+            "dwi",
+        ]
 
     @patch(f"{MODULE}.get_path_manager")
-    @patch(f"{MODULE}._convert_modality")
-    def test_no_converted_warns(self, mock_convert, mock_gpm, tmp_path):
-        """Logs warning when no files converted."""
-        pm = MagicMock()
-        pm.sourcedata_subject.return_value = str(tmp_path / "sourcedata" / "sub-001")
-        pm.bids_anat.return_value = str(tmp_path / "sub-001" / "anat")
-        pm.bids_dwi.return_value = str(tmp_path / "sub-001" / "dwi")
-        mock_gpm.return_value = pm
+    @patch(f"{MODULE}._ingest_modality")
+    def test_skips_absent_modality_folders(self, mock_ingest, mock_gpm, tmp_path):
+        """A subject with only T1w must not trigger CT or DWI work."""
+        (tmp_path / "sourcedata" / "sub-001" / "T1w").mkdir(parents=True)
+        mock_gpm.return_value = self._path_manager(tmp_path)
+        mock_ingest.return_value = True
 
-        mock_convert.return_value = False
+        run_dicom_to_nifti("/proj", "001", logger=MagicMock())
+
+        assert [call.args[3] for call in mock_ingest.call_args_list] == ["T1w"]
+
+    @patch(f"{MODULE}.get_path_manager")
+    @patch(f"{MODULE}._ingest_modality")
+    def test_ct_goes_to_anat_and_dwi_to_dwi(self, mock_ingest, mock_gpm, tmp_path):
+        """CT is a local extension living in anat/; DWI goes where QSIPrep looks."""
+        sourcedata = tmp_path / "sourcedata" / "sub-001"
+        (sourcedata / "ct").mkdir(parents=True)
+        (sourcedata / "dwi").mkdir(parents=True)
+        mock_gpm.return_value = self._path_manager(tmp_path)
+        mock_ingest.return_value = True
+
+        run_dicom_to_nifti("/proj", "001", logger=MagicMock())
+
+        destinations = {
+            call.args[3]: call.args[1] for call in mock_ingest.call_args_list
+        }
+        assert destinations["ct"] == tmp_path / "sub-001" / "anat"
+        assert destinations["dwi"] == tmp_path / "sub-001" / "dwi"
+
+    @patch(f"{MODULE}.get_path_manager")
+    @patch(f"{MODULE}._ingest_modality")
+    def test_no_converted_warns(self, mock_ingest, mock_gpm, tmp_path):
+        (tmp_path / "sourcedata" / "sub-001" / "T1w").mkdir(parents=True)
+        mock_gpm.return_value = self._path_manager(tmp_path)
+        mock_ingest.return_value = False
         logger = MagicMock()
 
         run_dicom_to_nifti("/proj", "001", logger=logger)

--- a/tests/test_pre_dicom.py
+++ b/tests/test_pre_dicom.py
@@ -79,22 +79,40 @@ class TestSafeScanning:
         assert [p.name for p in found] == ["scan.dcm"]
 
     def test_unreadable_entry_is_skipped_not_fatal(self, tmp_path):
-        """A non-dot entry that cannot be stat'd is skipped, not raised.
+        """A non-dot entry whose is_dir/is_file raises is skipped, not fatal.
 
-        Covers filesystems reporting DT_UNKNOWN, where scandir must fall back
-        to a real stat syscall.
+        Covers filesystems reporting DT_UNKNOWN, where scandir cannot answer
+        from the directory entry and falls back to a real stat syscall.
         """
-        (tmp_path / "scan.dcm").touch()
 
-        with patch(
-            f"{MODULE}.os.scandir",
-            return_value=[
-                MagicMock(
-                    name="x", **{"is_dir.side_effect": PermissionError(1, "nope")}
-                )
-            ],
-        ):
-            assert list(_iter_files(tmp_path)) == []
+        class _Unreadable:
+            """A DirEntry whose type cannot be determined."""
+
+            name = "locked.dcm"
+            path = str(tmp_path / "locked.dcm")
+
+            def is_dir(self):
+                raise PermissionError(1, "Operation not permitted")
+
+            def is_file(self):
+                raise PermissionError(1, "Operation not permitted")
+
+        class _Readable:
+            name = "scan.dcm"
+            path = str(tmp_path / "scan.dcm")
+
+            def is_dir(self):
+                return False
+
+            def is_file(self):
+                return True
+
+        with patch(f"{MODULE}.os.scandir", return_value=[_Unreadable(), _Readable()]):
+            found = list(_iter_files(tmp_path))
+
+        # The unreadable entry is dropped, but the readable sibling survives:
+        # one bad entry must not cost us the rest of the directory.
+        assert [p.name for p in found] == ["scan.dcm"]
 
     def test_unreadable_directory_is_skipped(self, tmp_path):
         """An unreadable directory does not abort the whole scan."""
@@ -112,6 +130,36 @@ class TestSafeScanning:
         assert [p.name for p in _find_files(tmp_path, _DICOM_SUFFIXES)] == [
             "scan.DICOM"
         ]
+
+    def test_follows_symlinked_directory(self, tmp_path):
+        """Researchers point sourcedata at a shared DICOM store by symlink."""
+        store = tmp_path / "store"
+        store.mkdir()
+        (store / "scan.dcm").touch()
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "dicom").symlink_to(store, target_is_directory=True)
+
+        assert [p.name for p in _find_files(modality_dir, _DICOM_SUFFIXES)] == [
+            "scan.dcm"
+        ]
+
+    def test_symlink_cycle_yields_each_file_once(self, tmp_path):
+        """A cycle must not re-yield the same file over and over.
+
+        The kernel's ELOOP cap eventually stops the walk, but without a
+        visited set the same DICOM is reported ~40 times, inflating both the
+        'Found N DICOM file(s)' count and the work handed to dcm2niix.
+        """
+        dicom_dir = tmp_path / "T1w" / "dicom"
+        dicom_dir.mkdir(parents=True)
+        (dicom_dir / "scan.dcm").touch()
+        (dicom_dir / "loop").symlink_to("..", target_is_directory=True)
+
+        found = _find_files(tmp_path / "T1w", _DICOM_SUFFIXES)
+
+        assert len(found) == 1
+        assert found[0].name == "scan.dcm"
 
     def test_ignores_non_dicom_files(self, tmp_path):
         """Only .dcm/.dicom count as DICOM input."""
@@ -192,6 +240,47 @@ class TestArchives:
 
         assert not (nested / "extracted_archives").exists()
 
+    def test_same_named_archives_do_not_collide(self, tmp_path):
+        """Recursive search finds both; a shared destination would drop one."""
+        modality_dir = tmp_path / "T1w"
+        for series in ("series1", "series2"):
+            folder = modality_dir / series
+            folder.mkdir(parents=True)
+            with zipfile.ZipFile(folder / "data.zip", "w") as zf:
+                zf.writestr(f"{series}.dcm", "dicom")
+
+        _extract_archives(modality_dir, MagicMock())
+
+        found = {p.name for p in _find_files(modality_dir, _DICOM_SUFFIXES)}
+        assert found == {"series1.dcm", "series2.dcm"}
+
+    def test_ancestor_named_extracted_archives_is_not_skipped(self, tmp_path):
+        """The recursion guard is relative: an ancestor of that name is fine."""
+        modality_dir = tmp_path / "extracted_archives" / "proj" / "T1w"
+        modality_dir.mkdir(parents=True)
+        with zipfile.ZipFile(modality_dir / "series.zip", "w") as zf:
+            zf.writestr("scan.dcm", "dicom")
+
+        _extract_archives(modality_dir, MagicMock())
+
+        assert [p.name for p in _find_files(modality_dir, _DICOM_SUFFIXES)] == [
+            "scan.dcm"
+        ]
+
+    def test_reuses_previous_extraction(self, tmp_path):
+        """Re-running must not extract an archive a second time."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        with zipfile.ZipFile(modality_dir / "series.zip", "w") as zf:
+            zf.writestr("scan.dcm", "dicom")
+        logger = MagicMock()
+
+        _extract_archives(modality_dir, logger)
+        logger.reset_mock()
+        _extract_archives(modality_dir, logger)
+
+        assert "Using previously extracted" in str(logger.info.call_args)
+
     def test_bad_archive_warns_and_continues(self, tmp_path):
         """A corrupt archive is reported, not fatal."""
         modality_dir = tmp_path / "T1w"
@@ -220,6 +309,32 @@ class TestModalitySourceDir:
 
     def test_missing_folder_returns_default(self, tmp_path):
         assert _modality_source_dir(tmp_path, "dwi") == tmp_path / "dwi"
+
+    def test_populated_case_variant_beats_empty_scaffold(self, tmp_path):
+        """Regression: an empty scaffolded ct/ must not shadow the user's CT/.
+
+        ensure_subject_dirs pre-creates the canonical lowercase folder, so on
+        a case-sensitive filesystem the user's DICOMs were silently skipped.
+        Only meaningful where ct/ and CT/ are distinct -- the container is
+        Linux, but a macOS dev box is not.
+        """
+        (tmp_path / "ct").mkdir()
+        if (tmp_path / "CT").exists():
+            pytest.skip("case-insensitive filesystem: ct/ and CT/ are one folder")
+        user_dir = tmp_path / "CT" / "dicom"
+        user_dir.mkdir(parents=True)
+        (user_dir / "real.dcm").touch()
+
+        picked = _modality_source_dir(tmp_path, "ct")
+
+        assert list(_iter_files(picked)), f"{picked} holds no DICOMs"
+        assert picked.name == "CT"
+
+    def test_empty_folder_still_resolves(self, tmp_path):
+        """With nothing anywhere, the canonical folder is still returned."""
+        (tmp_path / "ct").mkdir()
+
+        assert _modality_source_dir(tmp_path, "ct") == tmp_path / "ct"
 
 
 class TestNiftiPassthrough:
@@ -284,6 +399,20 @@ class TestNiftiPassthrough:
         mock_convert.assert_called_once()
         assert not (out_dir / "sub-001_T1w.nii.gz").exists()
 
+    def test_bval_bvec_are_not_copied_for_anatomicals(self, tmp_path):
+        """A .bval beside a T1w is not valid BIDS in anat/."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.nii.gz").write_bytes(b"volume")
+        (modality_dir / "scan.bval").write_text("0 1000")
+        (modality_dir / "scan.json").write_text("{}")
+        out_dir = tmp_path / "anat"
+
+        assert _ingest_modality(modality_dir, out_dir, "001", "T1w", MagicMock(), None)
+
+        assert (out_dir / "sub-001_T1w.json").exists()
+        assert not (out_dir / "sub-001_T1w.bval").exists()
+
     def test_nifti_stem_strips_double_extension(self):
         assert _nifti_stem(Path("scan.nii.gz")) == "scan"
         assert _nifti_stem(Path("scan.nii")) == "scan"
@@ -310,6 +439,34 @@ class TestIngestModality:
 
         with pytest.raises(PreprocessError, match="already exists"):
             _ingest_modality(modality_dir, out_dir, "001", "T1w", MagicMock(), None)
+
+    def test_existing_uncompressed_output_raises(self, tmp_path):
+        """A hand-placed .nii counts too, or the subject gets the entity twice."""
+        modality_dir = tmp_path / "T1w"
+        modality_dir.mkdir()
+        (modality_dir / "scan.dcm").touch()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "sub-001_T1w.nii").touch()
+
+        with pytest.raises(PreprocessError, match="already exists"):
+            _ingest_modality(modality_dir, out_dir, "001", "T1w", MagicMock(), None)
+
+    def test_empty_folder_with_existing_output_is_skipped_not_fatal(self, tmp_path):
+        """Nothing to ingest is a skip, even when an output is already there.
+
+        An empty scaffolded ct/ folder must not abort a run that converts the
+        other modalities fine.
+        """
+        modality_dir = tmp_path / "ct"
+        modality_dir.mkdir()
+        out_dir = tmp_path / "anat"
+        out_dir.mkdir()
+        (out_dir / "sub-001_ct.nii.gz").touch()
+
+        assert not _ingest_modality(
+            modality_dir, out_dir, "001", "ct", MagicMock(), None
+        )
 
     @patch(f"{MODULE}.subprocess.run")
     def test_subprocess_success(self, mock_run, tmp_path):

--- a/tests/test_pre_pipeline.py
+++ b/tests/test_pre_pipeline.py
@@ -419,6 +419,20 @@ class TestRunPipelineReports:
     @patch(f"{STRUCTURAL}.ensure_dataset_descriptions")
     @patch(f"{STRUCTURAL}.ensure_subject_dirs")
     @patch(f"{STRUCTURAL}.get_path_manager")
+    def test_scaffolds_bidsignore_once_per_run(
+        self, mock_pm, mock_dirs, mock_datasets, mock_run_sub, _stub_bidsignore
+    ):
+        """CT output needs .bidsignore, so the pipeline must write it."""
+        from tit.pre import structural
+
+        run_pipeline(["001", "002"], convert_dicom=True, runner=_make_runner())
+
+        structural.ensure_bidsignore.assert_called_once()
+
+    @patch(f"{STRUCTURAL}._run_subject_pipeline")
+    @patch(f"{STRUCTURAL}.ensure_dataset_descriptions")
+    @patch(f"{STRUCTURAL}.ensure_subject_dirs")
+    @patch(f"{STRUCTURAL}.get_path_manager")
     def test_report_generated_for_each_subject(
         self, mock_pm, mock_dirs, mock_datasets, mock_run_sub, dummy_report
     ):

--- a/tests/test_pre_pipeline.py
+++ b/tests/test_pre_pipeline.py
@@ -34,6 +34,17 @@ STRUCTURAL = "tit.pre.structural"
 REPORTING = "tit.reporting"
 
 
+@pytest.fixture(autouse=True)
+def _stub_bidsignore():
+    """These tests mock the path manager, so the project root is not a real path.
+
+    ensure_bidsignore writes there for real; its own behaviour is covered by
+    TestEnsureBidsignore in test_pre_utils_full.py.
+    """
+    with patch(f"{STRUCTURAL}.ensure_bidsignore"):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_pre_utils_full.py
+++ b/tests/test_pre_utils_full.py
@@ -8,7 +8,9 @@ from unittest.mock import MagicMock, patch, mock_open
 
 import pytest
 
+from tit.pre.dicom2nifti import MODALITIES
 from tit.pre.utils import (
+    BIDSIGNORE_LINES,
     CommandRunner,
     PreprocessCancelled,
     PreprocessError,
@@ -17,6 +19,7 @@ from tit.pre.utils import (
     _terminate_process,
     build_logger,
     discover_subjects,
+    ensure_bidsignore,
     ensure_dataset_descriptions,
     ensure_subject_dirs,
 )
@@ -84,6 +87,50 @@ class TestFindAnatFiles:
         assert result_t2 is None
 
 
+class TestEnsureBidsignore:
+    """Tests for ensure_bidsignore."""
+
+    def test_creates_bidsignore(self, tmp_path):
+        """CT is not in BIDS, so the validator needs to be told to skip it."""
+        ensure_bidsignore(str(tmp_path))
+
+        content = (tmp_path / ".bidsignore").read_text()
+        assert "*_ct.nii.gz" in content
+        assert "*_ct.json" in content
+
+    def test_preserves_existing_user_lines(self, tmp_path):
+        """Users curate this file by hand; never clobber their rules."""
+        target = tmp_path / ".bidsignore"
+        target.write_text("my_custom_rule/\n")
+
+        ensure_bidsignore(str(tmp_path))
+
+        lines = target.read_text().splitlines()
+        assert lines[0] == "my_custom_rule/"
+        assert "*_ct.nii.gz" in lines
+
+    def test_is_idempotent(self, tmp_path):
+        """Re-running the pipeline must not append duplicate lines."""
+        ensure_bidsignore(str(tmp_path))
+        first = (tmp_path / ".bidsignore").read_text()
+        ensure_bidsignore(str(tmp_path))
+
+        assert (tmp_path / ".bidsignore").read_text() == first
+        assert first.count("*_ct.nii.gz") == 1
+
+    def test_adds_only_missing_lines(self, tmp_path):
+        """A partially present file gains just the lines it lacks."""
+        target = tmp_path / ".bidsignore"
+        target.write_text("*_ct.nii.gz\n")
+
+        ensure_bidsignore(str(tmp_path))
+
+        lines = target.read_text().splitlines()
+        assert lines.count("*_ct.nii.gz") == 1
+        assert "*_ct.json" in lines
+        assert set(BIDSIGNORE_LINES) <= set(lines)
+
+
 class TestEnsureSubjectDirs:
     """Tests for ensure_subject_dirs."""
 
@@ -98,9 +145,12 @@ class TestEnsureSubjectDirs:
 
         ensure_subject_dirs("/proj", "001")
 
-        assert (
-            pm.ensure.call_count == 5
-        )  # T1w dicom, T2w dicom, bids_anat, sub, ti-toolbox
+        # One sourcedata dicom dir per supported modality, plus bids_anat,
+        # sub and ti-toolbox.
+        assert pm.ensure.call_count == len(MODALITIES) + 3
+        assert [call.args[1] for call in pm.sourcedata_dicom.call_args_list] == [
+            modality for modality, _ in MODALITIES
+        ]
 
     @patch(f"{MODULE}.get_path_manager")
     def test_does_not_precreate_freesurfer_subject_dir(self, mock_gpm):

--- a/tests/test_stats_coverage.py
+++ b/tests/test_stats_coverage.py
@@ -62,7 +62,6 @@ from tit.stats.config import (  # noqa: E402
     CorrelationResult,
 )
 
-
 # ═══════════════════════════════════════════════════════════════════════════
 # reporting.py
 # ═══════════════════════════════════════════════════════════════════════════
@@ -269,8 +268,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            5.0, [], {}, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            5.0,
+            [],
+            {},
+            out,
         )
 
         text = open(out).read()
@@ -304,8 +310,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            5.0, clusters, {}, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            5.0,
+            clusters,
+            {},
+            out,
         )
 
         text = open(out).read()
@@ -327,8 +340,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            5.0, [], {}, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            5.0,
+            [],
+            {},
+            out,
             subject_ids=["001", "002", "003"],
         )
 
@@ -350,8 +370,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            5.0, [], {}, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            5.0,
+            [],
+            {},
+            out,
             subject_ids=["001", "002", "003"],
             weights=weights,
         )
@@ -379,8 +406,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            5.0, [], atlas_results, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            5.0,
+            [],
+            atlas_results,
+            out,
         )
 
         text = open(out).read()
@@ -401,8 +435,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            10.0, [], {}, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            10.0,
+            [],
+            {},
+            out,
         )
 
         text = open(out).read()
@@ -422,8 +463,15 @@ class TestGenerateCorrelationSummary:
         out = str(tmp_path / "corr_summary.txt")
 
         generate_correlation_summary(
-            cfg, subject_data, effect_sizes, r_values, sig_mask,
-            5.0, [], {}, out,
+            cfg,
+            subject_data,
+            effect_sizes,
+            r_values,
+            sig_mask,
+            5.0,
+            [],
+            {},
+            out,
         )
 
         text = open(out).read()
@@ -476,7 +524,8 @@ class TestPermutationEngineCorrectGroups:
         with patch("tit.stats.io_utils.save_permutation_details"):
             sig_mask, threshold, sig_clusters, null_dist, obs, corr_data = (
                 engine.correct_groups(
-                    resp, non_resp,
+                    resp,
+                    non_resp,
                     p_values=p_values,
                     t_statistics=t_statistics,
                     valid_mask=valid_mask,
@@ -505,7 +554,8 @@ class TestPermutationEngineCorrectGroups:
         with patch("tit.stats.io_utils.save_permutation_details"):
             sig_mask, threshold, sig_clusters, null_dist, obs, corr_data = (
                 engine.correct_groups(
-                    resp, non_resp,
+                    resp,
+                    non_resp,
                     p_values=p_values,
                     t_statistics=t_statistics,
                     valid_mask=valid_mask,
@@ -536,7 +586,8 @@ class TestPermutationEngineCorrectGroups:
         with patch("tit.stats.io_utils.save_permutation_details"):
             sig_mask, threshold, sig_clusters, null_dist, obs, corr_data = (
                 engine.correct_groups(
-                    resp, non_resp,
+                    resp,
+                    non_resp,
                     p_values=p_values,
                     t_statistics=t_statistics,
                     valid_mask=valid_mask,
@@ -569,7 +620,8 @@ class TestPermutationEngineCorrectGroups:
 
         with patch("tit.stats.io_utils.save_permutation_details"):
             result = engine.correct_groups(
-                resp, non_resp,
+                resp,
+                non_resp,
                 p_values=p_values,
                 t_statistics=t_statistics,
                 valid_mask=valid_mask,
@@ -595,7 +647,8 @@ class TestPermutationEngineCorrectGroups:
 
         with patch("tit.stats.io_utils.save_permutation_details") as mock_save:
             engine.correct_groups(
-                resp, non_resp,
+                resp,
+                non_resp,
                 p_values=p_values,
                 t_statistics=t_statistics,
                 valid_mask=valid_mask,
@@ -610,9 +663,7 @@ class TestPermutationEngineCorrectGroups:
     def test_correct_groups_mass_raises_without_t_stats(self):
         """cluster_stat='mass' raises ValueError if t_statistics is None."""
         resp, non_resp = self._make_data()
-        p_values, _, valid_mask = ttest_voxelwise(
-            resp, non_resp, test_type="unpaired"
-        )
+        p_values, _, valid_mask = ttest_voxelwise(resp, non_resp, test_type="unpaired")
 
         engine = PermutationEngine(
             cluster_threshold=0.05,
@@ -624,7 +675,8 @@ class TestPermutationEngineCorrectGroups:
 
         with pytest.raises(ValueError, match="t_statistics required"):
             engine.correct_groups(
-                resp, non_resp,
+                resp,
+                non_resp,
                 p_values=p_values,
                 t_statistics=None,
                 valid_mask=valid_mask,
@@ -673,7 +725,8 @@ class TestPermutationEngineCorrectCorrelation:
         )
 
         result = engine.correct_correlation(
-            subject_data, effect_sizes,
+            subject_data,
+            effect_sizes,
             r_values=r_values,
             t_statistics=t_statistics,
             p_values=p_values,
@@ -702,7 +755,8 @@ class TestPermutationEngineCorrectCorrelation:
 
         sig_mask, threshold, sig_clusters, null_dist, obs, corr_data = (
             engine.correct_correlation(
-                subject_data, effect_sizes,
+                subject_data,
+                effect_sizes,
                 r_values=r_values,
                 t_statistics=t_statistics,
                 p_values=p_values,
@@ -732,7 +786,8 @@ class TestPermutationEngineCorrectCorrelation:
         )
 
         result = engine.correct_correlation(
-            subject_data, effect_sizes,
+            subject_data,
+            effect_sizes,
             r_values=r_values,
             t_statistics=t_statistics,
             p_values=p_values,
@@ -760,7 +815,8 @@ class TestPermutationEngineCorrectCorrelation:
         )
 
         result = engine.correct_correlation(
-            subject_data, effect_sizes,
+            subject_data,
+            effect_sizes,
             r_values=r_values,
             t_statistics=t_statistics,
             p_values=p_values,
@@ -788,7 +844,8 @@ class TestPermutationEngineCorrectCorrelation:
         )
 
         result = engine.correct_correlation(
-            subject_data, effect_sizes,
+            subject_data,
+            effect_sizes,
             r_values=r_values,
             t_statistics=t_statistics,
             p_values=p_values,
@@ -817,7 +874,8 @@ class TestPermutationEngineCorrectCorrelation:
         )
 
         result = engine.correct_correlation(
-            subject_data, effect_sizes,
+            subject_data,
+            effect_sizes,
             r_values=r_values,
             t_statistics=t_statistics,
             p_values=p_values,
@@ -860,7 +918,12 @@ class TestRunSingleCorrelationPermutation:
         """Without return_indices, returns 3-tuple."""
         vd, es, vc, vm, shape = self._make_inputs()
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             correlation_type="pearson",
             seed=42,
             return_indices=False,
@@ -871,7 +934,12 @@ class TestRunSingleCorrelationPermutation:
         """With return_indices=True, returns 4-tuple."""
         vd, es, vc, vm, shape = self._make_inputs()
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             correlation_type="pearson",
             seed=42,
             return_indices=True,
@@ -899,7 +967,12 @@ class TestRunSingleCorrelationPermutation:
         """Spearman type executes without error."""
         vd, es, vc, vm, shape = self._make_inputs()
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             correlation_type="spearman",
             seed=42,
         )
@@ -910,7 +983,12 @@ class TestRunSingleCorrelationPermutation:
         vd, es, vc, vm, shape = self._make_inputs()
         weights = np.ones(len(es))
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             correlation_type="pearson",
             weights=weights,
             seed=42,
@@ -921,7 +999,12 @@ class TestRunSingleCorrelationPermutation:
         """cluster_stat='mass' uses mass-based max stat."""
         vd, es, vc, vm, shape = self._make_inputs()
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             cluster_stat="mass",
             seed=42,
         )
@@ -931,7 +1014,12 @@ class TestRunSingleCorrelationPermutation:
         """'greater' alternative path executes."""
         vd, es, vc, vm, shape = self._make_inputs()
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             alternative="greater",
             seed=42,
         )
@@ -941,7 +1029,12 @@ class TestRunSingleCorrelationPermutation:
         """'less' alternative path executes."""
         vd, es, vc, vm, shape = self._make_inputs()
         result = _run_single_correlation_permutation(
-            vd, es, vc, 0.05, vm, shape,
+            vd,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             alternative="less",
             seed=42,
         )
@@ -952,9 +1045,15 @@ class TestRunSingleCorrelationPermutation:
         vd, es, vc, vm, shape = self._make_inputs()
         # Pre-rank the voxel data
         from scipy.stats import rankdata
+
         vd_ranked = np.apply_along_axis(rankdata, 1, vd)
         result = _run_single_correlation_permutation(
-            vd_ranked, es, vc, 0.05, vm, shape,
+            vd_ranked,
+            es,
+            vc,
+            0.05,
+            vm,
+            shape,
             correlation_type="spearman",
             voxel_data_preranked=True,
             seed=42,
@@ -1028,8 +1127,10 @@ class TestLoadSubjectNiftiTiToolbox:
         mock_img = MagicMock()
         mock_img.get_fdata.return_value = np.random.rand(3, 3, 3).astype(np.float32)
 
-        with patch("tit.stats.nifti.get_path_manager", return_value=mock_pm), \
-             patch("tit.stats.nifti.nib.load", return_value=mock_img):
+        with (
+            patch("tit.stats.nifti.get_path_manager", return_value=mock_pm),
+            patch("tit.stats.nifti.nib.load", return_value=mock_img),
+        ):
             from tit.stats.nifti import load_subject_nifti_ti_toolbox
 
             data, img, fpath = load_subject_nifti_ti_toolbox("001", "my_sim")
@@ -1078,8 +1179,10 @@ class TestLoadSubjectNiftiTiToolbox:
         # Return 4D data
         mock_img.get_fdata.return_value = np.random.rand(3, 3, 3, 1).astype(np.float32)
 
-        with patch("tit.stats.nifti.get_path_manager", return_value=mock_pm), \
-             patch("tit.stats.nifti.nib.load", return_value=mock_img):
+        with (
+            patch("tit.stats.nifti.get_path_manager", return_value=mock_pm),
+            patch("tit.stats.nifti.nib.load", return_value=mock_img),
+        ):
             from tit.stats.nifti import load_subject_nifti_ti_toolbox
 
             data, img, fpath = load_subject_nifti_ti_toolbox("001", "my_sim")
@@ -1099,12 +1202,15 @@ class TestLoadSubjectNiftiTiToolbox:
         mock_img = MagicMock()
         mock_img.get_fdata.return_value = np.random.rand(3, 3, 3).astype(np.float32)
 
-        with patch("tit.stats.nifti.get_path_manager", return_value=mock_pm), \
-             patch("tit.stats.nifti.nib.load", return_value=mock_img):
+        with (
+            patch("tit.stats.nifti.get_path_manager", return_value=mock_pm),
+            patch("tit.stats.nifti.nib.load", return_value=mock_img),
+        ):
             from tit.stats.nifti import load_subject_nifti_ti_toolbox
 
             data, img, fpath = load_subject_nifti_ti_toolbox(
-                "001", "my_sim",
+                "001",
+                "my_sim",
                 nifti_file_pattern="custom_{subject_id}_{simulation_name}.nii.gz",
             )
 
@@ -1121,7 +1227,9 @@ class TestLoadGroupDataTiToolbox:
 
         data_shape = (3, 3, 3)
 
-        def mock_load_subject(subject_id, simulation_name, nifti_file_pattern, dtype=np.float32):
+        def mock_load_subject(
+            subject_id, simulation_name, nifti_file_pattern, dtype=np.float32
+        ):
             data = np.random.rand(*data_shape).astype(dtype)
             mock_img = MagicMock()
             mock_img.affine = np.eye(4)
@@ -1134,8 +1242,13 @@ class TestLoadGroupDataTiToolbox:
             {"subject_id": "002", "simulation_name": "sim2"},
         ]
 
-        with patch("tit.stats.nifti.load_subject_nifti_ti_toolbox", side_effect=mock_load_subject), \
-             patch("tit.stats.nifti.nib.Nifti1Image") as mock_nifti_cls:
+        with (
+            patch(
+                "tit.stats.nifti.load_subject_nifti_ti_toolbox",
+                side_effect=mock_load_subject,
+            ),
+            patch("tit.stats.nifti.nib.Nifti1Image") as mock_nifti_cls,
+        ):
             mock_nifti_cls.return_value = MagicMock()
             from tit.stats.nifti import load_group_data_ti_toolbox
 
@@ -1174,10 +1287,14 @@ class TestLoadGroupedSubjectsTiToolbox:
             {"subject_id": "003", "simulation_name": "sim3", "group": "non_responders"},
         ]
 
-        with patch("tit.stats.nifti.load_group_data_ti_toolbox", side_effect=mock_load_group):
+        with patch(
+            "tit.stats.nifti.load_group_data_ti_toolbox", side_effect=mock_load_group
+        ):
             from tit.stats.nifti import load_grouped_subjects_ti_toolbox
 
-            groups_data, template_img, groups_ids = load_grouped_subjects_ti_toolbox(configs)
+            groups_data, template_img, groups_ids = load_grouped_subjects_ti_toolbox(
+                configs
+            )
 
         assert "responders" in groups_data
         assert "non_responders" in groups_data
@@ -1201,7 +1318,9 @@ class TestLoadGroupedSubjectsTiToolbox:
             {"subject_id": "002", "simulation_name": "sim2"},
         ]
 
-        with patch("tit.stats.nifti.load_group_data_ti_toolbox", side_effect=mock_load_group):
+        with patch(
+            "tit.stats.nifti.load_group_data_ti_toolbox", side_effect=mock_load_group
+        ):
             from tit.stats.nifti import load_grouped_subjects_ti_toolbox
 
             groups_data, _, groups_ids = load_grouped_subjects_ti_toolbox(configs)
@@ -1256,9 +1375,7 @@ class TestPermutationHelpers:
 
         from tit.stats.permutation import _resolve_output_dir
 
-        output_dir = _resolve_output_dir(
-            "group_comparison", "my_analysis"
-        )
+        output_dir = _resolve_output_dir("group_comparison", "my_analysis")
 
         assert os.path.isdir(output_dir)
         assert "my_analysis" in output_dir
@@ -1273,8 +1390,10 @@ class TestPermutationHelpers:
         mock_template.header = MagicMock()
         out_path = str(tmp_path / "test.nii.gz")
 
-        with patch("tit.stats.permutation.nib.Nifti1Image") as mock_cls, \
-             patch("tit.stats.permutation.nib.save") as mock_save:
+        with (
+            patch("tit.stats.permutation.nib.Nifti1Image") as mock_cls,
+            patch("tit.stats.permutation.nib.save") as mock_save,
+        ):
             _save_nifti(data, mock_template, out_path)
 
             mock_cls.assert_called_once()
@@ -1325,13 +1444,15 @@ class TestRunGroupComparison:
         mock_template.affine = np.eye(4)
         mock_template.header = MagicMock()
 
-        with patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load, \
-             patch("tit.stats.permutation._save_nifti") as mock_save_nifti, \
-             patch("tit.stats.permutation.generate_summary") as mock_gen_summary, \
-             patch("tit.stats.permutation.plot_permutation_null_distribution"), \
-             patch("tit.stats.permutation.plot_cluster_size_mass_correlation"), \
-             patch("tit.stats.permutation.atlas_overlap_analysis", return_value={}), \
-             patch("nibabel.affines.apply_affine", side_effect=lambda a, c: c):
+        with (
+            patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load,
+            patch("tit.stats.permutation._save_nifti") as mock_save_nifti,
+            patch("tit.stats.permutation.generate_summary") as mock_gen_summary,
+            patch("tit.stats.permutation.plot_permutation_null_distribution"),
+            patch("tit.stats.permutation.plot_cluster_size_mass_correlation"),
+            patch("tit.stats.permutation.atlas_overlap_analysis", return_value={}),
+            patch("nibabel.affines.apply_affine", side_effect=lambda a, c: c),
+        ):
 
             mock_load.side_effect = [
                 (resp_data, mock_template, ["001", "002", "003"]),
@@ -1361,8 +1482,16 @@ class TestRunGroupComparison:
 
         with patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load:
             mock_load.side_effect = [
-                (np.random.rand(*shape, 3).astype(np.float32), mock_template, ["001", "002", "003"]),
-                (np.random.rand(*shape, 3).astype(np.float32), mock_template, ["004", "005", "006"]),
+                (
+                    np.random.rand(*shape, 3).astype(np.float32),
+                    mock_template,
+                    ["001", "002", "003"],
+                ),
+                (
+                    np.random.rand(*shape, 3).astype(np.float32),
+                    mock_template,
+                    ["004", "005", "006"],
+                ),
             ]
 
             from tit.stats.permutation import run_group_comparison
@@ -1417,14 +1546,16 @@ class TestRunCorrelation:
 
         # Mock scipy_label used in permutation.py for cluster annotation
         mock_labeled = np.zeros(shape, dtype=int)
-        with patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load, \
-             patch("tit.stats.permutation._save_nifti"), \
-             patch("tit.stats.permutation.generate_correlation_summary"), \
-             patch("tit.stats.permutation.plot_permutation_null_distribution"), \
-             patch("tit.stats.permutation.plot_cluster_size_mass_correlation"), \
-             patch("tit.stats.permutation.atlas_overlap_analysis", return_value={}), \
-             patch("nibabel.affines.apply_affine", side_effect=lambda a, c: c), \
-             patch("scipy.ndimage.label", return_value=(mock_labeled, 0)):
+        with (
+            patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load,
+            patch("tit.stats.permutation._save_nifti"),
+            patch("tit.stats.permutation.generate_correlation_summary"),
+            patch("tit.stats.permutation.plot_permutation_null_distribution"),
+            patch("tit.stats.permutation.plot_cluster_size_mass_correlation"),
+            patch("tit.stats.permutation.atlas_overlap_analysis", return_value={}),
+            patch("nibabel.affines.apply_affine", side_effect=lambda a, c: c),
+            patch("scipy.ndimage.label", return_value=(mock_labeled, 0)),
+        ):
 
             mock_load.return_value = (
                 subject_data,
@@ -1493,14 +1624,16 @@ class TestRunCorrelation:
         mock_template.header = MagicMock()
 
         mock_labeled = np.zeros(shape, dtype=int)
-        with patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load, \
-             patch("tit.stats.permutation._save_nifti"), \
-             patch("tit.stats.permutation.generate_correlation_summary"), \
-             patch("tit.stats.permutation.plot_permutation_null_distribution"), \
-             patch("tit.stats.permutation.plot_cluster_size_mass_correlation"), \
-             patch("tit.stats.permutation.atlas_overlap_analysis", return_value={}), \
-             patch("nibabel.affines.apply_affine", side_effect=lambda a, c: c), \
-             patch("scipy.ndimage.label", return_value=(mock_labeled, 0)):
+        with (
+            patch("tit.stats.permutation.load_group_data_ti_toolbox") as mock_load,
+            patch("tit.stats.permutation._save_nifti"),
+            patch("tit.stats.permutation.generate_correlation_summary"),
+            patch("tit.stats.permutation.plot_permutation_null_distribution"),
+            patch("tit.stats.permutation.plot_cluster_size_mass_correlation"),
+            patch("tit.stats.permutation.atlas_overlap_analysis", return_value={}),
+            patch("nibabel.affines.apply_affine", side_effect=lambda a, c: c),
+            patch("scipy.ndimage.label", return_value=(mock_labeled, 0)),
+        ):
 
             mock_load.return_value = (
                 subject_data,
@@ -1535,8 +1668,13 @@ class TestIdentifySignificantClustersCoverage:
         null = np.array([0.0, 1.0, 0.0, 0.0, 1.0])
 
         sig_mask, sig_clusters, observed = _identify_significant_clusters(
-            labeled, 1, t_stats, null, "size",
-            alpha=0.05, alternative="greater",
+            labeled,
+            1,
+            t_stats,
+            null,
+            "size",
+            alpha=0.05,
+            alternative="greater",
             _log=logging.getLogger("test"),
         )
 
@@ -1554,8 +1692,13 @@ class TestIdentifySignificantClustersCoverage:
         null = np.array([0.0, 0.5, 0.0, 0.3, 0.1])
 
         sig_mask, sig_clusters, observed = _identify_significant_clusters(
-            labeled, 1, t_stats, null, "mass",
-            alpha=0.05, alternative="less",
+            labeled,
+            1,
+            t_stats,
+            null,
+            "mass",
+            alpha=0.05,
+            alternative="less",
             _log=logging.getLogger("test"),
         )
 
@@ -1574,8 +1717,13 @@ class TestIdentifySignificantClustersCoverage:
         null = np.array([0.0, 0.0, 0.0])
 
         sig_mask, sig_clusters, observed = _identify_significant_clusters(
-            labeled, 15, t_stats, null, "size",
-            alpha=0.05, alternative="two-sided",
+            labeled,
+            15,
+            t_stats,
+            null,
+            "size",
+            alpha=0.05,
+            alternative="two-sided",
             _log=logging.getLogger("test"),
         )
 
@@ -1592,8 +1740,13 @@ class TestIdentifySignificantClustersCoverage:
         null = np.array([0.0])
 
         sig_mask, sig_clusters, observed = _identify_significant_clusters(
-            labeled, 2, t_stats, null, "size",
-            alpha=0.05, alternative="two-sided",
+            labeled,
+            2,
+            t_stats,
+            null,
+            "size",
+            alpha=0.05,
+            alternative="two-sided",
             _log=logging.getLogger("test"),
         )
 

--- a/tests/test_stats_main.py
+++ b/tests/test_stats_main.py
@@ -59,7 +59,6 @@ from tit.stats.__main__ import (  # noqa: E402
     main,
 )
 
-
 # ============================================================================
 # _nifti_pattern_for_tissue — WHITE and ALL branches
 # ============================================================================
@@ -156,8 +155,7 @@ class TestConfigTissueTypes:
             tissue_type=GroupComparisonConfig.TissueType.WHITE,
         )
         assert (
-            cfg.nifti_file_pattern
-            == "white_{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
+            cfg.nifti_file_pattern == "white_{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
         )
 
     def test_group_all_tissue_type(self):
@@ -166,9 +164,7 @@ class TestConfigTissueTypes:
             subjects=self._make_group_subjects(),
             tissue_type=GroupComparisonConfig.TissueType.ALL,
         )
-        assert (
-            cfg.nifti_file_pattern == "{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
-        )
+        assert cfg.nifti_file_pattern == "{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
 
     def test_corr_white_tissue_type(self):
         cfg = CorrelationConfig(
@@ -177,8 +173,7 @@ class TestConfigTissueTypes:
             tissue_type=CorrelationConfig.TissueType.WHITE,
         )
         assert (
-            cfg.nifti_file_pattern
-            == "white_{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
+            cfg.nifti_file_pattern == "white_{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
         )
 
     def test_corr_all_tissue_type(self):
@@ -187,9 +182,7 @@ class TestConfigTissueTypes:
             subjects=self._make_corr_subjects(),
             tissue_type=CorrelationConfig.TissueType.ALL,
         )
-        assert (
-            cfg.nifti_file_pattern == "{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
-        )
+        assert cfg.nifti_file_pattern == "{simulation_name}_TI_MNI_MNI_TI_max.nii.gz"
 
 
 # ============================================================================
@@ -292,9 +285,7 @@ class TestRunGroupComparison:
             call_args = mock_run.call_args
             config = call_args[0][0]
             assert config.test_type == GroupComparisonConfig.TestType.PAIRED
-            assert (
-                config.alternative == GroupComparisonConfig.Alternative.GREATER
-            )
+            assert config.alternative == GroupComparisonConfig.Alternative.GREATER
             assert config.cluster_stat == GroupComparisonConfig.ClusterStat.SIZE
             assert config.n_permutations == 500
             assert config.tissue_type == GroupComparisonConfig.TissueType.WHITE
@@ -359,10 +350,7 @@ class TestRunCorrelation:
             data["effect_metric"] = "Improvement Score"
             _run_correlation(data)
             config = mock_run.call_args[0][0]
-            assert (
-                config.correlation_type
-                == CorrelationConfig.CorrelationType.SPEARMAN
-            )
+            assert config.correlation_type == CorrelationConfig.CorrelationType.SPEARMAN
             assert config.cluster_stat == CorrelationConfig.ClusterStat.SIZE
             assert config.n_permutations == 200
             assert config.effect_metric == "Improvement Score"
@@ -372,9 +360,7 @@ class TestRunCorrelation:
     def test_run_correlation_negative_clusters(self, mock_sys):
         mock_result = MagicMock()
         mock_result.n_significant_clusters = -1
-        with patch(
-            "tit.stats.permutation.run_correlation", return_value=mock_result
-        ):
+        with patch("tit.stats.permutation.run_correlation", return_value=mock_result):
             data = self._make_data()
             _run_correlation(data)
             mock_sys.exit.assert_called_once_with(1)
@@ -493,9 +479,7 @@ class TestNiftiFileNotFound:
         pm = init_pm
 
         # Build the expected directory structure
-        sim_dir = os.path.join(
-            pm.simulation("001", "test_sim"), "TI", "niftis"
-        )
+        sim_dir = os.path.join(pm.simulation("001", "test_sim"), "TI", "niftis")
         os.makedirs(sim_dir, exist_ok=True)
 
         # Create some files in the directory so they show in the error
@@ -516,9 +500,7 @@ class TestNiftiFileNotFound:
         """Error message should include the names of files in the directory."""
         pm = init_pm
 
-        sim_dir = os.path.join(
-            pm.simulation("001", "test_sim"), "TI", "niftis"
-        )
+        sim_dir = os.path.join(pm.simulation("001", "test_sim"), "TI", "niftis")
         os.makedirs(sim_dir, exist_ok=True)
 
         # Create a known file
@@ -549,9 +531,7 @@ class TestNiftiFileNotFound:
         """When directory has >20 files, the error should show a truncation note."""
         pm = init_pm
 
-        sim_dir = os.path.join(
-            pm.simulation("001", "test_sim"), "TI", "niftis"
-        )
+        sim_dir = os.path.join(pm.simulation("001", "test_sim"), "TI", "niftis")
         os.makedirs(sim_dir, exist_ok=True)
 
         # Create 25 files so we exceed the 20-file preview limit
@@ -573,9 +553,7 @@ class TestNiftiFileNotFound:
         with an empty file list (covers lines 73-74)."""
         pm = init_pm
 
-        sim_dir = os.path.join(
-            pm.simulation("001", "test_sim"), "TI", "niftis"
-        )
+        sim_dir = os.path.join(pm.simulation("001", "test_sim"), "TI", "niftis")
         os.makedirs(sim_dir, exist_ok=True)
 
         from tit.stats.nifti import load_subject_nifti_ti_toolbox

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -391,7 +391,9 @@ class TestTrackOperation:
         assert len(payloads) == 2
         params_by_status = _operation_params_by_status(payloads)
         assert set(params_by_status) == {"start", "success"}
-        assert params_by_status["start"]["run_id"] == params_by_status["success"]["run_id"]
+        assert (
+            params_by_status["start"]["run_id"] == params_by_status["success"]["run_id"]
+        )
 
     def test_success_includes_duration(self, monkeypatch):
         self._force_enabled(monkeypatch)
@@ -434,7 +436,9 @@ class TestTrackOperation:
         _wait_for_telemetry_threads()
 
         params_by_status = _operation_params_by_status(payloads)
-        assert params_by_status["start"]["run_id"] == params_by_status["error"]["run_id"]
+        assert (
+            params_by_status["start"]["run_id"] == params_by_status["error"]["run_id"]
+        )
 
     def test_error_detail_strips_paths(self, monkeypatch):
         self._force_enabled(monkeypatch)

--- a/tit/gui/help_tab.py
+++ b/tit/gui/help_tab.py
@@ -110,7 +110,9 @@ Project Directory/
 │   │   ├── sub-{subject}_space-XXX_T1w.nii.gz
 │   │   ├── sub-{subject}_space-XXX_T1w.json
 │   │   ├── sub-{subject}_space-XXX_T2w.nii.gz
-│   │   └── sub-{subject}_space-XXX_T2w.json
+│   │   ├── sub-{subject}_space-XXX_T2w.json
+│   │   ├── sub-{subject}_ct.nii.gz         <i>(Optional: CT, see note below)</i>
+│   │   └── sub-{subject}_ct.json
 │   ├── dwi/                                <i>(Optional: For diffusion data)</i>
 │   ├── eeg/                                <i>(Optional: For EEG data)</i>
 │   ├── func/                               <i>(Optional: For functional MRI data)</i>
@@ -121,6 +123,10 @@ Project Directory/
 │       │   └── dicom/                      <i>(Place T1w DICOM files here)</i>
 │       ├── T2w/                            <i>(Optional)</i>
 │       │   └── dicom/                      <i>(Place T2w DICOM files here)</i>
+│       ├── ct/                             <i>(Optional)</i>
+│       │   └── dicom/                      <i>(Place CT DICOM files here)</i>
+│       ├── dwi/                            <i>(Optional)</i>
+│       │   └── dicom/                      <i>(Place DWI DICOM files here)</i>
 │       └── additional_files/               <i>(Optional documentation)</i>
 ├── derivatives/                            <i>(Auto-created during pre-processing)</i>
 │   ├── freesurfer/                         
@@ -155,6 +161,8 @@ Project Directory/
             <li>The <b>sourcedata</b> directory must be set up by the user before preprocessing</li>
             <li>DICOM files must be placed in <code>sourcedata/sub-{subject}/T1w/dicom/</code></li>
             <li>T2w images are optional but can improve head model quality</li>
+            <li>Supported modality folders are <b>T1w</b>, <b>T2w</b>, <b>ct</b> and <b>dwi</b>. Each is searched recursively for <code>.dcm</code>/<code>.dicom</code> files, and <code>.zip</code>/<code>.tar</code>/<code>.tar.gz</code>/<code>.tgz</code> archives are extracted first. A folder holding a <code>.nii</code>/<code>.nii.gz</code> instead is copied straight into place.</li>
+            <li><b>CT is not part of the BIDS standard</b> (BEP024 is still a draft), so it is written to <code>anat/sub-{subject}_ct.nii.gz</code> and listed in the project <code>.bidsignore</code> to keep the BIDS validator quiet.</li>
             <li>All other directories are automatically created during processing</li>
             <li>The <code>code/ti-toolbox</code> directory contains shared configuration files</li>
             <li>TI-Toolbox outputs are organized under <code>derivatives/tit/</code> with subdirectories for tissue analysis, logs, and reports</li>
@@ -166,7 +174,7 @@ Project Directory/
             <li>Create the sourcedata directory structure</li>
             <li>Create a subject folder in sourcedata (e.g., "sub-101")</li>
             <li>Place T1w DICOM files in <code>sourcedata/sub-101/T1w/dicom/</code></li>
-            <li>Optionally add T2w DICOM files in <code>sourcedata/sub-101/T2w/dicom/</code></li>
+            <li>Optionally add T2w, CT or DWI DICOM files in <code>sourcedata/sub-101/{T2w,ct,dwi}/dicom/</code></li>
             <li>Use the Pre-processing tab to begin processing</li>
         </ol>
 

--- a/tit/gui/pre_process_tab.py
+++ b/tit/gui/pre_process_tab.py
@@ -338,7 +338,8 @@ class PreProcessTab(QtWidgets.QWidget):
         # Reference to underlying console for backward compatibility
         self.output_text = self.console_widget.get_console_widget()
 
-        # Modalities are determined by the T1w/T2w sourcedata folder layout.
+        # Modalities are determined by the sourcedata folder layout; see
+        # tit.pre.dicom2nifti.MODALITIES for the supported set.
 
         # Update available subjects initially
         self.update_available_subjects()
@@ -374,9 +375,10 @@ class PreProcessTab(QtWidgets.QWidget):
                 "No Subjects Found",
                 "No subjects found in the project directory.\n\n"
                 "Please ensure your subjects follow this structure:\n"
-                f"  {os.path.join(self.project_dir, 'sourcedata', 'sub-{{subjectID}}', '{{T1w,T2w}}', 'dicom')}\n"
+                f"  {os.path.join(self.project_dir, 'sourcedata', 'sub-{{subjectID}}', '{{T1w,T2w,ct,dwi}}', 'dicom')}\n"
                 "with recursive .dcm/.dicom files, or .zip/.tar/.tar.gz/.tgz archives\n"
-                "placed in the modality folder or its dicom/ folder.",
+                "placed anywhere in the modality folder. A modality folder holding\n"
+                "a .nii/.nii.gz instead is copied straight into place.",
             )
 
     def set_processing_state(self, is_processing):
@@ -454,7 +456,9 @@ class PreProcessTab(QtWidgets.QWidget):
         dialog = QtWidgets.QMessageBox(self)
         dialog.setIcon(QtWidgets.QMessageBox.Warning)
         dialog.setWindowTitle("Missing Pre-processing Inputs")
-        dialog.setText("Some selected pre-processing steps are missing required inputs.")
+        dialog.setText(
+            "Some selected pre-processing steps are missing required inputs."
+        )
         dialog.setInformativeText(
             "Adjust the selected subjects, enable DICOM conversion, replace existing "
             "converted outputs, or add the expected T1w file before starting."

--- a/tit/paths.py
+++ b/tit/paths.py
@@ -334,13 +334,17 @@ class PathManager:
         """Path to ``<project>/sub-{sid}/`` (raw BIDS subject root)."""
         return os.path.join(self._root(), f"sub-{sid}")
 
+    def bids_datatype(self, sid: str, datatype: str) -> str:
+        """Path to ``<project>/sub-{sid}/{datatype}/`` for any BIDS datatype."""
+        return os.path.join(self.bids_subject(sid), datatype)
+
     def bids_anat(self, sid: str) -> str:
         """Path to ``<project>/sub-{sid}/anat/``."""
-        return os.path.join(self.bids_subject(sid), "anat")
+        return self.bids_datatype(sid, "anat")
 
     def bids_dwi(self, sid: str) -> str:
         """Path to ``<project>/sub-{sid}/dwi/``."""
-        return os.path.join(self.bids_subject(sid), "dwi")
+        return self.bids_datatype(sid, "dwi")
 
     def sourcedata_subject(self, sid: str) -> str:
         """Path to ``sourcedata/sub-{sid}/``."""

--- a/tit/pre/dicom2nifti.py
+++ b/tit/pre/dicom2nifti.py
@@ -1,67 +1,109 @@
 #!/usr/bin/env python
-"""
-DICOM-to-NIfTI conversion with BIDS-compliant naming.
+"""Source-image ingestion with BIDS-compliant naming.
 
-Wraps ``dcm2niix`` to convert DICOM series into NIfTI files that follow
-the BIDS naming convention (``sub-{id}_{modality}.nii.gz``).
+Converts each modality found under ``sourcedata/sub-{id}/`` into a
+BIDS-named NIfTI (``sub-{id}_{suffix}.nii.gz``). DICOM series are
+converted with ``dcm2niix``; a modality folder that already holds a
+NIfTI is copied into place instead.
 
 Public API
 ----------
 run_dicom_to_nifti
-    Convert DICOM files for a subject to BIDS-compliant NIfTI.
+    Ingest every supported modality for a subject.
+MODALITIES
+    Supported modalities and their BIDS datatype directories.
 
 See Also
 --------
 tit.pre.structural.run_pipeline : Full preprocessing pipeline.
 """
 
+import gzip
+import os
 import shutil
 import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
+from typing import Iterator
 
 from tit.paths import get_path_manager
 from .utils import CommandRunner, PreprocessError
 
 _ARCHIVE_SUFFIXES = (".zip", ".tar", ".tar.gz", ".tgz")
 _DICOM_SUFFIXES = (".dcm", ".dicom")
+_NIFTI_SUFFIXES = (".nii.gz", ".nii")
+_SIDECAR_SUFFIXES = (".json", ".bval", ".bvec")
 _EXTRACTED_ARCHIVES_DIR = "extracted_archives"
+
+# Source folder name (also the BIDS suffix) -> BIDS datatype directory.
+#
+# Single source of truth: tit.pre.preflight derives its rerun/cleanup list
+# from this table, so a modality only has to be added here.
+#
+# ``ct`` is a deliberate local extension. BIDS has no CT datatype and no CT
+# suffix -- BEP024 has been an unmerged draft since 2018 -- so no CT layout
+# validates today. We write anat/sub-{id}_ct.nii.gz because that matches both
+# BEP024's proposed suffix (making a future migration a directory move with no
+# rename) and the majority of published OpenNeuro datasets carrying a head CT.
+# tit.pre.utils.ensure_bidsignore keeps the validator quiet about it.
+MODALITIES: tuple[tuple[str, str], ...] = (
+    ("T1w", "anat"),
+    ("T2w", "anat"),
+    ("ct", "anat"),
+    ("dwi", "dwi"),
+)
+
+
+def _has_suffix(name: str, suffixes: tuple[str, ...]) -> bool:
+    """Return ``True`` when *name* ends with any of *suffixes* (case-insensitive)."""
+    lowered = name.lower()
+    return any(lowered.endswith(suffix) for suffix in suffixes)
+
+
+def _iter_files(directory: Path) -> Iterator[Path]:
+    """Yield regular files under *directory*, skipping dotfiles and unreadable entries.
+
+    Dotfiles are filtered by name *before* any ``stat`` call, which is what
+    makes this safe rather than merely tidy. macOS seeds bind mounts with
+    AppleDouble ``._*`` siblings whose ``stat`` raises ``EPERM`` inside Docker,
+    and Python 3.11's ``Path.is_file`` only swallows ENOENT/ENOTDIR/EBADF/ELOOP
+    -- ``EPERM`` propagates and aborts the whole scan. ``dcm2niix`` skips
+    dotfiles by the same rule, and BIDS reserves them for system use.
+
+    The ``OSError`` guards cover the rest: filesystems that report
+    ``DT_UNKNOWN`` make ``os.scandir`` fall back to a real ``stat`` syscall,
+    so an unreadable non-dot entry must not abort the scan either.
+    """
+    stack = [directory]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(os.scandir(current))
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.name.startswith("."):
+                continue
+            try:
+                if entry.is_dir():
+                    stack.append(Path(entry.path))
+                elif entry.is_file():
+                    yield Path(entry.path)
+            except OSError:
+                continue
+
+
+def _find_files(directory: Path, suffixes: tuple[str, ...]) -> list[Path]:
+    """Return sorted files under *directory* whose name ends with one of *suffixes*."""
+    return sorted(
+        path for path in _iter_files(directory) if _has_suffix(path.name, suffixes)
+    )
 
 
 def _is_archive(path: Path) -> bool:
     """Return ``True`` when *path* is a supported archive."""
-    name = path.name.lower()
-    return any(name.endswith(suffix) for suffix in _ARCHIVE_SUFFIXES)
-
-
-def _find_dicom_files(dicom_dir: Path) -> list[Path]:
-    """Return recursive ``.dcm`` and ``.dicom`` files under *dicom_dir*."""
-    if not dicom_dir.exists():
-        return []
-    return sorted(
-        path
-        for path in dicom_dir.rglob("*")
-        if path.is_file() and path.suffix.lower() in _DICOM_SUFFIXES
-    )
-
-
-def _find_archives(modality_dir: Path, dicom_dir: Path) -> list[Path]:
-    """Find supported archives directly in modality or modality/dicom folders."""
-    archives: list[Path] = []
-    for directory in (modality_dir, dicom_dir):
-        if not directory.exists():
-            continue
-        archives.extend(
-            path for path in directory.iterdir() if path.is_file() and _is_archive(path)
-        )
-    return sorted(set(archives))
-
-
-def _archive_extract_dir(dicom_dir: Path, archive: Path) -> Path:
-    """Return deterministic extraction directory for *archive*."""
-    safe_name = archive.name.replace("/", "_").replace("\\", "_")
-    return dicom_dir / _EXTRACTED_ARCHIVES_DIR / safe_name
+    return _has_suffix(path.name, _ARCHIVE_SUFFIXES)
 
 
 def _safe_target(base_dir: Path, member_name: str) -> Path:
@@ -122,12 +164,14 @@ def _extract_archive(archive: Path, destination: Path) -> int:
     return _extract_tar(archive, destination)
 
 
-def _prepare_dicom_inputs(modality_dir: Path, dicom_dir: Path, logger) -> list[Path]:
-    """Extract supported archives and return recursive DICOM files."""
-    archives = _find_archives(modality_dir, dicom_dir)
-    for archive in archives:
-        destination = _archive_extract_dir(dicom_dir, archive)
-        if destination.exists() and any(destination.iterdir()):
+def _extract_archives(modality_dir: Path, logger) -> None:
+    """Extract every archive under *modality_dir* into ``extracted_archives/``."""
+    for archive in _find_files(modality_dir, _ARCHIVE_SUFFIXES):
+        # Never re-extract our own output, or extraction would recurse.
+        if _EXTRACTED_ARCHIVES_DIR in archive.parts:
+            continue
+        destination = modality_dir / _EXTRACTED_ARCHIVES_DIR / archive.name
+        if destination.exists() and any(_iter_files(destination)):
             logger.info(f"Using previously extracted {archive.name} at {destination}")
             continue
         try:
@@ -139,61 +183,117 @@ def _prepare_dicom_inputs(modality_dir: Path, dicom_dir: Path, logger) -> list[P
             f"Extracted {extracted} file(s) from {archive.name} to {destination}"
         )
 
-    dicom_files = _find_dicom_files(dicom_dir)
-    if dicom_files:
-        logger.info(f"Found {len(dicom_files)} DICOM file(s) under {dicom_dir}")
-    else:
-        logger.info(
-            f"No .dcm or .dicom files found under {dicom_dir}; skipping conversion"
-        )
-    return dicom_files
 
+def _modality_source_dir(sourcedata_dir: Path, modality: str) -> Path:
+    """Return the source folder for *modality*, matching its name case-insensitively.
 
-def _modality_dicom_dir(sourcedata_dir: Path, modality: str) -> Path:
-    """Return the DICOM dir for *modality*, matching the folder name case-insensitively."""
-    default = sourcedata_dir / modality / "dicom"
+    Users name the folder ``CT`` as readily as ``ct``, and ``DWI`` as ``dwi``.
+    """
+    default = sourcedata_dir / modality
     if default.exists() or not sourcedata_dir.exists():
         return default
-    for child in sorted(sourcedata_dir.iterdir()):
-        if child.is_dir() and child.name.lower() == modality.lower():
-            return child / "dicom"
+    try:
+        entries = sorted(os.scandir(sourcedata_dir), key=lambda entry: entry.name)
+    except OSError:
+        return default
+    for entry in entries:
+        if entry.name.startswith(".") or entry.name.lower() != modality.lower():
+            continue
+        try:
+            if entry.is_dir():
+                return Path(entry.path)
+        except OSError:
+            continue
     return default
 
 
-def _convert_modality(
-    dicom_dir: Path,
+def _nifti_stem(path: Path) -> str:
+    """Return *path*'s name without its NIfTI extension (``.nii`` or ``.nii.gz``)."""
+    for suffix in _NIFTI_SUFFIXES:
+        if path.name.lower().endswith(suffix):
+            return path.name[: -len(suffix)]
+    return path.stem
+
+
+def _copy_sidecars(source: Path, output_dir: Path, bids_name: str, logger) -> None:
+    """Copy any ``.json``/``.bval``/``.bvec`` sitting beside *source*.
+
+    The ``.bval``/``.bvec`` pair is what makes a copied DWI usable: QSIPrep
+    rejects a diffusion series without them.
+    """
+    stem = _nifti_stem(source)
+    for suffix in _SIDECAR_SUFFIXES:
+        sidecar = source.with_name(f"{stem}{suffix}")
+        if not sidecar.exists():
+            continue
+        shutil.copyfile(sidecar, output_dir / f"{bids_name}{suffix}")
+        logger.info(f"Copied {sidecar.name} -> {bids_name}{suffix}")
+
+
+def _copy_nifti(source: Path, output_dir: Path, bids_name: str, logger) -> bool:
+    """Copy an existing NIfTI *source* into *output_dir* under its BIDS name."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / f"{bids_name}.nii.gz"
+    if source.name.lower().endswith(".gz"):
+        shutil.copyfile(source, target)
+    else:
+        # Compress with stdlib gzip: nibabel's gzip save is unreliable on
+        # Docker bind mounts, and this avoids loading the volume into memory.
+        with source.open("rb") as src, gzip.open(target, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+    logger.info(f"Copied {source.name} -> {target.name}")
+    _copy_sidecars(source, output_dir, bids_name, logger)
+    return True
+
+
+def _check_dcm2niix_outputs(output_dir: Path, bids_name: str, logger) -> bool:
+    """Confirm dcm2niix produced the expected NIfTI and flag extra series."""
+    produced = sorted(path.name for path in output_dir.glob(f"{bids_name}*"))
+    expected = f"{bids_name}.nii.gz"
+    if expected not in produced:
+        logger.warning(
+            f"dcm2niix produced no {expected} "
+            f"(found: {', '.join(produced) if produced else 'nothing'})"
+        )
+        return False
+    # dcm2niix appends a bare letter on name collisions (sub-01_T1wa.nii.gz),
+    # which is not a BIDS name and is ignored by every downstream step.
+    extra = [name for name in produced if not name.startswith(f"{bids_name}.")]
+    if extra:
+        logger.warning(
+            f"More than one series was present, so dcm2niix suffixed the extras: "
+            f"{', '.join(extra)}. Only {expected} is used downstream — keep one "
+            f"series per modality folder if that is not the one you want."
+        )
+    logger.info(f"Created {expected}")
+    return True
+
+
+def _run_dcm2niix(
+    input_dir: Path,
     output_dir: Path,
-    subject_id: str,
-    modality: str,
+    bids_name: str,
     logger,
     runner: CommandRunner | None,
 ) -> bool:
-    """Convert DICOM files for a single modality to BIDS location."""
-    modality_dir = dicom_dir.parent
-    dicom_files = _prepare_dicom_inputs(modality_dir, dicom_dir, logger)
-    if not dicom_files:
-        return False
-
-    bids_name = f"sub-{subject_id}_{modality}"
-    if (output_dir / f"{bids_name}.nii.gz").exists():
-        raise PreprocessError(
-            f"Output already exists for {bids_name}. "
-            "Remove the files manually before rerunning."
-        )
-
+    """Convert the DICOMs under *input_dir* into ``{bids_name}.nii.gz``."""
     output_dir.mkdir(parents=True, exist_ok=True)
-    logger.info(f"Converting {modality} DICOMs from {dicom_dir}")
+    logger.info(f"Converting DICOMs from {input_dir}")
     cmd = [
         "dcm2niix",
         "-z",
         "y",
         "-b",
         "y",
+        # Search depth: dcm2niix defaults to 5, which a deep archive layout can
+        # exceed. 9 is its maximum. It skips dotfiles on its own.
+        "-d",
+        "9",
         "-f",
         bids_name,
         "-o",
         str(output_dir),
-        str(dicom_dir),
+        str(input_dir),
     ]
 
     if runner:
@@ -203,11 +303,53 @@ def _convert_modality(
         exit_code = result.returncode
 
     if exit_code != 0:
-        logger.warning(f"dcm2niix failed for {modality}")
+        logger.warning(f"dcm2niix failed for {bids_name} (exit code {exit_code})")
         return False
 
-    logger.info(f"Created {bids_name}.nii.gz")
-    return True
+    return _check_dcm2niix_outputs(output_dir, bids_name, logger)
+
+
+def _ingest_modality(
+    modality_dir: Path,
+    output_dir: Path,
+    subject_id: str,
+    modality: str,
+    logger,
+    runner: CommandRunner | None,
+) -> bool:
+    """Ingest one modality folder into its BIDS destination.
+
+    DICOMs win when both are present: they carry the metadata dcm2niix needs
+    to write a full sidecar, so a stray NIfTI never shadows the real series.
+    """
+    bids_name = f"sub-{subject_id}_{modality}"
+    if (output_dir / f"{bids_name}.nii.gz").exists():
+        raise PreprocessError(
+            f"Output already exists for {bids_name}. "
+            "Remove the files manually before rerunning."
+        )
+
+    _extract_archives(modality_dir, logger)
+
+    dicom_files = _find_files(modality_dir, _DICOM_SUFFIXES)
+    if dicom_files:
+        logger.info(f"Found {len(dicom_files)} DICOM file(s) under {modality_dir}")
+        return _run_dcm2niix(modality_dir, output_dir, bids_name, logger, runner)
+
+    nifti_files = _find_files(modality_dir, _NIFTI_SUFFIXES)
+    if nifti_files:
+        if len(nifti_files) > 1:
+            logger.warning(
+                f"Found {len(nifti_files)} NIfTI files under {modality_dir}; "
+                f"using {nifti_files[0].name} and ignoring the rest."
+            )
+        return _copy_nifti(nifti_files[0], output_dir, bids_name, logger)
+
+    logger.info(
+        f"No DICOM (.dcm/.dicom) or NIfTI (.nii/.nii.gz) files found under "
+        f"{modality_dir}; skipping {modality}"
+    )
+    return False
 
 
 def run_dicom_to_nifti(
@@ -217,18 +359,23 @@ def run_dicom_to_nifti(
     logger,
     runner: CommandRunner | None = None,
 ) -> None:
-    """Convert DICOM files to BIDS-compliant NIfTI for a subject.
+    """Ingest a subject's source images into BIDS-named NIfTI files.
 
-    Looks for ``T1w``, ``T2w``, and ``dwi`` DICOM directories under
-    ``sourcedata/sub-{subject_id}/`` (modality folder names are matched
-    case-insensitively) and converts each found modality using
-    ``dcm2niix``. Anatomical images go to the subject ``anat/`` folder
-    and diffusion images to ``dwi/`` (with ``.bval``/``.bvec`` sidecars).
-    DICOM discovery is recursive under each modality's ``dicom/``
-    directory and includes ``.dcm`` and ``.dicom`` files. Supported
-    archives (``.zip``, ``.tar``, ``.tar.gz``, ``.tgz``) placed directly
-    in the modality folder or its ``dicom/`` folder are safely extracted
-    to ``dicom/extracted_archives/`` before discovery.
+    Looks for a ``T1w``, ``T2w``, ``ct``, and ``dwi`` folder under
+    ``sourcedata/sub-{subject_id}/`` (folder names are matched
+    case-insensitively) and ingests each one that exists. Anatomical images
+    and CT go to the subject's ``anat/`` folder, diffusion images to ``dwi/``
+    (with their ``.bval``/``.bvec`` sidecars).
+
+    Each modality folder is searched recursively. Supported archives
+    (``.zip``, ``.tar``, ``.tar.gz``, ``.tgz``) are safely extracted to
+    ``extracted_archives/`` first. DICOM files (``.dcm``/``.dicom``) are then
+    converted with ``dcm2niix``; if the folder holds no DICOMs but does hold a
+    NIfTI, that file is copied into place instead (compressing a bare ``.nii``
+    on the way). Dotfiles are ignored throughout.
+
+    CT is written as ``anat/sub-{id}_ct.nii.gz``. This is a local convention,
+    not BIDS -- see :data:`MODALITIES`.
 
     Parameters
     ----------
@@ -244,11 +391,12 @@ def run_dicom_to_nifti(
     Raises
     ------
     PreprocessError
-        If output NIfTI files already exist for a modality.
+        If an output NIfTI already exists for a modality.
 
     See Also
     --------
     run_pipeline : Full preprocessing pipeline.
+    MODALITIES : Supported modalities and their BIDS datatype directories.
     """
     from tit.telemetry import track_operation
     from tit import constants as _const
@@ -256,20 +404,17 @@ def run_dicom_to_nifti(
     with track_operation(_const.TELEMETRY_OP_PRE_DICOM):
         pm = get_path_manager(project_dir)
         sourcedata_dir = Path(pm.sourcedata_subject(subject_id))
-        bids_anat_dir = Path(pm.bids_anat(subject_id))
-        modality_targets = (
-            ("T1w", bids_anat_dir),
-            ("T2w", bids_anat_dir),
-            ("dwi", Path(pm.bids_dwi(subject_id))),
-        )
 
         converted = False
-        for modality, output_dir in modality_targets:
-            dicom_dir = _modality_dicom_dir(sourcedata_dir, modality)
-            if _convert_modality(
-                dicom_dir, output_dir, subject_id, modality, logger, runner
+        for modality, datatype in MODALITIES:
+            modality_dir = _modality_source_dir(sourcedata_dir, modality)
+            if not modality_dir.exists():
+                continue
+            output_dir = Path(pm.bids_datatype(subject_id, datatype))
+            if _ingest_modality(
+                modality_dir, output_dir, subject_id, modality, logger, runner
             ):
                 converted = True
 
         if not converted:
-            logger.warning("No DICOM files found or converted")
+            logger.warning("No DICOM or NIfTI files found or converted")

--- a/tit/pre/dicom2nifti.py
+++ b/tit/pre/dicom2nifti.py
@@ -74,10 +74,22 @@ def _iter_files(directory: Path) -> Iterator[Path]:
     The ``OSError`` guards cover the rest: filesystems that report
     ``DT_UNKNOWN`` make ``os.scandir`` fall back to a real ``stat`` syscall,
     so an unreadable non-dot entry must not abort the scan either.
+
+    Symlinked directories are followed -- researchers routinely point
+    sourcedata at a shared DICOM store -- but each real directory is visited
+    only once, so a cycle cannot yield the same file repeatedly.
     """
+    seen: set[Path] = set()
     stack = [directory]
     while stack:
         current = stack.pop()
+        try:
+            resolved = current.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
         try:
             entries = list(os.scandir(current))
         except OSError:
@@ -99,11 +111,6 @@ def _find_files(directory: Path, suffixes: tuple[str, ...]) -> list[Path]:
     return sorted(
         path for path in _iter_files(directory) if _has_suffix(path.name, suffixes)
     )
-
-
-def _is_archive(path: Path) -> bool:
-    """Return ``True`` when *path* is a supported archive."""
-    return _has_suffix(path.name, _ARCHIVE_SUFFIXES)
 
 
 def _safe_target(base_dir: Path, member_name: str) -> Path:
@@ -165,12 +172,23 @@ def _extract_archive(archive: Path, destination: Path) -> int:
 
 
 def _extract_archives(modality_dir: Path, logger) -> None:
-    """Extract every archive under *modality_dir* into ``extracted_archives/``."""
+    """Extract every archive under *modality_dir* beside itself.
+
+    Each archive extracts to ``<its own folder>/extracted_archives/<name>``
+    rather than to one shared folder, so two archives that happen to share a
+    basename (``series1/data.zip`` and ``series2/data.zip``) cannot collide.
+    """
     for archive in _find_files(modality_dir, _ARCHIVE_SUFFIXES):
-        # Never re-extract our own output, or extraction would recurse.
-        if _EXTRACTED_ARCHIVES_DIR in archive.parts:
+        # Never re-extract our own output, or extraction would recurse. The
+        # check is relative to modality_dir: an absolute path could otherwise
+        # contain an unrelated ancestor of that name.
+        try:
+            relative_parts = archive.relative_to(modality_dir).parts
+        except ValueError:
             continue
-        destination = modality_dir / _EXTRACTED_ARCHIVES_DIR / archive.name
+        if _EXTRACTED_ARCHIVES_DIR in relative_parts:
+            continue
+        destination = archive.parent / _EXTRACTED_ARCHIVES_DIR / archive.name
         if destination.exists() and any(_iter_files(destination)):
             logger.info(f"Using previously extracted {archive.name} at {destination}")
             continue
@@ -188,23 +206,27 @@ def _modality_source_dir(sourcedata_dir: Path, modality: str) -> Path:
     """Return the source folder for *modality*, matching its name case-insensitively.
 
     Users name the folder ``CT`` as readily as ``ct``, and ``DWI`` as ``dwi``.
+    A folder holding something wins over an empty one: on a case-sensitive
+    filesystem the empty ``ct/`` that :func:`tit.pre.utils.ensure_subject_dirs`
+    scaffolds would otherwise shadow the user's populated ``CT/``.
     """
-    default = sourcedata_dir / modality
-    if default.exists() or not sourcedata_dir.exists():
-        return default
+    candidates: list[Path] = []
     try:
         entries = sorted(os.scandir(sourcedata_dir), key=lambda entry: entry.name)
     except OSError:
-        return default
+        return sourcedata_dir / modality
     for entry in entries:
         if entry.name.startswith(".") or entry.name.lower() != modality.lower():
             continue
         try:
             if entry.is_dir():
-                return Path(entry.path)
+                candidates.append(Path(entry.path))
         except OSError:
             continue
-    return default
+    for candidate in candidates:
+        if any(_iter_files(candidate)):
+            return candidate
+    return candidates[0] if candidates else sourcedata_dir / modality
 
 
 def _nifti_stem(path: Path) -> str:
@@ -215,14 +237,18 @@ def _nifti_stem(path: Path) -> str:
     return path.stem
 
 
-def _copy_sidecars(source: Path, output_dir: Path, bids_name: str, logger) -> None:
-    """Copy any ``.json``/``.bval``/``.bvec`` sitting beside *source*.
+def _copy_sidecars(
+    source: Path, output_dir: Path, bids_name: str, modality: str, logger
+) -> None:
+    """Copy the sidecars sitting beside *source* under the BIDS name.
 
-    The ``.bval``/``.bvec`` pair is what makes a copied DWI usable: QSIPrep
-    rejects a diffusion series without them.
+    ``.bval``/``.bvec`` only travel with a diffusion series -- they are what
+    make a copied DWI usable, since QSIPrep rejects one without them, but they
+    are not valid BIDS beside an anatomical image.
     """
+    suffixes = _SIDECAR_SUFFIXES if modality == "dwi" else (".json",)
     stem = _nifti_stem(source)
-    for suffix in _SIDECAR_SUFFIXES:
+    for suffix in suffixes:
         sidecar = source.with_name(f"{stem}{suffix}")
         if not sidecar.exists():
             continue
@@ -230,7 +256,9 @@ def _copy_sidecars(source: Path, output_dir: Path, bids_name: str, logger) -> No
         logger.info(f"Copied {sidecar.name} -> {bids_name}{suffix}")
 
 
-def _copy_nifti(source: Path, output_dir: Path, bids_name: str, logger) -> bool:
+def _copy_nifti(
+    source: Path, output_dir: Path, bids_name: str, modality: str, logger
+) -> bool:
     """Copy an existing NIfTI *source* into *output_dir* under its BIDS name."""
     output_dir.mkdir(parents=True, exist_ok=True)
     target = output_dir / f"{bids_name}.nii.gz"
@@ -242,8 +270,23 @@ def _copy_nifti(source: Path, output_dir: Path, bids_name: str, logger) -> bool:
         with source.open("rb") as src, gzip.open(target, "wb") as dst:
             shutil.copyfileobj(src, dst)
     logger.info(f"Copied {source.name} -> {target.name}")
-    _copy_sidecars(source, output_dir, bids_name, logger)
+    _copy_sidecars(source, output_dir, bids_name, modality, logger)
     return True
+
+
+def _reject_existing_output(output_dir: Path, bids_name: str) -> None:
+    """Raise if *bids_name* has already been ingested.
+
+    Both extensions are checked: we always write ``.nii.gz``, but a
+    hand-placed ``.nii`` counts too, and leaving it would make the subject
+    carry the same BIDS entity twice.
+    """
+    for suffix in _NIFTI_SUFFIXES:
+        if (output_dir / f"{bids_name}{suffix}").exists():
+            raise PreprocessError(
+                f"Output already exists for {bids_name}{suffix}. "
+                "Remove the files manually before rerunning."
+            )
 
 
 def _check_dcm2niix_outputs(output_dir: Path, bids_name: str, logger) -> bool:
@@ -256,14 +299,17 @@ def _check_dcm2niix_outputs(output_dir: Path, bids_name: str, logger) -> bool:
             f"(found: {', '.join(produced) if produced else 'nothing'})"
         )
         return False
-    # dcm2niix appends a bare letter on name collisions (sub-01_T1wa.nii.gz),
-    # which is not a BIDS name and is ignored by every downstream step.
+    # dcm2niix writes extra files under names we did not ask for: a bare
+    # letter per colliding series (sub-01_T1wa.nii.gz), and a suffix per
+    # derived volume (_Tilt_1 for gantry tilt, _Eq_1 for resliced). None are
+    # BIDS names, so every downstream step ignores them.
     extra = [name for name in produced if not name.startswith(f"{bids_name}.")]
     if extra:
         logger.warning(
-            f"More than one series was present, so dcm2niix suffixed the extras: "
-            f"{', '.join(extra)}. Only {expected} is used downstream — keep one "
-            f"series per modality folder if that is not the one you want."
+            f"dcm2niix wrote files beyond {expected}: {', '.join(extra)}. These "
+            f"are extra series, or derived volumes such as _Tilt_1 (gantry tilt) "
+            f"and _Eq_1 (resliced). Only {expected} is used downstream — if one "
+            f"of the others is the volume you want, rename it by hand."
         )
     logger.info(f"Created {expected}")
     return True
@@ -323,27 +369,24 @@ def _ingest_modality(
     to write a full sidecar, so a stray NIfTI never shadows the real series.
     """
     bids_name = f"sub-{subject_id}_{modality}"
-    if (output_dir / f"{bids_name}.nii.gz").exists():
-        raise PreprocessError(
-            f"Output already exists for {bids_name}. "
-            "Remove the files manually before rerunning."
-        )
 
     _extract_archives(modality_dir, logger)
 
     dicom_files = _find_files(modality_dir, _DICOM_SUFFIXES)
     if dicom_files:
         logger.info(f"Found {len(dicom_files)} DICOM file(s) under {modality_dir}")
+        _reject_existing_output(output_dir, bids_name)
         return _run_dcm2niix(modality_dir, output_dir, bids_name, logger, runner)
 
     nifti_files = _find_files(modality_dir, _NIFTI_SUFFIXES)
     if nifti_files:
+        _reject_existing_output(output_dir, bids_name)
         if len(nifti_files) > 1:
             logger.warning(
                 f"Found {len(nifti_files)} NIfTI files under {modality_dir}; "
                 f"using {nifti_files[0].name} and ignoring the rest."
             )
-        return _copy_nifti(nifti_files[0], output_dir, bids_name, logger)
+        return _copy_nifti(nifti_files[0], output_dir, bids_name, modality, logger)
 
     logger.info(
         f"No DICOM (.dcm/.dicom) or NIfTI (.nii/.nii.gz) files found under "

--- a/tit/pre/preflight.py
+++ b/tit/pre/preflight.py
@@ -11,6 +11,7 @@ from typing import Iterable, Sequence
 from tit import constants as const
 from tit.paths import get_path_manager
 
+from .dicom2nifti import MODALITIES
 from .qsi.utils import validate_bids_dwi
 from .utils import _find_nifti
 
@@ -199,14 +200,9 @@ def _existing_bids_sidecars(output_dir: Path, bids_name: str) -> tuple[Path, ...
 
 def _dicom_outputs(project_dir: str, subject_id: str) -> list[PreprocessingOutput]:
     pm = get_path_manager(project_dir)
-    anat_dir = Path(pm.bids_anat(subject_id))
-    modality_dirs = (
-        ("T1w", anat_dir),
-        ("T2w", anat_dir),
-        ("dwi", Path(pm.bids_dwi(subject_id))),
-    )
     outputs: list[PreprocessingOutput] = []
-    for modality, output_dir in modality_dirs:
+    for modality, datatype in MODALITIES:
+        output_dir = Path(pm.bids_datatype(subject_id, datatype))
         bids_name = f"sub-{subject_id}_{modality}"
         cleanup_paths = _existing_bids_sidecars(output_dir, bids_name)
         if cleanup_paths:

--- a/tit/pre/structural.py
+++ b/tit/pre/structural.py
@@ -47,6 +47,7 @@ from .utils import (
     PreprocessCancelled,
     PreprocessError,
     build_logger,
+    ensure_bidsignore,
     ensure_dataset_descriptions,
     ensure_subject_dirs,
 )
@@ -531,6 +532,7 @@ def _run_pipeline_inner(
     if create_m2m:
         datasets.add("simnibs")
     ensure_dataset_descriptions(project_dir, datasets)
+    ensure_bidsignore(project_dir)
 
     if runner is None:
         runner = CommandRunner(stop_event=stop_event)

--- a/tit/pre/utils.py
+++ b/tit/pre/utils.py
@@ -45,6 +45,9 @@ BIDSIGNORE_LINES = (
     "# anat/ with a lowercase _ct suffix, matching BEP024's proposal.",
     "*_ct.nii.gz",
     "*_ct.json",
+    "# dcm2niix derivatives of a CT series, e.g. _Tilt_1 for gantry tilt.",
+    "*_ct_*.nii.gz",
+    "*_ct_*.json",
 )
 
 

--- a/tit/pre/utils.py
+++ b/tit/pre/utils.py
@@ -39,6 +39,14 @@ DATASET_TEMPLATES = {
     "ti-toolbox": "ti-toolbox.dataset_description.json",
 }
 
+BIDSIGNORE_LINES = (
+    "# CT is not part of the BIDS specification (BEP024 is still a draft),",
+    "# so the validator would reject these. TI-Toolbox writes CT to",
+    "# anat/ with a lowercase _ct suffix, matching BEP024's proposal.",
+    "*_ct.nii.gz",
+    "*_ct.json",
+)
+
 
 class PreprocessError(RuntimeError):
     """Raised when a preprocessing step fails.
@@ -213,13 +221,37 @@ def _find_nifti(directory: Path, stem: str) -> Path | None:
 
 
 def ensure_subject_dirs(project_dir: str, subject_id: str) -> None:
-    """Create the standard BIDS directory scaffold for a subject."""
+    """Create the standard BIDS directory scaffold for a subject.
+
+    Scaffolds a ``dicom/`` folder for every supported modality so the drop
+    location for each one is discoverable without reading the docs.
+    """
+    from .dicom2nifti import MODALITIES
+
     pm = get_path_manager(project_dir)
-    for modality in ("T1w", "T2w"):
+    for modality, _datatype in MODALITIES:
         pm.ensure(pm.sourcedata_dicom(subject_id, modality))
     pm.ensure(pm.bids_anat(subject_id))
     pm.ensure(pm.sub(subject_id))
     pm.ensure(pm.ti_toolbox())
+
+
+def ensure_bidsignore(project_dir: str) -> None:
+    """Create or extend the project's root ``.bidsignore``.
+
+    CT has no place in BIDS yet (BEP024 is still a draft), so
+    ``anat/sub-{id}_ct.nii.gz`` would otherwise raise a validator error.
+    Existing lines are preserved -- users curate this file by hand.
+    """
+    target = Path(project_dir) / ".bidsignore"
+    existing = (
+        target.read_text(encoding="utf-8").splitlines() if target.exists() else []
+    )
+    missing = [line for line in BIDSIGNORE_LINES if line not in existing]
+    if not missing:
+        return
+    lines = [*existing, *missing] if existing else list(BIDSIGNORE_LINES)
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _dataset_description_target(project_dir: str, dataset: str) -> Path:


### PR DESCRIPTION
## The bug

DICOM conversion aborted for any subject whose `sourcedata` tree had been touched by macOS:

```
PermissionError: [Errno 1] Operation not permitted:
  '/mnt/000_ieeg/sourcedata/sub-P076/T1w/._.DS_Store'
```

The scan called `Path.is_file()` on every directory entry. Python 3.11's pathlib only swallows `ENOENT/ENOTDIR/EBADF/ELOOP` (`_IGNORED_ERRNOS = (2, 20, 9, 40)`), so the `EPERM` that a bind-mounted AppleDouble file raises propagated and killed the run.

**This is why it looked fixed and wasn't.** Python 3.13+ broadened the ignored errnos, so it never reproduces on a modern host Python — only inside the container. Verified directly:

| | `Path.is_file()` on `._.DS_Store` (stat → EPERM) |
|---|---|
| Host Python 3.14 | returns `False` — swallowed |
| Container Python 3.11 | **raises `PermissionError`** |

An earlier fix (4fd87b5) tightened the *output* filenames but left both input scans exposed. Confirmed against the old code on 3.11 — note it fails in **both** scan functions, so fixing only the line in the traceback would have moved the crash one function down:

```
OLD _find_archives    RAISED: PermissionError [Errno 1] Operation not permitted
OLD _find_dicom_files RAISED: PermissionError [Errno 1] Operation not permitted
NEW archives -> []
NEW dicoms   -> ['scan.dcm']
```

## The fix

Scanning filters dotfiles **by name before any stat call**, then guards the remaining stat calls. This matches `dcm2niix`, which skips any name starting with `.` (`nii_dicom_batch.cpp:9802`), and BIDS, which reserves dotfiles for system use. The name filter is what makes it correct; the `OSError` guards cover filesystems reporting `DT_UNKNOWN`, where `scandir` falls back to a real stat.

## Streamlining T1w / T2w / ct / dwi

**CT support.** BIDS has no CT datatype and no CT suffix — BEP024 has been an unmerged draft since 2018 — so **no CT layout validates today**. CT is written to `anat/sub-{id}_ct.nii.gz`, which matches BEP024's proposed suffix (a future migration is a directory move with no rename) and 4 of the 5 OpenNeuro iEEG datasets that carry a head CT. A root `.bidsignore` keeps the validator quiet. `dcm2niix` tags the sidecar `"Modality": "CT"` on its own.

> Documented as a **local extension, not BIDS compliance** — that's the honest framing when no layout is valid.

**NIfTI passthrough.** A modality folder holding a `.nii`/`.nii.gz` instead of DICOMs is copied into place, gzipping a bare `.nii` via stdlib gzip (nibabel's gzip save is unreliable on Docker bind mounts) and carrying `.json`/`.bval`/`.bvec` across — the bval/bvec pair is what makes a copied DWI usable by QSIPrep. DICOMs win when both are present, since they carry the metadata for a full sidecar.

**One modality table.** `MODALITIES` now drives conversion, rerun/cleanup preflight, and directory scaffolding, replacing three separately-maintained lists.

**Other robustness:**
- Search is recursive over the whole modality folder, so archives no longer have to sit in a `dicom/` subfolder. Extraction is now relative to the modality folder (previously-extracted content under `dicom/extracted_archives/` is still found).
- `dcm2niix` is passed `-d 9` rather than relying on its default depth of 5. (Recursion is `-d`; `-r` means *rename instead of convert* — passing it would silently produce zero NIfTIs.)
- Conversion is verified afterwards: a zero exit code with no matching NIfTI is now a failure, and extra series — which dcm2niix names `sub-01_T1wa.nii.gz`, not a BIDS name — are reported instead of silently ignored.

DICOM detection still requires `.dcm`/`.dicom`, as requested.

## Testing

**Unit:** 33 tests in `test_pre_dicom.py`, including a regression test that mocks `os.stat` to raise EPERM on `._*`. Full suite green on host 3.14 and container 3.11 (1923 passed; the 3 `test_opt_flex` failures are pre-existing on `main`).

**End-to-end in `idossha/simnibs:v2.5.0`** (Python 3.11, dcm2niix v1.0.20211006) against real pydicom-generated series with `.DS_Store`/`._.DS_Store` seeded in every folder:

```
sourcedata/sub-P076/T1w/dicom/   real MR DICOMs + ._.DS_Store   (the reported failure)
sourcedata/sub-P076/T2w/         DICOMs inside a .zip
sourcedata/sub-P076/CT/dicom/    real CT DICOMs, uppercase folder, .dicom ext
sourcedata/sub-P076/dwi/         bare scan.nii + bval/bvec
                                    ↓
  PASS  sub-P076/anat/sub-P076_T1w.nii.gz shape=(16, 16, 4)
  PASS  sub-P076/anat/sub-P076_T2w.nii.gz shape=(16, 16, 4)
  PASS  sub-P076/anat/sub-P076_ct.nii.gz  shape=(16, 16, 4)
  PASS  sub-P076/dwi/sub-P076_dwi.nii.gz  shape=(8, 8, 8, 2)
  PASS  bval/bvec sidecars copied
  PASS  no dotfiles leaked into BIDS output
```

Every output loads through nibabel; CT sidecar reads `"Modality": "CT"`.