### PR TITLE
[Track] volumetric-cortical-roi: project cortical atlas labels into the GM ribbon for leadfield search

### DIFF
--- a/tests/test_opt_config.py
+++ b/tests/test_opt_config.py
@@ -35,6 +35,7 @@ NonROIMethod = FlexConfig.NonROIMethod
 SphericalROI = FlexConfig.SphericalROI
 AtlasROI = FlexConfig.AtlasROI
 SubcorticalROI = FlexConfig.SubcorticalROI
+CorticalROI = FlexConfig.CorticalROI
 FlexElectrodeConfig = FlexConfig.ElectrodeConfig
 
 # ---------------------------------------------------------------------------
@@ -365,6 +366,11 @@ class TestROIDefaults:
     def test_subcortical_roi_defaults(self):
         roi = SubcorticalROI(atlas_path="/atlas.nii.gz", label=17)
         assert roi.atlas_space == "subject"
+        assert roi.tissues == "GM"
+
+    def test_cortical_roi_defaults(self):
+        roi = CorticalROI(atlas_path="/atlas.annot", label=18)
+        assert roi.hemisphere == "lh"
         assert roi.tissues == "GM"
 
     def test_flex_electrode_config_defaults(self):

--- a/tests/test_opt_roi.py
+++ b/tests/test_opt_roi.py
@@ -1,0 +1,523 @@
+"""Tests for tit/opt/roi.py -- ROIResolver on volume-only leadfield meshes.
+
+General ROIResolver coverage (spherical ROI, tissue filtering, non-ROI
+resolution, the surface-only AtlasROI rejection) already lives in
+``tests/test_opt_mp.py`` alongside the rest of the multi-polar search
+suite. This file adds dedicated coverage for the ``CorticalROI``
+surface-to-volume projection path added in the volumetric-cortical-roi
+track: an ``.annot`` cortical label rasterized into the subject's aseg
+voxel grid and intersected with the GM ribbon, so it can be handed to the
+leadfield-based optimizers exactly like a ``SubcorticalROI``.
+
+numpy is real; simnibs/scipy/nibabel are mocked (see conftest.py) --
+``nibabel``/``nibabel.freesurfer``/``scipy.spatial`` are monkeypatched
+per-test with small, deterministic fakes so the projection math itself
+(not just "it runs") is verified.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from tit.opt.config import FlexConfig
+
+SphericalROI = FlexConfig.SphericalROI
+AtlasROI = FlexConfig.AtlasROI
+SubcorticalROI = FlexConfig.SubcorticalROI
+CorticalROI = FlexConfig.CorticalROI
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _BruteForceTree:
+    """Pure-numpy stand-in for ``scipy.spatial.cKDTree`` (exact NN query).
+
+    ``scipy.spatial`` is mocked wholesale by conftest.py; the test data
+    here is always small enough that a brute-force nearest-neighbour
+    search is both exact and fast, so it can stand in for the real
+    ``cKDTree`` that ``ROIResolver`` imports lazily.
+    """
+
+    def __init__(self, data):
+        self.data = np.asarray(data, dtype=float)
+
+    def query(self, points, k=1):
+        points = np.atleast_2d(np.asarray(points, dtype=float))
+        diffs = points[:, None, :] - self.data[None, :, :]
+        dists = np.linalg.norm(diffs, axis=2)
+        idx = np.argmin(dists, axis=1)
+        return dists[np.arange(len(points)), idx], idx
+
+
+def _make_mock_mesh(barycenters, tags, volumes=None):
+    """Mock mesh exposing exactly what ROIResolver touches.
+
+    Unlike ``test_opt_mp.py``'s random-barycenter helper, coordinates here
+    are caller-specified so a CorticalROI's projected world points can be
+    matched against known element positions.
+    """
+    barycenters = np.asarray(barycenters, dtype=float)
+    tags = np.asarray(tags)
+    if volumes is None:
+        volumes = np.ones(len(tags))
+
+    mesh = MagicMock()
+    mesh.elements_baricenters.return_value = SimpleNamespace(value=barycenters)
+    mesh.elements_volumes_and_areas.return_value = SimpleNamespace(
+        value=np.asarray(volumes, dtype=float)
+    )
+    mesh.elm = SimpleNamespace(tag1=tags)
+    return mesh
+
+
+def _install_fake_nibabel(monkeypatch, aseg, aseg_affine, gifti_points):
+    """Patch ``sys.modules["nibabel"]``/``["nibabel.freesurfer"]``.
+
+    Parameters
+    ----------
+    aseg : ndarray
+        3D aseg-style label volume (stands in for labeling.nii.gz).
+    aseg_affine : ndarray, shape (4, 4)
+        Affine for *aseg*.
+    gifti_points : dict[str, ndarray]
+        Maps a path suffix (e.g. ``"lh.white.gii"``) to the (N, 3) vertex
+        array ``nib.load(path).darrays[0].data`` should return for a path
+        ending in that suffix.
+
+    Returns
+    -------
+    fake_nib : MagicMock
+        The installed ``nibabel`` stand-in (``fake_nib.load`` call args can
+        be inspected for cache-hit assertions).
+    fake_freesurfer : MagicMock
+        The installed ``nibabel.freesurfer`` stand-in (``read_annot``).
+    """
+
+    def _load(path):
+        path = str(path)
+        if path.endswith(".gii"):
+            for suffix, pts in gifti_points.items():
+                if path.endswith(suffix):
+                    return SimpleNamespace(darrays=[SimpleNamespace(data=pts)])
+            raise AssertionError(f"Unexpected GIFTI load: {path}")
+        return SimpleNamespace(dataobj=aseg, affine=aseg_affine)
+
+    fake_nib = MagicMock()
+    fake_nib.load.side_effect = _load
+    monkeypatch.setitem(sys.modules, "nibabel", fake_nib)
+
+    fake_freesurfer = MagicMock()
+    monkeypatch.setitem(sys.modules, "nibabel.freesurfer", fake_freesurfer)
+    # ``import nibabel.freesurfer as nfs`` resolves via getattr() on the
+    # already-imported parent package, not a direct sys.modules lookup for
+    # the dotted name -- so the submodule must also be wired up as a real
+    # attribute of the parent mock, exactly as a genuine import would leave
+    # it (otherwise MagicMock auto-vivifies an unrelated child attribute).
+    fake_nib.freesurfer = fake_freesurfer
+
+    monkeypatch.setitem(
+        sys.modules, "scipy.spatial", MagicMock(cKDTree=_BruteForceTree)
+    )
+
+    return fake_nib, fake_freesurfer
+
+
+# ---------------------------------------------------------------------------
+# Synthetic subject fixture
+# ---------------------------------------------------------------------------
+#
+# A tiny, fully deterministic "subject": identity affine (world coords ==
+# voxel indices) so the projection math is easy to hand-verify.
+#
+# 6 lh vertices: vertices 0/1 carry the target label (5) and sit at aseg
+# voxels (5,5,5) / (5,5,6), both tagged Left-Cerebral-Cortex (3) -- inside
+# the GM ribbon. Vertex 2 also carries label 5 but sits at (2,2,2), tagged
+# White-Matter (2) in the fake aseg -- outside the ribbon, so it must be
+# filtered out by the cortex-tag intersection. Vertices 3-5 carry a
+# different label (0) and are irrelevant.
+#
+# white == pial per vertex (zero cortical thickness) so every one of the
+# 6 t-samples collapses onto the same voxel -- exercises the ribbon
+# sampling code path without needing non-trivial geometry to hand-verify.
+
+
+def _lh_annot_labels():
+    return np.array([5, 5, 5, 0, 0, 0])
+
+
+def _lh_gifti_points():
+    pts = np.array(
+        [
+            [5.0, 5.0, 5.0],
+            [5.0, 5.0, 6.0],
+            [2.0, 2.0, 2.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [9.0, 9.0, 9.0],
+        ]
+    )
+    return pts
+
+
+def _make_aseg():
+    aseg = np.zeros((10, 10, 10), dtype=int)
+    aseg[5, 5, 5] = 3  # Left-Cerebral-Cortex
+    aseg[5, 5, 6] = 3  # Left-Cerebral-Cortex
+    aseg[2, 2, 2] = 2  # Left-Cerebral-White-Matter (outside the GM ribbon)
+    return aseg, np.eye(4)
+
+
+def _setup_subject(
+    monkeypatch, tmp_path, names=("unknown", "a", "b", "c", "d", "target")
+):
+    """Wire up the fake nibabel + a real (empty) m2m directory tree.
+
+    ``os.path.isfile`` guards in ``_resolve_cortical_surface`` need real
+    paths to exist; content is irrelevant since ``nib.load``/
+    ``read_annot`` are patched to ignore it.
+    """
+    m2m = tmp_path / "m2m_test"
+    seg_dir = m2m / "segmentation"
+    surf_dir = m2m / "surfaces"
+    seg_dir.mkdir(parents=True)
+    surf_dir.mkdir(parents=True)
+
+    annot_path = seg_dir / "lh.test_a2009s.annot"
+    annot_path.write_bytes(b"")
+    (seg_dir / "labeling.nii.gz").write_bytes(b"")
+    (surf_dir / "lh.white.gii").write_bytes(b"")
+    (surf_dir / "lh.pial.gii").write_bytes(b"")
+
+    aseg, aseg_affine = _make_aseg()
+    gifti_points = {
+        "lh.white.gii": _lh_gifti_points(),
+        "lh.pial.gii": _lh_gifti_points(),
+    }
+    fake_nib, fake_freesurfer = _install_fake_nibabel(
+        monkeypatch, aseg, aseg_affine, gifti_points
+    )
+    fake_freesurfer.read_annot.return_value = (
+        _lh_annot_labels(),
+        np.zeros((len(names), 5)),
+        list(names),
+    )
+    return str(m2m), str(annot_path), fake_nib, fake_freesurfer
+
+
+# ===========================================================================
+# CorticalROI dataclass
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestCorticalROIDataclass:
+    def test_defaults(self):
+        roi = CorticalROI(atlas_path="/a.annot", label=5)
+        assert roi.hemisphere == "lh"
+        assert roi.tissues == "GM"
+
+    def test_rejects_empty_label(self):
+        with pytest.raises(ValueError, match="label must be non-empty"):
+            CorticalROI(atlas_path="/a.annot", label=[])
+
+    def test_rejects_mismatched_atlas_path_length(self):
+        with pytest.raises(ValueError, match="atlas_path must be a scalar"):
+            CorticalROI(atlas_path=["/a.annot", "/b.annot"], label=[1, 2, 3])
+
+    def test_rejects_mismatched_hemisphere_length(self):
+        with pytest.raises(ValueError, match="hemisphere must be a scalar"):
+            CorticalROI(
+                atlas_path="/a.annot", label=[1, 2], hemisphere=["lh", "rh", "lh"]
+            )
+
+    def test_union_of_labels_accepted(self):
+        roi = CorticalROI(
+            atlas_path="/a.annot", label=[1, 2], hemisphere=["lh", "rh"], tissues="both"
+        )
+        assert roi.label == [1, 2]
+        assert roi.tissues == "both"
+
+
+# ===========================================================================
+# ROIResolver.resolve_roi dispatch
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestResolveRoiDispatch:
+    def test_still_rejects_atlas_roi(self):
+        """Regression: switching resolve_roi's AtlasROI check from
+        duck-typing (``hasattr(roi, "hemisphere")``) to an isinstance check
+        must not stop rejecting the real surface-only AtlasROI -- both
+        AtlasROI and the new CorticalROI carry a ``hemisphere`` attribute,
+        so hasattr alone can no longer tell them apart.
+        """
+        from tit.opt.roi import ROIResolver
+
+        mesh = _make_mock_mesh([[0, 0, 0]], [2])
+        resolver = ROIResolver(mesh)
+        with pytest.raises(ValueError, match="AtlasROI"):
+            resolver.resolve_roi(AtlasROI(atlas_path="/a.annot", label=1))
+
+    def test_dispatches_cortical_roi_to_projection(self, monkeypatch, tmp_path):
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, _, _ = _setup_subject(monkeypatch, tmp_path)
+        mesh = _make_mock_mesh(
+            [[5.0, 5.0, 5.0], [5.0, 5.0, 6.0]],
+            [2, 2],
+        )
+        resolver = ROIResolver(mesh, m2m_path)
+        idx, vol = resolver.resolve_roi(
+            CorticalROI(atlas_path=annot_path, label=5, hemisphere="lh")
+        )
+        assert set(idx.tolist()) == {0, 1}
+
+
+# ===========================================================================
+# ROIResolver._resolve_cortical_surface
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestResolveCorticalSurface:
+    def test_requires_m2m_path(self):
+        from tit.opt.roi import ROIResolver
+
+        mesh = _make_mock_mesh([[0, 0, 0]], [2])
+        resolver = ROIResolver(mesh, m2m_path=None)
+        with pytest.raises(ValueError, match="m2m_path is required"):
+            resolver.resolve_roi(CorticalROI(atlas_path="/a.annot", label=5))
+
+    def test_label_lookup_failure_gives_clear_error(self, monkeypatch, tmp_path):
+        """Acceptance criterion: label lookup failure must be a clear error."""
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, _, _ = _setup_subject(monkeypatch, tmp_path)
+        mesh = _make_mock_mesh([[5.0, 5.0, 5.0]], [2])
+        resolver = ROIResolver(mesh, m2m_path)
+
+        with pytest.raises(ValueError, match="Label index 99 not found"):
+            resolver.resolve_roi(
+                CorticalROI(atlas_path=annot_path, label=99, hemisphere="lh")
+            )
+
+    def test_label_with_zero_vertices_gives_clear_error(self, monkeypatch, tmp_path):
+        from tit.opt.roi import ROIResolver
+
+        # "c" (index 3) exists in the colour table but no vertex carries it.
+        m2m_path, annot_path, _, _ = _setup_subject(monkeypatch, tmp_path)
+        mesh = _make_mock_mesh([[5.0, 5.0, 5.0]], [2])
+        resolver = ROIResolver(mesh, m2m_path)
+
+        with pytest.raises(ValueError, match="zero vertices"):
+            resolver.resolve_roi(
+                CorticalROI(atlas_path=annot_path, label=3, hemisphere="lh")
+            )
+
+    def test_empty_projection_after_gm_ribbon_intersection(self, monkeypatch, tmp_path):
+        """Acceptance criterion: empty projection must be a clear error.
+
+        Vertex 2 carries the target label but sits at an aseg voxel tagged
+        White-Matter, not cortex -- if it were the *only* masked vertex,
+        the GM-ribbon intersection must drop every candidate voxel and
+        raise, rather than silently returning an empty-but-successful ROI.
+        """
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, _, fake_freesurfer = _setup_subject(monkeypatch, tmp_path)
+        # Only vertex 2 (off-ribbon) carries the target label this time.
+        fake_freesurfer.read_annot.return_value = (
+            np.array([0, 0, 5, 0, 0, 0]),
+            np.zeros((6, 5)),
+            ["unknown", "a", "b", "c", "d", "target"],
+        )
+        mesh = _make_mock_mesh([[2.0, 2.0, 2.0]], [2])
+        resolver = ROIResolver(mesh, m2m_path)
+
+        with pytest.raises(ValueError, match="0 voxels after intersecting"):
+            resolver.resolve_roi(
+                CorticalROI(atlas_path=annot_path, label=5, hemisphere="lh")
+            )
+
+    def test_missing_aseg_segmentation_gives_clear_error(self, monkeypatch, tmp_path):
+        from tit.opt.roi import ROIResolver
+
+        m2m = tmp_path / "m2m_missing_aseg"
+        (m2m / "segmentation").mkdir(parents=True)
+        (m2m / "surfaces").mkdir(parents=True)
+        annot_path = m2m / "segmentation" / "lh.test_a2009s.annot"
+        annot_path.write_bytes(b"")
+        fake_nib = MagicMock()
+        fake_freesurfer = MagicMock()
+        fake_nib.freesurfer = fake_freesurfer
+        monkeypatch.setitem(sys.modules, "nibabel", fake_nib)
+        monkeypatch.setitem(sys.modules, "nibabel.freesurfer", fake_freesurfer)
+
+        mesh = _make_mock_mesh([[0.0, 0.0, 0.0]], [2])
+        resolver = ROIResolver(mesh, str(m2m))
+        with pytest.raises(ValueError, match="aseg segmentation"):
+            resolver.resolve_roi(CorticalROI(atlas_path=str(annot_path), label=5))
+
+    def test_missing_surface_gives_clear_error(self, monkeypatch, tmp_path):
+        from tit.opt.roi import ROIResolver
+
+        m2m = tmp_path / "m2m_no_surf"
+        (m2m / "segmentation").mkdir(parents=True)
+        (m2m / "surfaces").mkdir(parents=True)
+        annot_path = m2m / "segmentation" / "lh.test_a2009s.annot"
+        annot_path.write_bytes(b"")
+        (m2m / "segmentation" / "labeling.nii.gz").write_bytes(b"")
+        # White/pial surfaces intentionally not created.
+
+        aseg, aseg_affine = _make_aseg()
+        fake_nib = MagicMock()
+        fake_nib.load.return_value = SimpleNamespace(dataobj=aseg, affine=aseg_affine)
+        monkeypatch.setitem(sys.modules, "nibabel", fake_nib)
+        fake_freesurfer = MagicMock()
+        fake_freesurfer.read_annot.return_value = (
+            _lh_annot_labels(),
+            np.zeros((6, 5)),
+            ["unknown", "a", "b", "c", "d", "target"],
+        )
+        monkeypatch.setitem(sys.modules, "nibabel.freesurfer", fake_freesurfer)
+        fake_nib.freesurfer = fake_freesurfer
+
+        mesh = _make_mock_mesh([[5.0, 5.0, 5.0]], [2])
+        resolver = ROIResolver(mesh, str(m2m))
+        with pytest.raises(ValueError, match="white/pial surface"):
+            resolver.resolve_roi(
+                CorticalROI(atlas_path=str(annot_path), label=5, hemisphere="lh")
+            )
+
+    def test_rejects_invalid_hemisphere(self, monkeypatch, tmp_path):
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, _, _ = _setup_subject(monkeypatch, tmp_path)
+        mesh = _make_mock_mesh([[5.0, 5.0, 5.0]], [2])
+        resolver = ROIResolver(mesh, m2m_path)
+        with pytest.raises(ValueError, match="hemisphere must be 'lh' or 'rh'"):
+            resolver.resolve_roi(
+                CorticalROI(atlas_path=annot_path, label=5, hemisphere="center")
+            )
+
+    def test_known_region_resolves_expected_elements_only(self, monkeypatch, tmp_path):
+        """Acceptance criterion: a known region's expected volume.
+
+        The synthetic subject places the target label's GM-ribbon voxels at
+        (5,5,5) and (5,5,6) only -- vertex 2 carries the same label but its
+        voxel is tagged white matter and must be excluded by the GM-ribbon
+        intersection. The leadfield mesh has a GM element at each of the
+        three candidate voxels; only the two true-GM ones may be selected.
+        """
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, _, _ = _setup_subject(monkeypatch, tmp_path)
+        mesh = _make_mock_mesh(
+            barycenters=[
+                [5.0, 5.0, 5.0],  # in-ribbon -> expected match
+                [5.0, 5.0, 6.0],  # in-ribbon -> expected match
+                [2.0, 2.0, 2.0],  # off-ribbon (WM aseg tag) -> must be excluded
+                [9.0, 9.0, 9.0],  # far away, irrelevant GM element
+            ],
+            tags=[2, 2, 2, 2],
+            volumes=[1.5, 2.5, 3.5, 4.5],
+        )
+        resolver = ROIResolver(mesh, m2m_path)
+        idx, vol = resolver.resolve_roi(
+            CorticalROI(atlas_path=annot_path, label=5, hemisphere="lh")
+        )
+
+        assert set(idx.tolist()) == {0, 1}
+        assert sorted(vol.tolist()) == [1.5, 2.5]
+
+    def test_tissue_filter_excludes_wm_elements(self, monkeypatch, tmp_path):
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, _, _ = _setup_subject(monkeypatch, tmp_path)
+        mesh = _make_mock_mesh(
+            barycenters=[[5.0, 5.0, 5.0], [5.0, 5.0, 6.0]],
+            tags=[2, 1],  # second element is WM, not GM
+        )
+        resolver = ROIResolver(mesh, m2m_path)
+        idx, _ = resolver.resolve_roi(
+            CorticalROI(atlas_path=annot_path, label=5, hemisphere="lh", tissues="GM")
+        )
+        assert idx.tolist() == [0]
+
+    def test_caches_projection_across_calls(self, monkeypatch, tmp_path):
+        """Acceptance/task-2: the projection must be memoized per-resolver so
+        resolving the same CorticalROI twice (e.g. roi then a "specific"
+        non_roi referencing it) doesn't redo the annot read + rasterization.
+        """
+        from tit.opt.roi import ROIResolver
+
+        m2m_path, annot_path, fake_nib, fake_freesurfer = _setup_subject(
+            monkeypatch, tmp_path
+        )
+        mesh = _make_mock_mesh([[5.0, 5.0, 5.0], [5.0, 5.0, 6.0]], [2, 2])
+        resolver = ROIResolver(mesh, m2m_path)
+        roi = CorticalROI(atlas_path=annot_path, label=5, hemisphere="lh")
+
+        resolver.resolve_roi(roi)
+        annot_calls_after_first = fake_freesurfer.read_annot.call_count
+        resolver.resolve_roi(roi)
+        annot_calls_after_second = fake_freesurfer.read_annot.call_count
+
+        assert annot_calls_after_first == 1
+        assert annot_calls_after_second == 1  # no repeat read on the cache hit
+
+    def test_union_across_two_labels(self, monkeypatch, tmp_path):
+        """A two-label union (mirrors AtlasROI's union semantics) should
+        combine both labels' matched elements."""
+        from tit.opt.roi import ROIResolver
+
+        m2m = tmp_path / "m2m_union"
+        seg_dir = m2m / "segmentation"
+        surf_dir = m2m / "surfaces"
+        seg_dir.mkdir(parents=True)
+        surf_dir.mkdir(parents=True)
+        annot_path = seg_dir / "lh.test_a2009s.annot"
+        annot_path.write_bytes(b"")
+        (seg_dir / "labeling.nii.gz").write_bytes(b"")
+        (surf_dir / "lh.white.gii").write_bytes(b"")
+        (surf_dir / "lh.pial.gii").write_bytes(b"")
+
+        aseg, aseg_affine = _make_aseg()
+        aseg[7, 7, 7] = 3  # a second cortex voxel for the second label
+        gifti_points = {
+            "lh.white.gii": np.array(
+                [[5.0, 5.0, 5.0], [7.0, 7.0, 7.0], [0.0, 0.0, 0.0]]
+            ),
+            "lh.pial.gii": np.array(
+                [[5.0, 5.0, 5.0], [7.0, 7.0, 7.0], [0.0, 0.0, 0.0]]
+            ),
+        }
+        fake_nib, fake_freesurfer = _install_fake_nibabel(
+            monkeypatch, aseg, aseg_affine, gifti_points
+        )
+        fake_freesurfer.read_annot.return_value = (
+            np.array([5, 6, 0]),
+            np.zeros((7, 5)),
+            ["unknown", "a", "b", "c", "d", "five", "six"],
+        )
+
+        mesh = _make_mock_mesh(
+            barycenters=[[5.0, 5.0, 5.0], [7.0, 7.0, 7.0]], tags=[2, 2]
+        )
+        resolver = ROIResolver(mesh, str(m2m))
+        idx, _ = resolver.resolve_roi(
+            CorticalROI(atlas_path=str(annot_path), label=[5, 6], hemisphere="lh")
+        )
+        assert set(idx.tolist()) == {0, 1}

--- a/tit/config_io.py
+++ b/tit/config_io.py
@@ -44,6 +44,7 @@ _TYPE_DISCRIMINATED: dict[type, str] = {
     FlexConfig.SphericalROI: "SphericalROI",
     FlexConfig.AtlasROI: "AtlasROI",
     FlexConfig.SubcorticalROI: "SubcorticalROI",
+    FlexConfig.CorticalROI: "CorticalROI",
     ExConfig.PoolElectrodes: "PoolElectrodes",
     ExConfig.BucketElectrodes: "BucketElectrodes",
     Montage: "Montage",

--- a/tit/opt/config.py
+++ b/tit/opt/config.py
@@ -380,6 +380,72 @@ class FlexConfig:
                 )
 
     @dataclass
+    class CorticalROI:
+        """Cortical surface-atlas label, projected into the volumetric GM ribbon.
+
+        Field shape mirrors :class:`AtlasROI` exactly (same
+        *atlas_path*/*label*/*hemisphere* union semantics) -- only the
+        resolution target differs. :class:`AtlasROI` is evaluated directly
+        on the cortical surface by flex-search; ``CorticalROI`` instead
+        rasterizes the same ``.annot`` label into voxel space (sampling
+        along each masked vertex's white->pial "cortical column"),
+        intersects with the subject's aseg cortex ribbon
+        (``segmentation/labeling.nii.gz``, Left/Right-Cerebral-Cortex), and
+        matches the surviving voxels to volume tetrahedra. This is what lets
+        :class:`~tit.opt.roi.ROIResolver` hand a cortical atlas region to the
+        leadfield-based optimizers (:mod:`tit.opt.mp`), which have no notion
+        of a surface ROI and otherwise only accept :class:`SphericalROI` /
+        :class:`SubcorticalROI`.
+
+        Attributes
+        ----------
+        atlas_path : str or list of str
+            Path(s) to the FreeSurfer ``.annot`` annotation file(s).
+        label : int or list of int
+            Integer label index/indices within the annotation atlas -- the
+            position of the region in the ``.annot`` colour table, i.e. the
+            same indexing convention as :class:`AtlasROI.label`.
+        hemisphere : str or list of str
+            Hemisphere(s) to use (``"lh"`` or ``"rh"``), one per label.
+        tissues : str
+            Tissue compartments to include in the final volumetric match.
+            One of ``"GM"``, ``"WM"``, or ``"both"``. ``"GM"`` (default) is
+            almost always correct for a cortical label.
+
+        Raises
+        ------
+        ValueError
+            If *label* is empty, or *atlas_path*/*hemisphere* is a list whose
+            length neither equals 1 nor the number of labels.
+
+        See Also
+        --------
+        AtlasROI : The surface-only counterpart consumed directly by flex-search.
+        tit.opt.roi.ROIResolver : Performs the surface -> volume projection
+            and GM-ribbon intersection.
+        """
+
+        atlas_path: str | list[str]
+        label: int | list[int]
+        hemisphere: str | list[str] = "lh"
+        tissues: str = "GM"  # "GM", "WM", or "both"
+
+        def __post_init__(self):
+            n = len(_as_list(self.label))
+            if n == 0:
+                raise ValueError("CorticalROI label must be non-empty")
+            if len(_as_list(self.atlas_path)) not in (1, n):
+                raise ValueError(
+                    "CorticalROI atlas_path must be a scalar or match the number "
+                    "of labels"
+                )
+            if len(_as_list(self.hemisphere)) not in (1, n):
+                raise ValueError(
+                    "CorticalROI hemisphere must be a scalar or match the number "
+                    "of labels"
+                )
+
+    @dataclass
     class SubcorticalROI:
         """Subcortical volume ROI from a volumetric atlas.
 
@@ -948,13 +1014,15 @@ class MultiPolarConfig:
 
     Uses a precomputed leadfield matrix to optimize electrode placements
     and current weights for multi-channel TI stimulation via differential
-    evolution. AtlasROI is not supported; use SphericalROI or
-    SubcorticalROI.
+    evolution. Surface-only AtlasROI is not supported; use SphericalROI,
+    SubcorticalROI, or CorticalROI (an AtlasROI label projected into the
+    volumetric GM ribbon -- see :class:`FlexConfig.CorticalROI`).
 
     Attributes:
         subject_id: Subject identifier matching the m2m directory name.
         leadfield_hdf: Path to the precomputed leadfield HDF5 file.
-        roi: Target region of interest (SphericalROI or SubcorticalROI).
+        roi: Target region of interest (SphericalROI, SubcorticalROI, or
+            CorticalROI).
         n_pairs: Number of electrode pairs (must be an even number >= 2).
             Grouped into ``n_pairs // 2`` interference pairs per *scheme*
             (finding F11).
@@ -1051,13 +1119,13 @@ class MultiPolarConfig:
     # ── required ──
     subject_id: str
     leadfield_hdf: str
-    roi: "FlexConfig.SphericalROI | FlexConfig.SubcorticalROI"
+    roi: "FlexConfig.SphericalROI | FlexConfig.SubcorticalROI | FlexConfig.CorticalROI"
 
     # ── search ──
     n_pairs: int = 4
     current_mA: float = 2.0
     non_roi_method: str = "everything_else"
-    non_roi: "FlexConfig.SphericalROI | FlexConfig.SubcorticalROI | None" = None
+    non_roi: "FlexConfig.SphericalROI | FlexConfig.SubcorticalROI | FlexConfig.CorticalROI | None" = (None)
 
     # ── mTI pair grouping (finding F11) ──
     scheme: Literal["multiband", "dual_carrier"] = "multiband"
@@ -1087,10 +1155,12 @@ class MultiPolarConfig:
     def __post_init__(self):
         if self.n_pairs < 2 or self.n_pairs % 2 != 0:
             raise ValueError(f"n_pairs must be an even number >= 2, got {self.n_pairs}")
-        if hasattr(self.roi, "hemisphere"):
+        if isinstance(self.roi, FlexConfig.AtlasROI):
             raise ValueError(
-                "AtlasROI not supported for leadfield optimization. "
-                "Use SphericalROI or SubcorticalROI instead."
+                "AtlasROI (surface-only) is not supported for leadfield "
+                "optimization. Use SphericalROI, SubcorticalROI, or "
+                "CorticalROI (the same atlas label, projected into the "
+                "volumetric GM ribbon) instead."
             )
         if self.non_roi_method == "specific" and self.non_roi is None:
             raise ValueError("non_roi_method='specific' requires non_roi config")

--- a/tit/opt/mp/__main__.py
+++ b/tit/opt/mp/__main__.py
@@ -9,6 +9,7 @@ from tit.opt.mp.engine import run_mp_search
 _ROI_BUILDERS = {
     "SphericalROI": FlexConfig.SphericalROI,
     "SubcorticalROI": FlexConfig.SubcorticalROI,
+    "CorticalROI": FlexConfig.CorticalROI,
 }
 
 
@@ -17,6 +18,10 @@ def _build_roi(data: dict | None):
 
     Supports ``_type`` discriminator field. Falls back to field-based
     inference: ``x`` -> SphericalROI, ``atlas_path`` -> SubcorticalROI.
+    CorticalROI shares the ``atlas_path`` field with SubcorticalROI, so it
+    always relies on the ``_type`` discriminator (present on every config
+    serialized by ``tit.config_io``); the fallback only exists for
+    hand-written / pre-CorticalROI JSON.
     """
     if data is None:
         return None

--- a/tit/opt/roi.py
+++ b/tit/opt/roi.py
@@ -5,10 +5,15 @@ The leadfield is generated with ``tissues=[1,2]``, ``interpolation=None``,
 volume tetrahedra.  All ROI definitions operate on element barycenters
 of these volume elements.
 
-Surface-based ROI types (FreeSurfer ``.annot``) are **not** supported.
+A cortical surface ROI evaluated *directly on the surface*
+(``FlexConfig.AtlasROI``) is **not** supported -- there is no surface mesh
+here to evaluate it on.  A cortical *label*, however, can still be used: see
+``FlexConfig.CorticalROI``, which projects the same ``.annot`` label into
+this volume mesh's GM ribbon (:meth:`ROIResolver._resolve_cortical_surface`).
 """
 
 import logging
+import os
 
 import numpy as np
 
@@ -17,6 +22,10 @@ log = logging.getLogger(__name__)
 WM_TAG = 1
 GM_TAG = 2
 
+# aseg-style cortex tags in segmentation/labeling.nii.gz (labeling_LUT.txt):
+# 3 = Left-Cerebral-Cortex, 42 = Right-Cerebral-Cortex.
+_ASEG_CORTEX_TAG = {"lh": 3, "rh": 42}
+
 
 def _tissue_tags(tissues: str) -> list[int]:
     """Map tissue string to element tag list."""
@@ -24,6 +33,15 @@ def _tissue_tags(tissues: str) -> list[int]:
     if tissues not in mapping:
         raise ValueError(f"tissues must be 'GM', 'WM', or 'both', got '{tissues}'")
     return mapping[tissues]
+
+
+def _broadcast_to(values: list, n: int) -> list:
+    """Repeat a single-element list to length *n*; pass a full-length list through.
+
+    Mirrors ``tit.opt.flex.utils._broadcast`` -- used to align a shared
+    CorticalROI field (e.g. one ``.annot`` path) with a list of labels.
+    """
+    return values * n if len(values) == 1 and n != 1 else values
 
 
 class ROIResolver:
@@ -42,6 +60,13 @@ class ROIResolver:
         self.m2m_path = m2m_path
         self._barycenters: np.ndarray | None = None
         self._volumes: np.ndarray | None = None
+        # Per-(atlas_path, hemisphere, label) cache of projected ribbon world
+        # coordinates -- the surface read + GIFTI load + rasterization in
+        # _resolve_cortical_surface is the expensive part; memoize it the
+        # same way barycenters/volumes are lazily cached above, so a resolver
+        # instance that resolves the same CorticalROI more than once (e.g.
+        # roi then non_roi="specific") doesn't redo the projection.
+        self._cortical_cache: dict[tuple[str, str, int], np.ndarray] = {}
 
     # ── Lazy cached mesh properties ──────────────────────────────────────
 
@@ -65,24 +90,34 @@ class ROIResolver:
 
         Parameters
         ----------
-        roi_config : SphericalROI | SubcorticalROI
+        roi_config : SphericalROI | SubcorticalROI | CorticalROI
             ROI definition from ``FlexConfig``.
 
         Raises
         ------
         ValueError
-            If an unsupported ROI type is passed (e.g. AtlasROI).
+            If an unsupported ROI type is passed (e.g. the surface-only
+            AtlasROI).
         """
-        if hasattr(roi_config, "hemisphere"):
-            raise ValueError(
-                "AtlasROI is not supported for leadfield-based optimization. "
-                "Use SphericalROI or SubcorticalROI (volumetric atlas) instead. "
-                "For surface-based ROI, use flex-search."
-            )
+        # Lazy import: keeps this module free of a hard tit.opt.config
+        # dependency at import time, matching the lazy-import pattern used
+        # for simnibs/nibabel/scipy elsewhere in this file.
+        from tit.opt.config import FlexConfig
 
-        if hasattr(roi_config, "x"):  # SphericalROI
+        if isinstance(roi_config, FlexConfig.AtlasROI):
+            raise ValueError(
+                "AtlasROI is not supported for leadfield-based optimization "
+                "(there is no surface mesh here to evaluate it on). Use "
+                "SphericalROI, SubcorticalROI (volumetric atlas), or "
+                "CorticalROI (the same atlas label projected into the "
+                "volumetric GM ribbon) instead. For surface-based ROI, use "
+                "flex-search."
+            )
+        if isinstance(roi_config, FlexConfig.SphericalROI):
             return self._resolve_spherical(roi_config)
-        if hasattr(roi_config, "atlas_path"):  # SubcorticalROI
+        if isinstance(roi_config, FlexConfig.CorticalROI):
+            return self._resolve_cortical_surface(roi_config)
+        if isinstance(roi_config, FlexConfig.SubcorticalROI):
             return self._resolve_volumetric_label(roi_config)
 
         raise ValueError(f"Unsupported ROI type: {type(roi_config).__name__}")
@@ -102,7 +137,7 @@ class ROIResolver:
         method : str
             ``"everything_else"`` — all GM elements minus ROI.
             ``"specific"`` — resolve *nonroi_config* as a separate ROI.
-        nonroi_config : SphericalROI | SubcorticalROI, optional
+        nonroi_config : SphericalROI | SubcorticalROI | CorticalROI, optional
             Required when *method* is ``"specific"``.
         """
         if method == "everything_else":
@@ -182,17 +217,6 @@ class ROIResolver:
         voxel_hom = np.hstack([voxel_ijk, ones])  # (N, 4)
         world_coords = (affine @ voxel_hom.T).T[:, :3]  # (N, 3)
 
-        # Tissue filter
-        tissue_tags = _tissue_tags(roi.tissues)
-        tissue_mask = np.isin(self.mesh.elm.tag1, tissue_tags)
-        tissue_idx = np.flatnonzero(tissue_mask)
-        tissue_centers = self.barycenters[tissue_idx]
-
-        # For each tissue element, check if nearest atlas voxel is close enough.
-        # Use a KDTree for efficient spatial lookup.
-        from scipy.spatial import cKDTree
-
-        tree = cKDTree(world_coords)
         # Voxel size determines the matching radius.
         #
         # Must be derived from the COLUMN NORMS of the direction matrix, not
@@ -207,24 +231,242 @@ class ROIResolver:
                 f"{roi.atlas_path} (computed {voxel_size}). The atlas affine "
                 f"may be degenerate."
             )
-        dists, _ = tree.query(tissue_centers, k=1)
-        match_mask = dists <= voxel_size * 1.5  # generous tolerance
 
-        matched_idx = tissue_idx[match_mask]
+        source = (
+            f"SubcorticalROI(atlas={roi.atlas_path}, label={roi.label}, "
+            f"{len(voxel_ijk)} atlas voxels)"
+        )
+        matched_idx, matched_vol = self._match_world_points_to_tissue(
+            world_coords, roi.tissues, voxel_size, source
+        )
         log.info(
             f"SubcorticalROI: atlas={roi.atlas_path}, label={roi.label}, "
             f"tissues={roi.tissues}, voxel_size={voxel_size:.3f}mm "
             f"→ {len(matched_idx)} elements"
         )
+        return matched_idx, matched_vol
+
+    def _resolve_cortical_surface(self, roi) -> tuple[np.ndarray, np.ndarray]:
+        """Resolve CorticalROI (an ``.annot`` label projected into the GM ribbon).
+
+        For each ``(atlas_path, hemisphere, label)`` triple in the
+        (possibly unioned) ROI spec:
+
+        1. Read the ``.annot`` file and find the vertices carrying *label*.
+        2. Load that hemisphere's white/pial surfaces
+           (``m2m_<subject>/surfaces/{hemi}.{white,pial}.gii`` -- vertex-
+           aligned 1:1 with the ``.annot``, both produced by the same CHARM
+           run) and, for every masked vertex, sample points along its
+           white -> pial "cortical column". This thickens the 2D vertex
+           label into the 3D GM ribbon.
+        3. Rasterize those sample points into the subject's aseg voxel grid
+           (``segmentation/labeling.nii.gz``) and keep only voxels tagged
+           Left/Right-Cerebral-Cortex (3/42 -- see ``labeling_LUT.txt``), so
+           the projection can't bleed past the true GM boundary into white
+           matter or an adjacent gyrus.
+
+        The surviving voxels (unioned across every label) are then matched
+        to tissue-filtered leadfield elements exactly like
+        :meth:`_resolve_volumetric_label`.
+        """
+        import nibabel as nib
+        import nibabel.freesurfer as nfs
+
+        if self.m2m_path is None:
+            raise ValueError("m2m_path is required to resolve a CorticalROI")
+
+        from tit.opt.config import _as_list
+
+        labels = [int(v) for v in _as_list(roi.label)]
+        n = len(labels)
+        atlas_paths = _broadcast_to(_as_list(roi.atlas_path), n)
+        hemis = _broadcast_to(_as_list(roi.hemisphere), n)
+
+        labeling_path = os.path.join(self.m2m_path, "segmentation", "labeling.nii.gz")
+        if not os.path.isfile(labeling_path):
+            raise ValueError(
+                "CorticalROI requires the subject's aseg segmentation at "
+                f"{labeling_path} (used for the GM-ribbon constraint), which "
+                "was not found."
+            )
+        aseg_img = nib.load(labeling_path)
+        aseg = np.asarray(aseg_img.dataobj)
+        aseg_affine = aseg_img.affine
+        inv_affine = np.linalg.inv(aseg_affine)
+        aseg_voxel_size = float(np.linalg.norm(aseg_affine[:3, :3], axis=0).max())
+
+        region_points = []
+        for label_idx, atlas_path, hemi in zip(labels, atlas_paths, hemis):
+            if hemi not in _ASEG_CORTEX_TAG:
+                raise ValueError(
+                    f"CorticalROI hemisphere must be 'lh' or 'rh', got {hemi!r}"
+                )
+
+            cache_key = (atlas_path, hemi, label_idx)
+            cached = self._cortical_cache.get(cache_key)
+            if cached is not None:
+                region_points.append(cached)
+                continue
+
+            vertex_labels, _ctab, names = nfs.read_annot(atlas_path)
+            if not (0 <= label_idx < len(names)):
+                names_dec = [
+                    nm.decode() if isinstance(nm, bytes) else str(nm) for nm in names
+                ]
+                raise ValueError(
+                    f"Label index {label_idx} not found in {atlas_path} "
+                    f"(valid range 0-{len(names) - 1}: {names_dec})"
+                )
+            vertex_mask = vertex_labels == label_idx
+            if not np.any(vertex_mask):
+                name = names[label_idx]
+                name = name.decode() if isinstance(name, bytes) else str(name)
+                raise ValueError(
+                    f"Region '{hemi}.{name}' (label {label_idx}) has zero "
+                    f"vertices in {atlas_path}."
+                )
+
+            surf_dir = os.path.join(self.m2m_path, "surfaces")
+            white_path = os.path.join(surf_dir, f"{hemi}.white.gii")
+            pial_path = os.path.join(surf_dir, f"{hemi}.pial.gii")
+            for surf_path in (white_path, pial_path):
+                if not os.path.isfile(surf_path):
+                    raise ValueError(
+                        f"CorticalROI requires a white/pial surface at "
+                        f"{surf_path}, which was not found. SimNIBS's CHARM "
+                        "segmentation should produce this under "
+                        "m2m_<subject>/surfaces/."
+                    )
+            white_coords = nib.load(white_path).darrays[0].data.astype(float)
+            pial_coords = nib.load(pial_path).darrays[0].data.astype(float)
+            if len(white_coords) != len(vertex_labels) or len(pial_coords) != len(
+                vertex_labels
+            ):
+                raise ValueError(
+                    f"Vertex count mismatch between {atlas_path} "
+                    f"({len(vertex_labels)} vertices) and {hemi} white/pial "
+                    f"surfaces ({len(white_coords)}/{len(pial_coords)}); "
+                    "cannot project this annotation onto these surfaces."
+                )
+
+            white_v = white_coords[vertex_mask]
+            pial_v = pial_coords[vertex_mask]
+
+            # Sample points along each vertex's white -> pial cortical column.
+            n_samples = 6
+            t = np.linspace(0.0, 1.0, n_samples)
+            samples = (
+                white_v[:, None, :] + t[None, :, None] * (pial_v - white_v)[:, None, :]
+            )
+            samples = samples.reshape(-1, 3)
+
+            # Rasterize into the aseg voxel grid.
+            homog = np.hstack([samples, np.ones((len(samples), 1))])
+            voxel_coords = (inv_affine @ homog.T).T[:, :3]
+            voxel_ijk = np.round(voxel_coords).astype(int)
+            shape = np.array(aseg.shape)
+            in_bounds = np.all((voxel_ijk >= 0) & (voxel_ijk < shape), axis=1)
+            voxel_ijk = voxel_ijk[in_bounds]
+
+            # Intersect with the aseg cortex ribbon so the projection can't
+            # bleed past the true GM boundary (labeling_LUT.txt: 3 =
+            # Left-Cerebral-Cortex, 42 = Right-Cerebral-Cortex).
+            cortex_tag = _ASEG_CORTEX_TAG[hemi]
+            voxel_vals = aseg[voxel_ijk[:, 0], voxel_ijk[:, 1], voxel_ijk[:, 2]]
+            voxel_ijk = np.unique(voxel_ijk[voxel_vals == cortex_tag], axis=0)
+
+            if len(voxel_ijk) == 0:
+                name = names[label_idx]
+                name = name.decode() if isinstance(name, bytes) else str(name)
+                raise ValueError(
+                    f"CorticalROI projection for '{hemi}.{name}' produced 0 "
+                    f"voxels after intersecting with the aseg cortex ribbon "
+                    f"(tag {cortex_tag}) in {labeling_path}. The white/pial "
+                    "surfaces may not share the same space as "
+                    "segmentation/labeling.nii.gz."
+                )
+
+            homog_v = np.hstack([voxel_ijk.astype(float), np.ones((len(voxel_ijk), 1))])
+            region_world = (aseg_affine @ homog_v.T).T[:, :3]
+            self._cortical_cache[cache_key] = region_world
+            region_points.append(region_world)
+
+        world_coords = np.vstack(region_points)
+        source = (
+            f"CorticalROI(atlas={_as_list(roi.atlas_path)}, "
+            f"hemisphere={_as_list(roi.hemisphere)}, label={labels})"
+        )
+        matched_idx, matched_vol = self._match_world_points_to_tissue(
+            world_coords, roi.tissues, aseg_voxel_size, source
+        )
+        log.info(
+            f"CorticalROI: {n} label(s), hemisphere(s)={_as_list(roi.hemisphere)}, "
+            f"tissues={roi.tissues} → {len(world_coords)} ribbon voxels → "
+            f"{len(matched_idx)} elements"
+        )
+        return matched_idx, matched_vol
+
+    def _match_world_points_to_tissue(
+        self,
+        world_coords: np.ndarray,
+        tissues: str,
+        voxel_size: float,
+        source: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Match a cloud of world-space (mm) points to tissue-filtered elements.
+
+        Shared final step for :meth:`_resolve_volumetric_label` (points =
+        atlas voxel centers) and :meth:`_resolve_cortical_surface` (points =
+        projected cortical-ribbon voxel centers): every tissue-filtered
+        leadfield element is kept if its barycenter falls within
+        ``voxel_size * 1.5`` of the nearest point in *world_coords*.
+
+        Parameters
+        ----------
+        world_coords : array, shape (N, 3)
+            Candidate world-space (mm) points defining the target region.
+        tissues : str
+            ``"GM"``, ``"WM"``, or ``"both"``.
+        voxel_size : float
+            Matching-radius basis (mm); the actual tolerance applied is
+            ``voxel_size * 1.5``.
+        source : str
+            Human-readable description of the ROI, used only in the
+            zero-match error message.
+
+        Raises
+        ------
+        ValueError
+            If *voxel_size* is non-positive/non-finite, or no tissue-filtered
+            element falls within tolerance of any point.
+        """
+        if not np.isfinite(voxel_size) or voxel_size <= 0:
+            raise ValueError(
+                f"Could not determine a voxel size to match {source} against "
+                f"the leadfield mesh (computed {voxel_size})."
+            )
+
+        tissue_tags = _tissue_tags(tissues)
+        tissue_mask = np.isin(self.mesh.elm.tag1, tissue_tags)
+        tissue_idx = np.flatnonzero(tissue_mask)
+        tissue_centers = self.barycenters[tissue_idx]
+
+        # Use a KDTree for efficient nearest-point spatial lookup.
+        from scipy.spatial import cKDTree
+
+        tree = cKDTree(world_coords)
+        dists, _ = tree.query(tissue_centers, k=1)
+        match_mask = dists <= voxel_size * 1.5  # generous tolerance
+
+        matched_idx = tissue_idx[match_mask]
         if len(matched_idx) == 0:
             raise ValueError(
-                f"SubcorticalROI resolved to 0 mesh elements "
-                f"(atlas={roi.atlas_path}, label={roi.label}, "
-                f"tissues={roi.tissues}). The label exists in the atlas "
-                f"({len(voxel_ijk)} voxels) but no {roi.tissues} element "
-                f"barycenter fell within {voxel_size * 1.5:.2f}mm of it. "
-                f"Check that the atlas and the leadfield mesh are in the same "
-                f"space, and that the tissue filter is not excluding the target."
+                f"{source} resolved to 0 mesh elements (tissues={tissues}). "
+                f"The region has {len(world_coords)} candidate point(s) but "
+                f"no {tissues} element barycenter fell within "
+                f"{voxel_size * 1.5:.2f}mm of any of them. Check that the "
+                "ROI source and the leadfield mesh are in the same space, "
+                "and that the tissue filter is not excluding the target."
             )
         return matched_idx, self.volumes[matched_idx]
 


### PR DESCRIPTION
## Summary

`segmentation/labeling.nii.gz` is aseg-style: cortex is one label per
hemisphere (3/42), so there's no volumetric insula label (or any other
individual gyrus). Cortical sub-regions only exist in surface atlases
(`.annot`). Flex-search can already target insula via `AtlasROI` on the
surface, but the leadfield-based optimizers (`tit/opt/mp/`) are volume-only
and `ROIResolver` explicitly rejected `AtlasROI`.

