### PR TITLE
Fix main: N>2 mTI metric groundwork, broken postproc warning, vacuous tests

### DIFF
--- a/tests/README_TESTING.md
+++ b/tests/README_TESTING.md
@@ -186,6 +186,33 @@ the test image.
 
 ---
 
+## Numeric Correctness: Container Results Are Authoritative
+
+Host-side test runs (`pytest tests/ -q` on your local machine, outside Docker)
+mock `simnibs` and several other heavy dependencies (see `tests/conftest.py`).
+`numpy` is real on the host, so pure-Python/numpy math (e.g. `tit/calc.py`
+vector algebra) is exercised faithfully — but anything that goes through
+`simnibs.utils.TI_utils` or another mocked module only proves that the code
+*calls* the right functions with the right arguments, not that SimNIBS
+*returns* the numeric values the code assumes.
+
+For code paths that matter numerically (TI/mTI field math, optimization
+engines, anything touching `TI.get_field`/`TI.get_maxTI`/etc.), treat host
+results as a fast correctness-of-wiring signal only. Container results
+(`./tests/test.sh`, real SimNIBS) are authoritative — that's where real
+SimNIBS numerics actually run.
+
+**Known gap:** the CI test image (`idossha/ti-toolbox-test`, installer-based
+SimNIBS 4.6.0, used by `./tests/test.sh` and CircleCI) and the production
+image (`idossha/simnibs:v2.4.0`, built from `Dockerfile.simnibs`) are
+different builds. They have not been formally verified to produce identical
+numeric results for every code path — both currently pass the full suite,
+but no automated check compares their outputs bit-for-bit. If you're
+debugging a numeric discrepancy that only shows up for one image, this is a
+place to look.
+
+---
+
 ## CI/CD (CircleCI)
 
 ### Automatic Testing

