### PR TITLE
tests: fix stale flex-search mocks and stop MagicMock/ leaking into the repo

### DIFF
--- a/tests/test_opt_flex.py
+++ b/tests/test_opt_flex.py
@@ -52,13 +52,22 @@ class TestRunFlexSearch:
     @patch("tit.opt.flex.manifest.write_manifest")
     @patch("tit.opt.flex.utils.generate_label", return_value="test_label")
     @patch("tit.opt.flex.utils.generate_run_dirname", return_value="20260309_120000")
+    @patch("tit.opt.flex.flex.create_valid_skin_region_visualization")
     @patch("tit.opt.flex.flex.builder")
     @patch("tit.opt.flex.flex.get_path_manager")
     def test_single_run_success(
-        self, mock_gpm, mock_builder, mock_dirname, mock_label, mock_manifest, tmp_path
+        self,
+        mock_gpm,
+        mock_builder,
+        mock_skin_viz,
+        mock_dirname,
+        mock_label,
+        mock_manifest,
+        tmp_path,
     ):
         pm = MagicMock()
         pm.flex_search.return_value = str(tmp_path / "flex")
+        pm.logs.return_value = str(tmp_path / "logs")
         pm.m2m.return_value = str(tmp_path / "m2m")
         (tmp_path / "m2m").mkdir()
         (tmp_path / "m2m" / "001.msh").touch()
@@ -82,13 +91,22 @@ class TestRunFlexSearch:
     @patch("tit.opt.flex.manifest.write_manifest")
     @patch("tit.opt.flex.utils.generate_label", return_value="test_label")
     @patch("tit.opt.flex.utils.generate_run_dirname", return_value="20260309_120000")
+    @patch("tit.opt.flex.flex.create_valid_skin_region_visualization")
     @patch("tit.opt.flex.flex.builder")
     @patch("tit.opt.flex.flex.get_path_manager")
     def test_multistart_picks_best(
-        self, mock_gpm, mock_builder, mock_dirname, mock_label, mock_manifest, tmp_path
+        self,
+        mock_gpm,
+        mock_builder,
+        mock_skin_viz,
+        mock_dirname,
+        mock_label,
+        mock_manifest,
+        tmp_path,
     ):
         pm = MagicMock()
         pm.flex_search.return_value = str(tmp_path / "flex")
+        pm.logs.return_value = str(tmp_path / "logs")
         pm.m2m.return_value = str(tmp_path / "m2m")
         (tmp_path / "m2m").mkdir()
         (tmp_path / "m2m" / "001.msh").touch()
@@ -121,13 +139,22 @@ class TestRunFlexSearch:
     @patch("tit.opt.flex.manifest.write_manifest")
     @patch("tit.opt.flex.utils.generate_label", return_value="test_label")
     @patch("tit.opt.flex.utils.generate_run_dirname", return_value="20260309_120000")
+    @patch("tit.opt.flex.flex.create_valid_skin_region_visualization")
     @patch("tit.opt.flex.flex.builder")
     @patch("tit.opt.flex.flex.get_path_manager")
     def test_all_runs_fail(
-        self, mock_gpm, mock_builder, mock_dirname, mock_label, mock_manifest, tmp_path
+        self,
+        mock_gpm,
+        mock_builder,
+        mock_skin_viz,
+        mock_dirname,
+        mock_label,
+        mock_manifest,
+        tmp_path,
     ):
         pm = MagicMock()
         pm.flex_search.return_value = str(tmp_path / "flex")
+        pm.logs.return_value = str(tmp_path / "logs")
         pm.m2m.return_value = str(tmp_path / "m2m")
         (tmp_path / "m2m").mkdir()
         (tmp_path / "m2m" / "001.msh").touch()
@@ -149,13 +176,22 @@ class TestRunFlexSearch:
     @patch("tit.opt.flex.manifest.write_manifest")
     @patch("tit.opt.flex.utils.generate_label", return_value="test_label")
     @patch("tit.opt.flex.utils.generate_run_dirname", return_value="20260309_120000")