This adds `FlexConfig.CorticalROI`: a general (not insula-specific)
capability that projects an `.annot` cortical label into the volumetric GM
ribbon so `ROIResolver` can hand it to the leadfield-based optimizers
exactly like a `SubcorticalROI`.

- For each masked vertex in the atlas label, sample points along its
  white → pial "cortical column" (`m2m_<subject>/surfaces/{hemi}.{white,pial}.gii`,
  vertex-aligned 1:1 with the `.annot`), thickening the 2D vertex label
  into the 3D ribbon.
- Rasterize those samples into the subject's aseg voxel grid and keep only
  voxels tagged Left/Right-Cerebral-Cortex (3/42 per `labeling_LUT.txt`),
  so the projection can't bleed past the true GM boundary.
- Match the surviving voxels to tissue-filtered leadfield elements via the
  same KDTree-matching step `SubcorticalROI` already used (factored out
  into `ROIResolver._match_world_points_to_tissue`, shared by both paths).
- Per-resolver-instance cache of the projection, keyed by
  `(atlas_path, hemisphere, label)`, matching the lazy-caching pattern
  already used for `barycenters`/`volumes`.
- Wired through `MultiPolarConfig` (its `AtlasROI` rejection moved from
  `hasattr(roi, "hemisphere")` duck-typing to an explicit `isinstance`
  check, since `CorticalROI` also carries a `hemisphere` field) and through
  `tit/config_io.py`'s `_type` discriminator + `tit/opt/mp/__main__.py`'s
  `_ROI_BUILDERS`, so it round-trips through the same JSON config path
  every other ROI type uses.

