### PR TITLE
ci: bump action-gh-release v1->v2 to overwrite existing release assets

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload macOS Intel DMG to release
         if: needs.build-mac.result == 'success'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/macOS-Intel-dmg/*
         env:
@@ -219,7 +219,7 @@ jobs:
 
       - name: Upload macOS Silicon DMG to release
         if: needs.build-mac.result == 'success'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/macOS-Silicon-dmg/*
         env:
@@ -227,7 +227,7 @@ jobs:
 
       - name: Upload Windows to release
         if: needs.build-windows.result == 'success'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/Windows/*
         env:
@@ -235,7 +235,7 @@ jobs:
 
       - name: Upload Linux to release
         if: needs.build-linux.result == 'success'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/Linux/*
         env:


### PR DESCRIPTION
## Problem

The `Upload to Release` job in `release-build.yml` fails with `HTTP 422 Validation Failed [already_exists]` whenever a release asset with the same name already exists on the target release. This happens on **any re-run or retag** of an existing version — as seen repeatedly on the v2.4.0 releases, where the Windows `.exe` upload aborted the job and blocked the Linux upload step behind it.

Root cause: `softprops/action-gh-release@v1` has no overwrite handling — it errors when an asset name collides.

## Fix

Bump all five `softprops/action-gh-release` references from `@v1` to `@v2`. v2 defaults `overwrite_files: true`, which deletes the conflicting asset and retries the upload (422 `already_exists` retry logic), so re-runs replace assets cleanly instead of failing.

No behavior change for first-time releases.

## Verification

Confirmed against the action's current docs: `overwrite_files` defaults to `true` in v2, deleting existing same-named assets before upload (with GitHub filename-normalization matching).