+    @patch("tit.opt.flex.flex.create_valid_skin_region_visualization")
     @patch("tit.opt.flex.flex.builder")
     @patch("tit.opt.flex.flex.get_path_manager")
     def test_auto_output_folder(
-        self, mock_gpm, mock_builder, mock_dirname, mock_label, mock_manifest, tmp_path
+        self,
+        mock_gpm,
+        mock_builder,
+        mock_skin_viz,
+        mock_dirname,
+        mock_label,
+        mock_manifest,
+        tmp_path,
     ):
         pm = MagicMock()
         pm.flex_search.return_value = str(tmp_path / "flex")
+        pm.logs.return_value = str(tmp_path / "logs")
         pm.m2m.return_value = str(tmp_path / "m2m")
         (tmp_path / "m2m").mkdir()
         (tmp_path / "m2m" / "001.msh").touch()

--- a/tests/test_pre_pipeline.py
+++ b/tests/test_pre_pipeline.py
@@ -420,12 +420,16 @@ class TestRunPipelineReports:
     @patch(f"{STRUCTURAL}.ensure_subject_dirs")
     @patch(f"{STRUCTURAL}.get_path_manager")
     def test_scaffolds_bidsignore_once_per_run(
-        self, mock_pm, mock_dirs, mock_datasets, mock_run_sub, _stub_bidsignore
+        self, mock_pm, mock_dirs, mock_datasets, mock_run_sub, dummy_report
     ):
         """CT output needs .bidsignore, so the pipeline must write it."""
         from tit.pre import structural
 
-        run_pipeline(["001", "002"], convert_dicom=True, runner=_make_runner())
+        # Stub the report generator like the tests below: the mocked path
+        # manager makes the project root a MagicMock, and the real generator
+        # would write its HTML into a literal MagicMock/ tree in the repo.
+        with patch(f"{REPORTING}.PreprocessingReportGenerator", dummy_report):
+            run_pipeline(["001", "002"], convert_dicom=True, runner=_make_runner())
 
         structural.ensure_bidsignore.assert_called_once()
 


### PR DESCRIPTION
Fixes the 3 long-standing `TestRunFlexSearch` failures. **This was a test problem, not a source problem** — `tit/opt/flex/` is fine and unchanged.

## Root cause

`f560b7e` ("Add flex-search skin region controls and reports") added a `create_valid_skin_region_visualization` step to `run_flex_search`, defaulting on. The tests were never updated.

`skin_visualization.py` does its own `from tit.paths import get_path_manager` **inside the function**, so the tests' `@patch("tit.opt.flex.flex.get_path_manager")` never reached it. It got the real `PathManager`, which has no `project_dir`:

```
tit/opt/flex/skin_visualization.py:40: in create_valid_skin_region_visualization
    m2m = Path(pm.m2m(config.subject_id))
tit/paths.py:117: in _root
    raise RuntimeError("Project directory not set")
E   RuntimeError: Project directory not set
```

`test_all_runs_fail` passed only by accident — a failed run never reaches that step.

The tests now stub the visualization the same way they already stub `builder`. These tests cover the orchestrator, not skin rendering.

**Verified the fix doesn't hollow out the assertions:** forcing `best_idx = 0` still fails `test_multistart_picks_best`, so the tests still catch a real regression.

## Also: the `MagicMock/` directory

Every suite run wrote a literal `MagicMock/` tree into the repo root. Two independent causes:

- `TestRunFlexSearch` left `pm.logs()` as a MagicMock that got joined into a log path → `MagicMock/get_path_manager().logs()/<id>/flex_search_*.log`
- `test_scaffolds_bidsignore_once_per_run` (added in #133) didn't stub the report generator like its neighbours, so the real one wrote HTML under the mocked project root

Both fixed; a full suite run now leaves the working tree clean.

## Result

| | before | after |
|---|---|---|
| host (3.14) | 3 failed, 1933 passed | **1936 passed** |
| container (3.11) | 3 failed, 1936 passed | **1939 passed** |

No source files touched.