**Scope note:** `tit/opt/ex/` (exhaustive search) does not currently
consume `ROIResolver`/`SubcorticalROI` at all -- it uses a separate
CSV-file-based ROI mechanism (`roi_name`/`roi_radius`). There was no
existing pattern there to extend consistently, so `CorticalROI` is wired
only into `tit/opt/mp/`, the actual (and only) `ROIResolver` consumer. No
GUI changes either -- there is currently no GUI tab for `tit/opt/mp/` at
all (it's CLI/API-only today).

## Validation: Dice against the surface AtlasROI baseline (real data)

Ran inside `idossha/simnibs:v2.4.0` against real `sub-ernie` / `sub-101`
leadfields (`/mnt/000`, not synthetic), targeting `lh.insula` (DK40, label
35). To compare apples-to-apples in one shared space, the surface
baseline is: the same label's `lh.central.gii` vertices, matched to
tissue-filtered leadfield elements via the exact same
`_match_world_points_to_tissue` helper `CorticalROI` itself uses.

| Subject | CorticalROI elements | Surface-baseline elements | Intersection | Dice | Baseline containment |
|---|---|---|---|---|---|
| sub-ernie | 14290 | 10167 | 10160 | **0.8308** | 99.93% |
| sub-101 | 17107 | 8612 | 8600 | **0.6688** | 99.86% |

The containment column (`\|A ∩ B\| / \|B\|`) is the more informative number
here: essentially the *entire* surface baseline is contained inside the
projected volumetric mask in both subjects. Dice alone is lower for
sub-101 because `CorticalROI` legitimately captures more GM-ribbon depth
than the thin single-surface-vertex baseline (which only matches within
~1.2-1.5mm of the central surface) -- that's the expected, correct
difference between a true volumetric ribbon and a 2D surface proxy, not a
targeting error. sub-101's finer-resolution segmentation (0.5-0.8mm voxels
vs sub-ernie's 1mm) makes this depth difference more pronounced.

Also ran a short end-to-end `tit/opt/mp/` DE search (2 iterations,
population 6) against the projected `lh.insula` `CorticalROI` mask on both
subjects -- both completed without error (best_focality 1.49 / ernie,
1.65 / sub-101; `success=False` only because 2 iterations isn't enough to
hit the convergence tolerance, not a failure of the ROI path).

## Test plan

- [x] `black tit/opt/roi.py tests/test_opt_roi.py` (and the other touched
      files) -- clean, `black --check` passes
- [x] `pytest tests/test_opt_roi.py -v` -- 18/18 passed (label lookup
      failure, empty-projection-after-GM-ribbon-intersection, a
      fully-deterministic known-region element/volume check, tissue
      filtering, union-of-labels, per-instance caching, and a regression
      test that `MultiPolarConfig`/`ROIResolver` still reject the
      surface-only `AtlasROI` now that the check is `isinstance`-based
      instead of `hasattr(roi, "hemisphere")`)
- [x] Full suite: `pytest tests/ -q` -- 2178 passed, 8 skipped (pre-existing
      skips), no regressions
- [x] Verified in `idossha/simnibs:v2.4.0` against real `sub-ernie` /
      `sub-101` data (leadfields, m2m directories, GIFTI surfaces) -- see
      Dice numbers above

Do not merge -- for review.