--- a/tests/test_calc_mti.py
+++ b/tests/test_calc_mti.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env simnibs_python
+"""
+Unit tests for tit/calc.py — mti_modulation_depth (Phase 1 of
+tracks/active/mti-focality-core.md).
+
+Covers the verified N-pair (mTI) modulation-depth envelope:
+- Exact K=1 reduction to the Grossman/Huang two-channel form.
+- Agreement with a time-domain ground truth (square -> brick-wall
+  low-pass -> sqrt demodulation, per Botzanowski et al.) for K in
+  {1, 2, 4, 6}, both phase-blind (psi=None) and phase-aware (random psi).
+- The anti-phase cancellation case (Botzanowski Suppl. Fig. 1).
+- Equivalence with the ported collaborator implementation
+  (compute_botzanowski_directional_am_stats, from alba/ex-search-multipolar)
+  when psi=None.
+- Agreement with the exact K=1 closed form (get_TI_vectors) in full 3D via
+  the direction sweep.
+- Input validation and the carrier power (P) return value.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tit.calc import (
+    compute_botzanowski_directional_am_stats,
+    get_TI_vectors,
+    mti_modulation_depth,
+)
+
+RNG = np.random.default_rng(2026729)
+
+
+# ---------------------------------------------------------------------------
+# Time-domain ground truth (Botzanowski demodulator: square -> low-pass -> sqrt)
+# ---------------------------------------------------------------------------
+
+
+def _demodulate(x, fs, lp_hz=200.0):
+    """Square -> zero-phase brick-wall low-pass (frequency domain) -> sqrt."""
+    x2 = x**2
+    X = np.fft.rfft(x2)
+    freqs = np.fft.rfftfreq(len(x2), 1.0 / fs)
+    X[freqs > lp_hz] = 0.0
+    lp = np.fft.irfft(X, n=len(x2))
+    return np.sqrt(np.maximum(lp, 0.0))
+
+
+def _ground_truth_md(a, b, fca, fcb, pha, phb, fs=200_000.0, dur=0.4, edge=0.05):
+    """Synthesise the projected multi-carrier waveform, demodulate, return peak MD."""
+    t = np.arange(0, dur, 1.0 / fs)
+    x = np.zeros_like(t)
+    for ak, bk, fa, fb, pa, pb in zip(a, b, fca, fcb, pha, phb):
+        x += ak * np.cos(2 * np.pi * fa * t + pa)
+        x += bk * np.cos(2 * np.pi * fb * t + pb)
+    env_rms = _demodulate(x, fs)
+    n_edge = int(edge * len(t))  # drop FFT edge effects
+    core = env_rms[n_edge:-n_edge]
+    return np.sqrt(2.0) * (core.max() - core.min())
+
+
+def _make_fields(a, b):
+    """Embed scalar per-pair amplitudes a, b (each length K) as (1, 3) field
+    arrays [E_1a, E_1b, E_2a, E_2b, ...] all aligned with the x-axis, so that
+    projecting onto direction=[1,0,0] recovers exactly a_k, b_k."""
+    fields = []
+    for ak, bk in zip(a, b):
+        fields.append(np.array([[ak, 0.0, 0.0]]))
+        fields.append(np.array([[bk, 0.0, 0.0]]))
+    return fields
+
+
+_UNIT_X = np.array([[1.0, 0.0, 0.0]])
+
+
+# ---------------------------------------------------------------------------
+# K=1 exact reduction to Grossman/Huang 2*min(|a|,|b|)
+# ---------------------------------------------------------------------------
+
+
+class TestK1ExactReduction:
+    """For K=1, MD must reduce EXACTLY to 2*min(|a|,|b|) (< 1e-9)."""
+
+    def test_random_amplitudes(self):
+        for _ in range(20):
+            a, b = RNG.normal(size=2) * 3
+            fields = _make_fields([a], [b])
+            res = mti_modulation_depth(fields, directions=_UNIT_X)
+            want = 2 * min(abs(a), abs(b))
+            assert abs(res["md"][0] - want) < 1e-9
+
+    def test_equal_amplitudes(self):
+        fields = _make_fields([2.0], [2.0])
+        res = mti_modulation_depth(fields, directions=_UNIT_X)
+        assert abs(res["md"][0] - 4.0) < 1e-9
+
+    def test_zero_amplitude_gives_zero_md(self):
+        fields = _make_fields([0.0], [3.0])
+        res = mti_modulation_depth(fields, directions=_UNIT_X)
+        assert abs(res["md"][0]) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth agreement: K in {1, 2, 4, 6}, psi=None and random psi
+# ---------------------------------------------------------------------------
+
+
+class TestGroundTruthAgreement:
+    """mti_modulation_depth matches the time-domain demodulator ground truth
+    to < 0.01% for K in {1, 2, 4, 6}, both psi=None and random psi."""
+
+    @pytest.mark.parametrize("K", [1, 2, 4, 6])
+    def test_phase_blind(self, K):
+        means = np.linspace(2000.0, 2000.0 + 2000.0 * (K - 1), K)
+        df = 50.0
+        for trial in range(3):
+            a = RNG.normal(size=K) * 1.5
+            b = RNG.normal(size=K) * 1.5
+            gt = _ground_truth_md(
+                a, b, means - df / 2, means + df / 2, np.zeros(K), np.zeros(K)
+            )
+            res = mti_modulation_depth(_make_fields(a, b), psi=None, directions=_UNIT_X)
+            err_pct = 100 * abs(res["md"][0] - gt) / gt
+            assert err_pct < 0.01, f"K={K} trial={trial}: {err_pct:.5f}% error"
+
+    @pytest.mark.parametrize("K", [1, 2, 4, 6])
+    def test_random_phase(self, K):
+        means = np.linspace(2000.0, 2000.0 + 2000.0 * (K - 1), K)
+        df = 50.0
+        for trial in range(3):
+            a = RNG.normal(size=K) * 1.5
+            b = RNG.normal(size=K) * 1.5
+            pha = np.zeros(K)
+            phb = RNG.uniform(0, 2 * np.pi, K)
+            psi = phb - pha
+            gt = _ground_truth_md(a, b, means - df / 2, means + df / 2, pha, phb)
+            res = mti_modulation_depth(_make_fields(a, b), psi=psi, directions=_UNIT_X)
+            err_pct = 100 * abs(res["md"][0] - gt) / gt
+            assert err_pct < 0.01, f"K={K} trial={trial}: {err_pct:.5f}% error"
+
+
+# ---------------------------------------------------------------------------
+# Anti-phase cancellation (Botzanowski Suppl. Fig. 1)
+# ---------------------------------------------------------------------------
+
+
+class TestAntiPhaseCancellation:
+    """K=2, equal amplitudes, psi=[0, pi] -> aggregate envelope is exactly 0."""
+
+    def test_equal_amplitude_antiphase_pair_cancels(self):
+        fields = _make_fields([1.0, 1.0], [1.0, 1.0])
+        psi = np.array([0.0, np.pi])
+        res = mti_modulation_depth(fields, psi=psi, directions=_UNIT_X)
+        assert res["md"][0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_in_phase_pair_does_not_cancel(self):
+        fields = _make_fields([1.0, 1.0], [1.0, 1.0])
+        psi = np.array([0.0, 0.0])
+        res = mti_modulation_depth(fields, psi=psi, directions=_UNIT_X)
+        assert res["md"][0] > 1.0
+
+
+# ---------------------------------------------------------------------------
+# psi=None reproduces the ported collaborator implementation
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesCollaboratorImplementation:
+    """With psi=None, mti_modulation_depth must reproduce the ported
+    alba/ex-search-multipolar real-weight implementation
+    (compute_botzanowski_directional_am_stats) to floating-point equality.
+
+    The comparison goes through vectors=direction*amplitude on the
+    collaborator side (the only way to recover the scalar amplitude from
+    its public API), which reintroduces a norm/sqrt operation absent on
+    our side -- so equality is to ~1 ULP (machine precision), not
+    bit-for-bit through every intermediate.
+    """
+
+    @pytest.mark.parametrize("K", [1, 2, 4, 6])
+    def test_random_fields(self, K):
+        fields = [RNG.normal(size=(30, 3)) for _ in range(2 * K)]
+        ours = mti_modulation_depth(fields)["md"]
+        theirs = np.linalg.norm(
+            compute_botzanowski_directional_am_stats(fields)["vectors"], axis=1
+        )
+        np.testing.assert_allclose(ours, theirs, rtol=1e-10, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# K=1 direction sweep vs exact closed form (get_TI_vectors) in full 3D
+# ---------------------------------------------------------------------------
+
+
+class TestK1MatchesExactClosedFormIn3D:
+    """The best-direction sweep result for K=1 matches the exact Grossman
+    closed form (get_TI_vectors) to < 0.1% -- residual is direction-sweep
+    sampling error. The production default (192 directions) is a coarse
+    sweep (~1% mean error); this uses a much finer sweep to demonstrate the
+    sampling error vanishes with resolution, per
+    tracks/active/mti-focality-core.md Phase 1 acceptance."""
+
+    def test_fine_sweep_matches_grossman_closed_form(self):
+        n_trials = 8
+        E1 = RNG.normal(size=(n_trials, 3))
+        E2 = RNG.normal(size=(n_trials, 3))
+        res = mti_modulation_depth([E1, E2], num_directions=300_000)
+        md_sweep = res["md"]
+        md_exact = np.linalg.norm(get_TI_vectors(E1, E2), axis=1)
+        err_pct = 100 * np.abs(md_sweep - md_exact) / md_exact
+        assert err_pct.max() < 0.1, f"max error {err_pct.max():.4f}%"
+
+    def test_default_192_direction_sweep_is_a_coarser_approximation(self):
+        # Documents the production-default resolution/accuracy trade-off:
+        # 192 directions (matching the ported implementation) is fast and
+        # bit-parity-preserving for psi=None, but is NOT sub-0.1%-accurate
+        # against the exact closed form on its own -- num_directions must
+        # be raised for that; see the test above.
+        n_trials = 20
+        E1 = RNG.normal(size=(n_trials, 3))
+        E2 = RNG.normal(size=(n_trials, 3))
+        res = mti_modulation_depth([E1, E2])  # default num_directions=192
+        md_sweep = res["md"]
+        md_exact = np.linalg.norm(get_TI_vectors(E1, E2), axis=1)
+        err_pct = 100 * np.abs(md_sweep - md_exact) / md_exact
+        # Sweep result never overshoots the true maximum.
+        assert np.all(md_sweep <= md_exact + 1e-9)
+        # Coarse sweep is measurably less accurate than the fine one above.
+        assert err_pct.mean() > 0.1
+
+
+# ---------------------------------------------------------------------------
+# Carrier power (P) return value
+# ---------------------------------------------------------------------------
+
+
+class TestCarrierPower:
+    """P = 0.5 * sum_k (a_k^2 + b_k^2) at the direction MD was evaluated at."""
+
+    def test_carrier_power_matches_hand_computation_directional(self):
+        a = np.array([1.3, -0.7])
+        b = np.array([0.9, 1.4])
+        fields = _make_fields(a, b)
+        res = mti_modulation_depth(fields, directions=_UNIT_X)
+        expected_P = 0.5 * np.sum(a**2 + b**2)
+        assert res["carrier_power"][0] == pytest.approx(expected_P)
+
+    def test_carrier_power_nonnegative_and_bounds_md(self):
+        # P >= Q always (Q is a Cauchy-Schwarz-bounded coherent sum of the
+        # same terms P is built from), so MD = sqrt(2(P+Q)) - sqrt(2(P-Q))
+        # is well-defined and P >= md^2 / 8 for any single pair (K=1 case:
+        # P=0.5(a^2+b^2) >= |a||b| >= min(|a|,|b|)^2 = (md/2)^2).
+        fields = [RNG.normal(size=(25, 3)) for _ in range(4)]
+        res = mti_modulation_depth(fields)
+        assert np.all(res["carrier_power"] >= 0.0)
+        assert np.all(res["md"] >= 0.0)
+
+    def test_carrier_power_present_in_sweep_and_directional_modes(self):
+        fields = [RNG.normal(size=(10, 3)) for _ in range(4)]
+        directions = RNG.normal(size=(10, 3))
+        res_sweep = mti_modulation_depth(fields)
+        res_dir = mti_modulation_depth(fields, directions=directions)
+        assert "carrier_power" in res_sweep and "carrier_power" in res_dir
+        assert res_sweep["carrier_power"].shape == (10,)
+        assert res_dir["carrier_power"].shape == (10,)
+
+
+# ---------------------------------------------------------------------------
+# Return shape / best_direction
+# ---------------------------------------------------------------------------
+
+
+class TestReturnStructure:
+    def test_returns_dict_with_required_keys(self):
+        fields = [RNG.normal(size=(5, 3)) for _ in range(4)]
+        res = mti_modulation_depth(fields)
+        assert set(res.keys()) >= {"md", "carrier_power", "best_direction"}
+        assert res["md"].shape == (5,)
+        assert res["carrier_power"].shape == (5,)
+        assert res["best_direction"].shape == (5, 3)
+
+    def test_sweep_best_direction_is_unit_norm(self):
+        fields = [RNG.normal(size=(8, 3)) for _ in range(4)]
+        res = mti_modulation_depth(fields)
+        norms = np.linalg.norm(res["best_direction"], axis=1)
+        np.testing.assert_allclose(norms, 1.0, rtol=1e-10)
+
+    def test_directional_mode_normalises_input_direction(self):
+        fields = [RNG.normal(size=(3, 3)) for _ in range(4)]
+        directions = RNG.normal(size=(3, 3)) * 5.0  # not unit norm
+        res = mti_modulation_depth(fields, directions=directions)
+        norms = np.linalg.norm(res["best_direction"], axis=1)
+        np.testing.assert_allclose(norms, 1.0, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_odd_number_of_fields_raises(self):
+        fields = [RNG.normal(size=(3, 3)) for _ in range(3)]
+        with pytest.raises(ValueError):
+            mti_modulation_depth(fields)
+
+    def test_too_few_fields_raises(self):
+        with pytest.raises(ValueError):
+            mti_modulation_depth([RNG.normal(size=(3, 3))])
+
+    def test_wrong_field_dimensionality_raises(self):
+        with pytest.raises(ValueError):
+            mti_modulation_depth([RNG.normal(size=(3, 2)), RNG.normal(size=(3, 2))])
+
+    def test_mismatched_field_shapes_raises(self):
+        with pytest.raises(ValueError):
+            mti_modulation_depth([RNG.normal(size=(3, 3)), RNG.normal(size=(4, 3))])
+
+    def test_wrong_psi_length_raises(self):
+        fields = [RNG.normal(size=(3, 3)) for _ in range(4)]  # K=2
+        with pytest.raises(ValueError, match="psi"):
+            mti_modulation_depth(fields, psi=[0.0, 0.0, 0.0])
+
+    def test_wrong_directions_shape_raises(self):
+        fields = [RNG.normal(size=(3, 3)) for _ in range(2)]
+        with pytest.raises(ValueError):
+            mti_modulation_depth(fields, directions=RNG.normal(size=(5, 3)))

--- a/tests/test_opt_builder.py
+++ b/tests/test_opt_builder.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch, mock_open
 
@@ -276,6 +277,91 @@ class TestBuildOptimization:
 
         # current should be 4.0/1000 = 0.004 A
         assert pair_mock.current == [0.004, -0.004]
+
+
+# ---------------------------------------------------------------------------
+# build_optimization -- FieldPostproc.DIR_TI_TANGENTIAL deprecation warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDirTiTangentialDeprecation:
+    @patch("tit.opt.flex.builder.os.makedirs")
+    @patch("tit.opt.flex.builder.utils.configure_roi")
+    @patch("tit.paths.get_path_manager")
+    def test_dir_ti_tangential_warns(
+        self, mock_gpm, mock_roi, mock_mkdirs, builder_env
+    ):
+        """Selecting dir_TI_tangential emits exactly one DeprecationWarning."""
+        _, pm, _ = builder_env
+        mock_gpm.return_value = pm
+        from tit.opt.flex.builder import build_optimization
+
+        config = _make_config(postproc="dir_TI_tangential")
+        with pytest.warns(DeprecationWarning, match="DIR_TI_TANGENTIAL"):
+            result = build_optimization(config)
+
+        # The option still runs end-to-end -- it is not blocked or removed.
+        assert result.e_postproc == "dir_TI_tangential"
+
+    @patch("tit.opt.flex.builder.os.makedirs")
+    @patch("tit.opt.flex.builder.utils.configure_roi")
+    @patch("tit.paths.get_path_manager")
+    def test_dir_ti_tangential_warns_exactly_once(
+        self, mock_gpm, mock_roi, mock_mkdirs, builder_env
+    ):
+        _, pm, _ = builder_env
+        mock_gpm.return_value = pm
+        from tit.opt.flex.builder import build_optimization
+
+        config = _make_config(postproc="dir_TI_tangential")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            build_optimization(config)
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) == 1
+
+    @patch("tit.opt.flex.builder.os.makedirs")
+    @patch("tit.opt.flex.builder.utils.configure_roi")
+    @patch("tit.paths.get_path_manager")
+    def test_max_ti_does_not_warn(self, mock_gpm, mock_roi, mock_mkdirs, builder_env):
+        _, pm, _ = builder_env
+        mock_gpm.return_value = pm
+        from tit.opt.flex.builder import build_optimization
+
+        config = _make_config(postproc="max_TI")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            build_optimization(config)
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecation_warnings == []
+
+    @patch("tit.opt.flex.builder.os.makedirs")
+    @patch("tit.opt.flex.builder.utils.configure_roi")
+    @patch("tit.paths.get_path_manager")
+    def test_dir_ti_normal_does_not_warn(
+        self, mock_gpm, mock_roi, mock_mkdirs, builder_env
+    ):
+        """dir_TI_normal is a correct, unrelated field -- not deprecated."""
+        _, pm, _ = builder_env
+        mock_gpm.return_value = pm
+        from tit.opt.flex.builder import build_optimization
+
+        config = _make_config(postproc="dir_TI_normal")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            build_optimization(config)
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecation_warnings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_opt_engine.py
+++ b/tests/test_opt_engine.py
@@ -228,28 +228,39 @@ class TestFindGmElements:
 @pytest.mark.unit
 class TestComputeTiField:
     def test_computes_metrics(self):
-        from simnibs.utils import TI_utils as TI
+        import tit.opt.ex.engine as engine_mod
 
         engine = _make_engine()
         _setup_engine_fields(engine)
 
         # Mock TI functions to return known arrays
         ti_field = np.array([0.1, 0.2, 0.3, 0.15, 0.25])
-        TI.get_field = MagicMock(return_value=np.zeros((5, 3)))
-        TI.get_maxTI = MagicMock(return_value=ti_field)
+        engine_mod.TI.get_field = MagicMock(return_value=np.zeros((5, 3)))
+        engine_mod.TI.get_maxTI = MagicMock(return_value=ti_field)
 
         result = engine.compute_ti_field("E1", "E2", 1.0, "E3", "E4", 1.0)
 
-        assert "TestROI_TImax_ROI" in result
-        assert "TestROI_TImean_ROI" in result
-        assert "TestROI_TImean_GM" in result
-        assert "TestROI_Focality" in result
-        assert "TestROI_n_elements" in result
+        # roi_indices=[0,1,2] -> field_roi=[0.1,0.2,0.3]
+        assert result["TestROI_TImax_ROI"] == pytest.approx(0.3)
+        assert result["TestROI_TImean_ROI"] == pytest.approx(0.2)
+        # gm_indices=[0..4] -> field_gm=[0.1,0.2,0.3,0.15,0.25], mean=0.2
+        assert result["TestROI_TImean_GM"] == pytest.approx(0.2)
+        # focality = roi_mean / gm_mean = 0.2 / 0.2
+        assert result["TestROI_Focality"] == pytest.approx(1.0)
+        assert result["TestROI_n_elements"] == 3
         assert result["current_ch1_mA"] == 1.0
         assert result["current_ch2_mA"] == 1.0
 
+        engine_mod.TI.get_field.assert_any_call(
+            ["E1", "E2", 0.001], engine.leadfield, engine.idx_lf
+        )
+        engine_mod.TI.get_field.assert_any_call(
+            ["E3", "E4", 0.001], engine.leadfield, engine.idx_lf
+        )
+        engine_mod.TI.get_maxTI.assert_called_once()
+
     def test_empty_roi(self):
-        from simnibs.utils import TI_utils as TI
+        import tit.opt.ex.engine as engine_mod
 
         engine = _make_engine()
         _setup_engine_fields(engine)
@@ -257,17 +268,19 @@ class TestComputeTiField:
         engine.roi_volumes = np.array([])
 
         ti_field = np.array([0.1, 0.2, 0.3, 0.15, 0.25])
-        TI.get_field = MagicMock(return_value=np.zeros((5, 3)))
-        TI.get_maxTI = MagicMock(return_value=ti_field)
+        engine_mod.TI.get_field = MagicMock(return_value=np.zeros((5, 3)))
+        engine_mod.TI.get_maxTI = MagicMock(return_value=ti_field)
 
         result = engine.compute_ti_field("E1", "E2", 1.0, "E3", "E4", 1.0)
 
         assert result["TestROI_TImax_ROI"] == 0.0
         assert result["TestROI_TImean_ROI"] == 0.0
+        assert result["TestROI_TImean_GM"] == 0.0
         assert result["TestROI_Focality"] == 0.0
+        assert result["TestROI_n_elements"] == 0
 
     def test_zero_gm_mean(self):
-        from simnibs.utils import TI_utils as TI
+        import tit.opt.ex.engine as engine_mod
 
         engine = _make_engine()
         _setup_engine_fields(engine)
@@ -276,14 +289,20 @@ class TestComputeTiField:
 
         # All-zero GM field
         ti_field = np.array([0.1, 0.2, 0.3, 0.0, 0.0])
-        TI.get_field = MagicMock(return_value=np.zeros((5, 3)))
-        TI.get_maxTI = MagicMock(return_value=ti_field)
+        engine_mod.TI.get_field = MagicMock(return_value=np.zeros((5, 3)))
+        engine_mod.TI.get_maxTI = MagicMock(return_value=ti_field)
 
         result = engine.compute_ti_field("E1", "E2", 1.0, "E3", "E4", 1.0)
+
+        # roi_indices=[0,1,2] unaffected -> field_roi=[0.1,0.2,0.3]
+        assert result["TestROI_TImax_ROI"] == pytest.approx(0.3)
+        assert result["TestROI_TImean_ROI"] == pytest.approx(0.2)
+        # gm_indices=[3,4] -> field_gm=[0.0,0.0] -> gm_mean=0.0
+        assert result["TestROI_TImean_GM"] == pytest.approx(0.0)
         assert result["TestROI_Focality"] == 0.0
 
     def test_empty_gm(self):
-        from simnibs.utils import TI_utils as TI
+        import tit.opt.ex.engine as engine_mod
 
         engine = _make_engine()
         _setup_engine_fields(engine)
@@ -291,10 +310,14 @@ class TestComputeTiField:
         engine.gm_volumes = np.array([])
 
         ti_field = np.array([0.1, 0.2, 0.3])
-        TI.get_field = MagicMock(return_value=np.zeros((3, 3)))
-        TI.get_maxTI = MagicMock(return_value=ti_field)
+        engine_mod.TI.get_field = MagicMock(return_value=np.zeros((3, 3)))
+        engine_mod.TI.get_maxTI = MagicMock(return_value=ti_field)
 
         result = engine.compute_ti_field("E1", "E2", 1.0, "E3", "E4", 1.0)
+
+        # roi_indices=[0,1,2] -> field_roi=[0.1,0.2,0.3]
+        assert result["TestROI_TImax_ROI"] == pytest.approx(0.3)
+        assert result["TestROI_TImean_ROI"] == pytest.approx(0.2)
         assert result["TestROI_TImean_GM"] == 0.0
         assert result["TestROI_Focality"] == 0.0
 

--- a/tit/calc.py
+++ b/tit/calc.py
@@ -11,11 +11,60 @@ get_TI_vectors
     Compute TI modulation-amplitude vectors for a single electrode pair.
 get_nTI_vectors
     Generalised N-channel TI via recursive binary-tree pairing.
+    **Deprecated** -- see its docstring; no basis in the TI literature for
+    N > 2, kept only for backward compatibility with :mod:`tit.sim.mTI`.
 get_mTI_vectors
     4-channel mTI (convenience wrapper around :func:`get_TI_vectors`).
+mti_modulation_depth
+    Verified N-pair (mTI) modulation-depth envelope with an optional
+    per-pair coherent phase term.  The correct replacement for
+    :func:`get_nTI_vectors` in new code.
+compute_mti_metric_field, compute_mti_vectors
+    Dispatch across the ``MTI_METRIC_*`` family of N-pair metrics.
+
+Attribution
+-----------
+The ``MTI_METRIC_*`` constants, the ``compute_mti_vectors`` /
+``compute_mti_metric_field`` dispatch functions, and the
+``_botzanowski_*`` / ``_grossman_ext_*`` / ``_fibonacci_sphere`` helpers
+were authored by a collaborator on the ``alba/ex-search-multipolar``
+branch and are **ported here with attribution**, not reimplemented. They
+were independently verified (0.00% error) against a time-domain ground
+truth in ``tracks/active/mti-focality-core.md`` (Phase 1), which also
+promotes the Botzanowski directional metric to the package default (it
+was previously opt-in, with the unvalidated recursive-TI metric default).
+:func:`mti_modulation_depth` is new work built on top of that port: it
+generalises the real-weight (phase-blind) Botzanowski form with a
+per-pair coherent envelope-phase term and returns the carrier power that
+the ported implementation computes internally and discards.
 """
 
 import numpy as np
+
+# ── mTI metric family (ported from alba/ex-search-multipolar, see module
+#    docstring "Attribution") ─────────────────────────────────────────────
+
+MTI_METRIC_RECURSIVE_TI = "recursive_ti"
+MTI_METRIC_BOTZANOWSKI_MAGNITUDE_AM = "botzanowski_magnitude_am"
+MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM = "botzanowski_directional_am"
+MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM_AVG = "botzanowski_directional_am_ti_avg"
+MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM = "grossman_ext_directional_am"
+MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM_AVG = "grossman_ext_directional_am_ti_avg"
+
+MTI_METRICS = {
+    MTI_METRIC_RECURSIVE_TI,
+    MTI_METRIC_BOTZANOWSKI_MAGNITUDE_AM,
+    MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM,
+    MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM_AVG,
+    MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM,
+    MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM_AVG,
+}
+
+# Default metric for the compute_mti_* dispatch below. Promoted from
+# MTI_METRIC_RECURSIVE_TI (unvalidated, -13%/+12% error at N=4) to the
+# verified Botzanowski directional form (0.00% error) -- see
+# tracks/active/mti-focality-core.md Phase 1, findings F1/F2.
+_DEFAULT_MTI_METRIC = MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM
 
 
 def get_TI_vectors(E1_org, E2_org):
@@ -62,7 +111,9 @@ def get_TI_vectors(E1_org, E2_org):
     See Also
     --------
     get_mTI_vectors : 4-channel mTI (two pairs of pairs).
-    get_nTI_vectors : Generalised N-channel recursive TI.
+    get_nTI_vectors : Generalised N-channel recursive TI (deprecated).
+    mti_modulation_depth : Verified N-pair envelope; K=1 reduces to this
+        function's magnitude exactly.
     """
     # Input validation
     assert E1_org.shape == E2_org.shape, "E1 and E2 must have same shape"
@@ -157,6 +208,30 @@ def get_nTI_vectors(fields):
     For 6 fields: ``TI(TI(TI(E1,E2), TI(E3,E4)), TI(E5,E6))``
     For 8 fields: ``TI(TI(TI(E1,E2), TI(E3,E4)), TI(TI(E5,E6), TI(E7,E8)))``
 
+    .. deprecated:: mti-focality-core Phase 1
+        This recursive binary-tree formulation has **no basis in the
+        published TI literature** for N > 2 pairs. It is a category error:
+        it feeds two already-modulated *envelope* vectors (each already
+        oscillating at the beat frequency) into :func:`get_TI_vectors`, a
+        formula whose Grossman et al. (2017) derivation assumes two
+        *carrier* fields at distinct high frequencies -- this function
+        never sees a frequency assignment at all. Measured against a
+        time-domain ground truth (square -> brick-wall low-pass -> sqrt
+        demodulation), it errs **-13% to +12% with no consistent sign for
+        N=4**; it remains exact for N=2 (a single call to
+        :func:`get_TI_vectors`).
+
+        Kept for backward compatibility only: :mod:`tit.sim.mTI` still
+        calls this function to write the intermediate ``*_mTI.msh`` field
+        that downstream analysis reads, and removing it is a separate,
+        out-of-scope migration. See ``tracks/active/mti-focality-core.md``
+        (Phase 1, finding F1) for the full derivation of the error band.
+
+        Use :func:`mti_modulation_depth` for any new N>2 (mTI) work -- it
+        implements the verified Botzanowski-form envelope (0.00% error
+        against the same ground truth) with an optional per-pair coherent
+        phase term.
+
     Parameters
     ----------
     fields : list of np.ndarray, each shape (N, 3)
@@ -176,6 +251,7 @@ def get_nTI_vectors(fields):
     --------
     get_TI_vectors : Core 2-field TI calculation.
     get_mTI_vectors : 4-channel convenience wrapper.
+    mti_modulation_depth : Verified, non-deprecated N-pair replacement.
     """
     n = len(fields)
     if n < 2 or n % 2 != 0:
@@ -201,6 +277,488 @@ def get_nTI_vectors(fields):
         current = next_round
 
     return current[0]
+
+
+def compute_mti_vectors(fields, metric=_DEFAULT_MTI_METRIC):
+    """Compute vector-valued mTI output for metrics with a best direction.
+
+    Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution"). Default changed from ``MTI_METRIC_RECURSIVE_TI`` to
+    ``MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM``.
+    """
+    metric = _normalize_mti_metric(metric)
+    if metric == MTI_METRIC_RECURSIVE_TI:
+        return get_nTI_vectors(fields)
+    if metric == MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM:
+        return compute_botzanowski_directional_am_stats(fields)["vectors"]
+    if metric == MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM:
+        return compute_grossman_ext_directional_am_stats(fields)["vectors"]
+    raise ValueError(f"Metric does not produce mTI vectors: {metric!r}")
+
+
+def compute_mti_metric_field(fields, metric=_DEFAULT_MTI_METRIC):
+    """Compute a scalar mTI field for one selected multipolar metric.
+
+    Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution"). Default changed from ``MTI_METRIC_RECURSIVE_TI`` to
+    ``MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM``.
+
+    Parameters
+    ----------
+    fields : list of np.ndarray
+        Electric field vectors, one array per bipolar electrode pair.
+    metric : str
+        One of :data:`MTI_METRICS`.
+
+    Returns
+    -------
+    np.ndarray
+        Scalar metric value for each mesh element/voxel.
+    """
+    metric = _normalize_mti_metric(metric)
+    if metric == MTI_METRIC_RECURSIVE_TI:
+        return np.linalg.norm(get_nTI_vectors(fields), axis=1)
+    if metric == MTI_METRIC_BOTZANOWSKI_MAGNITUDE_AM:
+        return compute_botzanowski_magnitude_am_vectors(fields)
+    if metric == MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM:
+        return np.linalg.norm(
+            compute_botzanowski_directional_am_stats(fields)["vectors"], axis=1
+        )
+    if metric == MTI_METRIC_BOTZANOWSKI_DIRECTIONAL_AM_AVG:
+        return compute_botzanowski_directional_am_stats(fields)["avg"]
+    if metric == MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM:
+        return np.linalg.norm(
+            compute_grossman_ext_directional_am_stats(fields)["vectors"], axis=1
+        )
+    if metric == MTI_METRIC_GROSSMAN_EXT_DIRECTIONAL_AM_AVG:
+        return compute_grossman_ext_directional_am_stats(fields)["avg"]
+    raise ValueError(f"Unsupported mTI metric: {metric!r}")
+
+
+def compute_botzanowski_magnitude_am_vectors(fields):
+    """Compute direct-field AM from the envelope of ``||E(t)||``.
+
+    Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution").
+    """
+    mti_amp, _env_max = _botzanowski_magnitude_am_components(fields)
+    return mti_amp
+
+
+def compute_botzanowski_directional_am_stats(fields):
+    """Return best-direction and orientation-averaged Botzanowski AM fields.
+
+    Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution"). Real-weight (phase-blind) form; see
+    :func:`mti_modulation_depth` for the phase-aware generalisation.
+    """
+    vectors, peak_env, avg = _botzanowski_directional_am_components(fields)
+    return {"vectors": vectors, "avg": avg, "peak_env": peak_env}
+
+
+def compute_grossman_ext_directional_am_stats(fields):
+    """Return best-direction and orientation-averaged full-field AM fields.
+
+    Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution").
+    """
+    vectors, peak_env, avg = _grossman_ext_directional_am_components(fields)
+    return {"vectors": vectors, "avg": avg, "peak_env": peak_env}
+
+
+# ── mti_modulation_depth: verified, phase-aware N-pair envelope (new) ──────
+#
+# This is the genuinely new contribution of mti-focality-core Phase 1
+# (finding F3), built on the ported real-weight form above. It reuses the
+# ported _validate_field_list / _fibonacci_sphere helpers below.
+
+
+def mti_modulation_depth(
+    fields, psi=None, directions=None, num_directions=192, chunk_size=16384
+):
+    r"""Compute the coherent multi-pair TI modulation-depth envelope.
+
+    Implements the closed-form envelope for *K* electrode pairs that share
+    a common beat frequency :math:`\Delta f` but sit on separate carrier
+    bands, projected onto a direction :math:`\hat n`:
+
+    .. math::
+
+        MD(\hat n) = \sqrt{2}\,\left[\sqrt{P+Q} - \sqrt{P-Q}\right]
+
+        P = \tfrac12 \sum_k \left(a_k^2 + b_k^2\right)
+        \qquad\text{(total carrier power along } \hat n \text{)}
+
+        Q = \left|\sum_k a_k b_k\, e^{i\psi_k}\right|
+        \qquad\text{(coherent phasor sum over pairs)}
+
+        a_k = E_{ka}\cdot\hat n,\quad b_k = E_{kb}\cdot\hat n
+        \qquad\text{(signed projections; do not take } |a_k|, |b_k| \text{)}
+
+        \psi_k = \phi_{kb} - \phi_{ka}
+        \qquad\text{(per-pair envelope phase offset, radians)}
+
+    With ``psi=None`` (or all zeros), :math:`Q` reduces exactly to
+    :math:`\left|\sum_k a_k b_k\right|` -- the real-weight form ported from
+    the collaborator branch ``alba/ex-search-multipolar`` as
+    :func:`_botzanowski_directional_am_components` (see module docstring
+    "Attribution"). This function generalises that form with the coherent
+    phasor sum, and additionally returns ``P`` -- the carrier power the
+    ported implementation computes internally (as ``s0``) and discards.
+
+    For *K* = 1 this reduces **exactly** to the standard Grossman/Huang
+    two-channel modulation depth, ``2 * min(|a|, |b|)``.
+
+    Verified against a time-domain ground truth (square -> brick-wall
+    low-pass -> sqrt demodulation, per Botzanowski et al.) to < 0.01% error
+    for K in {1, 2, 4, 6}, both with ``psi=None`` and with random
+    per-pair phases -- see ``scripts/verify_mti_envelope.py`` and
+    ``tracks/active/mti-focality-core.md`` (Phase 1, finding F3). The
+    phase-blind (``psi=None``) form errs 5.7%-454% once the true
+    :math:`\psi_k \neq 0`, which is why the phase term matters whenever
+    per-pair envelope phase is not independently guaranteed to be zero.
+
+    Anti-phase pairs cancel exactly: for K=2 with equal amplitudes and
+    ``psi = [0, pi]``, ``MD`` is exactly 0.0 (Botzanowski Suppl. Fig. 1 --
+    a 180-degree envelope offset between pairs produces no aggregate
+    envelope).
+
+    Validity requires sufficient carrier-band separation between pairs
+    (finding F7); see :func:`tit.opt.config.validate_band_separation`.
+
+    Parameters
+    ----------
+    fields : list of np.ndarray, each shape (N, 3)
+        Electric field vectors ordered ``[E_1a, E_1b, E_2a, E_2b, ...]``
+        -- 2K arrays for K electrode pairs, one array per sub-channel.
+    psi : array-like of float, shape (K,), or None
+        Per-pair envelope phase offset in radians, ``psi_k = phi_kb -
+        phi_ka``. ``None`` (default) assumes every pair's envelope is
+        phase-aligned (``psi_k = 0``) and takes a real-only fast path that
+        is bit-identical to the ported real-weight implementation.
+    directions : np.ndarray, shape (N, 3), or None
+        If ``None`` (default), sweep a 192-point chunked Fibonacci-sphere
+        grid (matching the ported implementation's resolution and
+        16384-element chunk size) and return the best-direction envelope
+        per element -- the mode used for mTI field maps. If given, use
+        the supplied per-element direction directly (normalised
+        internally) with no search -- the mode used to project onto a
+        known orientation (e.g. cortical normal) or to validate the
+        closed form against ground truth at an exact, known direction.
+    num_directions : int, default 192
+        Number of Fibonacci-sphere sample directions when ``directions``
+        is ``None``. The default matches the ported implementation
+        exactly (required for the ``psi=None`` bit-identity guarantee
+        above). Higher values trade sampling error for compute cost --
+        e.g. verification against an exact analytical optimum (K=1) needs
+        a much finer sweep than the production default; see
+        ``scripts/verify_mti_envelope.py``.
+    chunk_size : int, default 16384
+        Mesh elements processed per chunk during the direction sweep,
+        bounding peak memory to ``chunk_size * num_directions`` floats
+        regardless of total element count.
+
+    Returns
+    -------
+    dict
+        ``"md"`` : np.ndarray, shape (N,)
+            Best-direction (or given-direction) modulation depth [V/m].
+        ``"carrier_power"`` : np.ndarray, shape (N,)
+            Total carrier power ``P`` at the direction ``md`` was
+            evaluated at [V/m^2] -- see finding F4 (carrier-exposure
+            constraint, wired up in Phase 2).
+        ``"best_direction"`` : np.ndarray, shape (N, 3)
+            Unit vector the envelope was evaluated at -- the swept-best
+            direction, or the (normalised) input ``directions``.
+
+    Raises
+    ------
+    ValueError
+        If ``fields`` is not an even-length list of identically-shaped
+        ``(N, 3)`` arrays, if ``psi`` does not have shape ``(K,)``, or if
+        ``directions`` (when given) does not match the field arrays' shape.
+
+    See Also
+    --------
+    get_TI_vectors : Exact K=1 closed form (Grossman et al. 2017); this
+        function's magnitude matches it exactly for K=1.
+    get_nTI_vectors : Deprecated, unvalidated N>2 predecessor.
+    compute_mti_metric_field : Dispatch across the ported MTI_METRIC_*
+        family (phase-blind only).
+    tit.opt.config.MTIFrequencyPlan : Records the per-pair carrier/phase
+        assignment this function's ``psi`` argument is derived from.
+    """
+    arrs = _validate_field_list(fields)
+    n_pairs = len(arrs) // 2
+    psi_arr = _validate_psi(psi, n_pairs)
+
+    if directions is not None:
+        return _mti_modulation_depth_at_directions(arrs, psi_arr, directions)
+    return _mti_modulation_depth_sweep(arrs, psi_arr, num_directions, chunk_size)
+
+
+def _validate_psi(psi, n_pairs):
+    """Normalise/validate the per-pair envelope phase array."""
+    if psi is None:
+        return None
+    psi_arr = np.asarray(psi, dtype=np.float64)
+    if psi_arr.shape != (n_pairs,):
+        raise ValueError(
+            "psi must be None or have shape "
+            f"({n_pairs},) -- one phase offset per electrode pair; got "
+            f"shape {psi_arr.shape}"
+        )
+    return psi_arr
+
+
+def _pairwise_products(proj_fields, psi):
+    """Return (P, Q) -- carrier power and coherent phasor magnitude.
+
+    ``proj_fields`` is a list of 2K arrays of identical shape (signed
+    projections onto one or more candidate directions). When ``psi`` is
+    ``None`` or all-zero, ``Q`` is computed via a real-only sum -- the
+    same operation order as the ported ``_botzanowski_directional_am_components``
+    -- so results are bit-identical to that implementation.
+    """
+    n_pairs = len(proj_fields) // 2
+
+    P = np.zeros_like(proj_fields[0], dtype=np.float64)
+    for p in proj_fields:
+        P += p * p
+    P *= 0.5
+
+    use_phase = psi is not None and np.any(psi != 0.0)
+    if use_phase:
+        z = np.zeros_like(P, dtype=np.complex128)
+        for k in range(n_pairs):
+            a = proj_fields[2 * k]
+            b = proj_fields[2 * k + 1]
+            z += (a * b) * np.exp(1j * psi[k])
+        Q = np.abs(z)
+    else:
+        b_sum = np.zeros_like(P)
+        for k in range(n_pairs):
+            a = proj_fields[2 * k]
+            b = proj_fields[2 * k + 1]
+            b_sum += a * b
+        Q = np.abs(b_sum)
+
+    return P, Q
+
+
+def _envelope_from_PQ(P, Q):
+    """MD = sqrt(2) * (sqrt(P+Q) - sqrt(P-Q)), clamped against negative
+    round-off inside the square roots."""
+    smin = np.maximum(P - Q, 0.0)
+    smax = np.maximum(P + Q, 0.0)
+    return np.sqrt(2.0 * smax) - np.sqrt(2.0 * smin)
+
+
+def _mti_modulation_depth_sweep(arrs, psi, num_directions, chunk_size):
+    """Chunked Fibonacci-sphere direction sweep -- returns best-direction
+    md/carrier_power/best_direction per element."""
+    directions = _fibonacci_sphere(num_directions)
+    n_vox = arrs[0].shape[0]
+
+    md = np.zeros(n_vox, dtype=np.float64)
+    carrier_power = np.zeros(n_vox, dtype=np.float64)
+    best_direction = np.zeros((n_vox, 3), dtype=np.float64)
+
+    for start in range(0, n_vox, chunk_size):
+        stop = min(start + chunk_size, n_vox)
+        proj = [field[start:stop] @ directions.T for field in arrs]
+        P, Q = _pairwise_products(proj, psi)
+        amp = _envelope_from_PQ(P, Q)
+
+        idx = np.argmax(amp, axis=1)
+        rows = np.arange(stop - start)
+        md[start:stop] = amp[rows, idx]
+        carrier_power[start:stop] = P[rows, idx]
+        best_direction[start:stop] = directions[idx]
+
+    return {"md": md, "carrier_power": carrier_power, "best_direction": best_direction}
+
+
+def _mti_modulation_depth_at_directions(arrs, psi, directions):
+    """Evaluate the envelope at an explicit per-element direction (no search)."""
+    directions = np.asarray(directions, dtype=np.float64)
+    if directions.shape != arrs[0].shape:
+        raise ValueError(
+            "directions must have the same shape as each field array; got "
+            f"{directions.shape}, expected {arrs[0].shape}"
+        )
+    norms = np.linalg.norm(directions, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    unit_dirs = directions / norms
+
+    proj = [np.sum(field * unit_dirs, axis=1) for field in arrs]
+    P, Q = _pairwise_products(proj, psi)
+    md = _envelope_from_PQ(P, Q)
+
+    return {"md": md, "carrier_power": P, "best_direction": unit_dirs}
+
+
+def _normalize_mti_metric(metric):
+    """Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution")."""
+    metric = metric.value if hasattr(metric, "value") else str(metric)
+    if metric not in MTI_METRICS:
+        raise ValueError(f"Unsupported mTI metric: {metric!r}")
+    return metric
+
+
+def _botzanowski_magnitude_am_components(fields):
+    """Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution")."""
+    arrs = _validate_field_list(fields)
+    weights = _pair_weights(len(arrs))
+
+    s0 = np.zeros(arrs[0].shape[0], dtype=np.float64)
+    for field in arrs:
+        s0 += np.sum(field * field, axis=1)
+    s0 *= 0.5
+
+    b = np.zeros_like(s0)
+    for pair_idx, weight in enumerate(weights):
+        f1 = arrs[2 * pair_idx]
+        f2 = arrs[2 * pair_idx + 1]
+        b += weight * np.sum(f1 * f2, axis=1)
+
+    abs_b = np.abs(b)
+    smin = np.maximum(s0 - abs_b, 0.0)
+    smax = np.maximum(s0 + abs_b, 0.0)
+    env_min = np.sqrt(2 * smin)
+    env_max = np.sqrt(2 * smax)
+    return env_max - env_min, env_max
+
+
+def _botzanowski_directional_am_components(fields):
+    """Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution"). Real-weight (phase-blind) directional sweep; the
+    reference implementation :func:`mti_modulation_depth` (``psi=None``)
+    reproduces to floating-point equality."""
+    arrs = _validate_field_list(fields)
+    weights = _pair_weights(len(arrs))
+    directions = _fibonacci_sphere(192)
+    chunk_size = 16384
+
+    n_vox = arrs[0].shape[0]
+    best_vectors = np.zeros((n_vox, 3), dtype=np.float64)
+    best_peak = np.zeros(n_vox, dtype=np.float64)
+    avg_amp = np.zeros(n_vox, dtype=np.float64)
+
+    for start in range(0, n_vox, chunk_size):
+        stop = min(start + chunk_size, n_vox)
+        proj_fields = [field[start:stop] @ directions.T for field in arrs]
+
+        s0 = np.zeros_like(proj_fields[0], dtype=np.float64)
+        for proj in proj_fields:
+            s0 += proj * proj
+        s0 *= 0.5
+
+        b = np.zeros_like(s0, dtype=np.float64)
+        for pair_idx, weight in enumerate(weights):
+            p1 = proj_fields[2 * pair_idx]
+            p2 = proj_fields[2 * pair_idx + 1]
+            b += weight * (p1 * p2)
+
+        abs_b = np.abs(b)
+        smin = np.maximum(s0 - abs_b, 0.0)
+        smax = np.maximum(s0 + abs_b, 0.0)
+        env_min = np.sqrt(2 * smin)
+        env_max = np.sqrt(2 * smax)
+        amp = env_max - env_min
+
+        avg_amp[start:stop] = np.mean(amp, axis=1)
+        best_idx = np.argmax(amp, axis=1)
+        rows = np.arange(stop - start)
+        best_amp = amp[rows, best_idx]
+        best_dirs = directions[best_idx]
+        best_vectors[start:stop] = best_dirs * best_amp[:, None]
+        best_peak[start:stop] = env_max[rows, best_idx]
+
+    return best_vectors, best_peak, avg_amp
+
+
+def _grossman_ext_directional_am_components(fields):
+    """Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution")."""
+    arrs = _validate_field_list(fields)
+    directions = _fibonacci_sphere(192)
+    chunk_size = 16384
+
+    n_vox = arrs[0].shape[0]
+    best_vectors = np.zeros((n_vox, 3), dtype=np.float64)
+    best_peak_env = np.zeros(n_vox, dtype=np.float64)
+    avg_amp = np.zeros(n_vox, dtype=np.float64)
+
+    for start in range(0, n_vox, chunk_size):
+        stop = min(start + chunk_size, n_vox)
+        proj_fields = [field[start:stop] @ directions.T for field in arrs]
+
+        env_psi0 = np.zeros((stop - start, directions.shape[0]), dtype=np.float64)
+        env_psi_pi = np.zeros_like(env_psi0)
+
+        for pair_idx in range(len(arrs) // 2):
+            a = proj_fields[2 * pair_idx]
+            b = proj_fields[2 * pair_idx + 1]
+            env_psi0 += np.abs(a + b)
+            env_psi_pi += np.abs(a - b)
+
+        env_hi = np.maximum(env_psi0, env_psi_pi)
+        env_lo = np.minimum(env_psi0, env_psi_pi)
+        amp = env_hi - env_lo
+
+        avg_amp[start:stop] = np.mean(amp, axis=1)
+        best_idx = np.argmax(amp, axis=1)
+        rows = np.arange(stop - start)
+        best_amp = amp[rows, best_idx]
+        best_peak_env[start:stop] = env_hi[rows, best_idx]
+        best_vectors[start:stop] = directions[best_idx] * best_amp[:, None]
+
+    return best_vectors, best_peak_env, avg_amp
+
+
+def _validate_field_list(fields):
+    """Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution")."""
+    arrs = [np.asarray(field, dtype=np.float64) for field in fields]
+    n = len(arrs)
+    if n < 2 or n % 2 != 0:
+        raise ValueError(f"mTI requires an even number of fields >= 2, got {n}")
+    ref_shape = arrs[0].shape
+    if len(ref_shape) != 2 or ref_shape[1] != 3:
+        raise ValueError(f"Fields must have shape (N, 3), got {ref_shape}")
+    for i, arr in enumerate(arrs[1:], start=2):
+        if arr.shape != ref_shape:
+            raise ValueError(
+                "All fields must have identical shape; "
+                f"field 1 has {ref_shape}, field {i} has {arr.shape}"
+            )
+    return arrs
+
+
+def _pair_weights(num_fields: int):
+    """Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution")."""
+    return [1.0] * (num_fields // 2)
+
+
+def _fibonacci_sphere(num_dirs: int) -> np.ndarray:
+    """Return approximately uniform unit vectors on the sphere.
+
+    Ported from ``alba/ex-search-multipolar`` (see module docstring
+    "Attribution")."""
+    if num_dirs < 2:
+        return np.array([[0.0, 0.0, 1.0]], dtype=np.float64)
+    i = np.arange(num_dirs, dtype=np.float64)
+    phi = np.pi * (3.0 - np.sqrt(5.0))
+    y = 1.0 - 2.0 * i / (num_dirs - 1)
+    radius = np.sqrt(np.maximum(0.0, 1.0 - y * y))
+    theta = phi * i
+    x = np.cos(theta) * radius
+    z = np.sin(theta) * radius
+    return np.stack((x, y, z), axis=1)
 
 
 def get_mTI_vectors(E1_org, E2_org, E3_org, E4_org):
@@ -235,7 +793,7 @@ def get_mTI_vectors(E1_org, E2_org, E3_org, E4_org):
     See Also
     --------
     get_TI_vectors : Core 2-field TI calculation.
-    get_nTI_vectors : Generalised N-channel recursive TI.
+    get_nTI_vectors : Generalised N-channel recursive TI (deprecated).
     """
     # Validate shapes
     for i, arr in enumerate([E1_org, E2_org, E3_org, E4_org], start=1):

--- a/tit/opt/flex/builder.py
+++ b/tit/opt/flex/builder.py
@@ -22,6 +22,7 @@ tit.opt.config.FlexConfig : Configuration dataclass consumed here.
 import base64
 import json
 import os
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 import logging
@@ -84,6 +85,20 @@ def build_optimization(config: FlexConfig):
             vals = [float(v) for v in thr_raw.split(",")]
             opt.threshold = vals if len(vals) > 1 else vals[0]
 
+    if config.postproc == FlexConfig.FieldPostproc.DIR_TI_TANGENTIAL:
+        warnings.warn(
+            "FieldPostproc.DIR_TI_TANGENTIAL ('dir_TI_tangential') computes "
+            "tangential TI as sqrt(max(0, maxTI**2 - dirTI_normal**2)) -- a "
+            "non-Pythagorean projection of already-modulated TI envelope "
+            "amplitudes, not a vector decomposition of the underlying "
+            "carrier fields. For a correct tangential/normal decomposition, "
+            "use get_dirTI(E1, E2, n) applied to the raw carrier fields "
+            "(as tit.analyzer's TI_normal does), not this postproc option. "
+            "This option is kept for backward compatibility with existing "
+            "configs and is not removed by this warning.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     opt.e_postproc = config.postproc.value
     opt.anisotropy_type = config.anisotropy_type
     opt.aniso_maxratio = config.aniso_maxratio


### PR DESCRIPTION
## Summary

Three small, independently-revertible, **zero-user-visible-behavior-change** fixes, per `tracks/active/fix-main-mti-bugs.md`.

### 1. Port the verified N>2 mTI metric into `tit/calc.py` (additive only)

`get_nTI_vectors()` (`tit/calc.py:148-203`) recursively re-applies the 2-carrier Grossman TI formula over a binary tree of already-modulated envelope vectors — a category error with no basis in the TI literature for N>2, measured at -13%/+12% error at N=4 (exact at N=2). This PR ports `mti_modulation_depth()` and the `MTI_METRIC_*` family — a verified replacement (<0.01% error vs. a time-domain ground truth) — into `tit/calc.py`, purely additively, along with `tests/test_calc_mti.py` (31 tests).

- `get_nTI_vectors`'s docstring is marked `.. deprecated::`. **Its logic is untouched.**
- **Hand-ported, not cherry-picked.** The source commit (`feature/mti-optimization@19261dd4`) also adds `MTIFrequencyPlan`/`validate_band_separation` to `tit/opt/config.py` plus `tests/test_opt_config.py` and `scripts/verify_mti_envelope.py` — that's part of the broader `mti-focality-core` track (frequency-plan validation, not yet reviewed/validated). This PR only takes the `tit/calc.py` port + `tests/test_calc_mti.py`, exactly as scoped by `fix-main-mti-bugs.md`'s Phase 1 task 1. (Two docstring cross-references to `tit.opt.config.MTIFrequencyPlan`/`validate_band_separation` remain in `tit/calc.py` as forward-pointing prose — they're not imports, so nothing breaks; those objects land when the frequency-plan track merges separately.)
- **Nothing on `main` calls `mti_modulation_depth` yet.** This is groundwork only.

### 2. `DeprecationWarning` for the broken `dir_TI_tangential` postproc option

`FieldPostproc.DIR_TI_TANGENTIAL` (`tit/opt/config.py:171`) computes tangential TI as `sqrt(max(0, maxTI**2 - dirTI_normal**2))` — a non-Pythagorean projection of already-modulated TI *envelope* amplitudes, not a vector decomposition of the underlying carrier fields. It's fully selectable end-to-end (GUI dropdown → `tit/opt/flex/builder.py:87` → SimNIBS, unfiltered) with zero warning anywhere in the chain today.

**Exact trigger condition:** `tit/opt/flex/builder.py::build_optimization` now emits exactly one `DeprecationWarning` when, and only when, `config.postproc == FlexConfig.FieldPostproc.DIR_TI_TANGENTIAL`. `max_TI` and `dir_TI_normal` are unaffected — `dir_TI_normal` is a **different, correct** computation (`get_dirTI` on raw carrier fields, same as `tit.analyzer`'s `TI_normal`) and is not touched. The option still runs end-to-end; existing configs referencing it do not crash. Covered by 4 new tests in `tests/test_opt_builder.py::TestDirTiTangentialDeprecation`.

### 3. Fix 4 vacuous tests in `tests/test_opt_engine.py::TestComputeTiField`

Each of `test_computes_metrics`, `test_empty_roi`, `test_zero_gm_mean`, `test_empty_gm` did a fresh `from simnibs.utils import TI_utils as TI` inside the test body and patched *that local name* — not the module object `tit/opt/ex/engine.py` actually binds at import time. **Proven vacuous by mutation testing:** with the patch commented out, 3 of 4 tests now fail (the 4th, `test_empty_roi`, is legitimately insensitive to the mocked field values since it exercises the `n_elements==0` short-circuit directly).

Fixed using the pattern already precedented in this file (`9a2738d9`, `TestLoadLeadfield`): `import tit.opt.ex.engine as engine_mod` then patch `engine_mod.TI.get_field` / `engine_mod.TI.get_maxTI`. Assertions strengthened to check real numeric values (e.g. `TImax_ROI == 0.3`, `Focality == 1.0`) rather than just key presence.

## Explicit scope statement — `tit/sim/mTI.py` output is UNCHANGED

Per the track file's "Scope decision" section (quoted below), **this PR does NOT switch `tit/sim/mTI.py`'s live simulation output to the corrected metric.** `get_nTI_vectors` is the only path `tit/sim/mTI.py:162` uses for N≥4 mTI simulation, and this PR does not touch its behavior — only its docstring. Reviewers should not expect (or ask for) any change in simulation numbers from this PR.

> **Decision (made explicitly, not by default): this track does NOT switch `tit/sim/mTI.py` to the corrected metric.** It only ports the corrected metric into `tit/calc.py`, additively, so it exists and is tested. Reasons:
> - Switching live simulation output changes numbers for every user running N>2 mTI today — `mti-focality-core.md`'s own risk table calls this out ("changing the default metric changes all prior mTI results — published/in-progress results shift").
> - The corrected metric should prove itself through Track B's validation matrix before it becomes the thing users' simulations are silently built on.
> - Track A's job is fixing what's unambiguously broken with unambiguously zero downside. This one qualifies for the *port*, not for flipping the switch on live output.
>
> **Follow-up, explicitly deferred, not forgotten:** once Track B validates the corrected metric, open a dedicated PR that (a) switches `tit/sim/mTI.py` to `mti_modulation_depth`, (b) records the metric name in `documentation/config.json`, and (c) adds a changelog entry stating the magnitude of the change. Do not bundle it here.

## Test plan

- [x] `pytest tests/test_calc_mti.py -v` — 31/31 pass, ground-truth agreement <0.01%
- [x] `pytest tests/test_opt_engine.py::TestComputeTiField -v` — 4/4 pass; proven non-vacuous by mutation testing (commented out the `engine_mod.TI.get_maxTI` patch locally, confirmed 3/4 now fail, then restored)
- [x] `pytest tests/test_opt_builder.py::TestDirTiTangentialDeprecation -v` — 4/4 pass (warns exactly once for `dir_TI_tangential`, never for `max_TI`/`dir_TI_normal`)
- [x] Full host suite: `pytest tests/ -q` → **1971 passed, 8 skipped, 0 failed** (main's baseline was 1936/8/0 — the +35 are purely additive: 31 new `test_calc_mti.py` tests + 4 new deprecation-warning tests)
- [x] Full suite in-container, real SimNIBS 4.6.0, CI image (`idossha/ti-toolbox-test:latest`, same image CircleCI uses via `./tests/test.sh`) → **1977 passed, 2 skipped, 0 failed**
- [x] Full suite in-container, production image (`idossha/simnibs:v2.4.0`, `Dockerfile.simnibs`-built) → **1974 passed, 5 skipped, 0 failed**
- [x] `black tit/ tests/` — all 5 touched Python files are clean (8 unrelated pre-existing-drift files in the repo were left untouched, out of scope for this PR)
- [x] Documented in `tests/README_TESTING.md`: container results are authoritative for numeric correctness (host mocks `simnibs`), and the CI-image/production-image reconciliation gap

## Not in this PR

- Switching `tit/sim/mTI.py`'s live output (deferred follow-up, see Scope decision above)
- `MTIFrequencyPlan`/`validate_band_separation`/`scripts/verify_mti_envelope.py` (belongs to `mti-focality-core`, not yet validated)
- Rebuilding CI (already exists and works — only documentation was the gap)

Do not merge — leaving open for human review per the track file.