### PR TITLE
calc: adopt Hirata 2024 sign-agnostic TI form, port peak-HF carrier metric

### DIFF
--- a/tests/test_calc_mti.py
+++ b/tests/test_calc_mti.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env simnibs_python
+"""
+Unit tests for tit/calc.py additions -- mTI focality-core Phase 4 (tasks 3, 5).
+
+Two independent pieces of new/changed behaviour are covered here:
+
+1. ``get_TI_vectors`` was rewritten to Hirata et al. (2024)'s sign-agnostic
+   closed form. ``TestHirataFormEquivalence`` proves the rewrite is exactly
+   equivalent (not just numerically close) to the previous
+   preprocess-then-branch implementation, by keeping a verbatim copy of
+   that old implementation as a private reference (``_legacy_get_TI_vectors``
+   below) and comparing outputs to 1e-12 over >= 1e4 random field pairs, plus
+   a battery of hand-picked degenerate/boundary cases.
+
+2. ``compute_direct_field_peak_hf`` / ``_direct_field_peak_hf_actual`` were
+   ported from the ``albantakis`` collaborator branches (``mTI_testing`` /
+   ``mti_formain_cleanup``), see ``tit/calc.py``'s module docstring
+   "Attribution". ``TestDirectFieldPeakHF`` adapts her
+   ``tests/test_calc.py::TestDirectFieldMagnitude`` /
+   ``TestDirectFieldDirectional`` cases (which exercised
+   ``compute_direct_field_peak_hf`` alongside functions not ported here) to
+   this repo's conventions, dropping the ``MTIFieldMethod`` dispatch
+   argument that does not exist in this repo's ``tit/calc.py``.
+"""
+
+import sys
+import pytest
+import numpy as np
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tit.calc import (
+    get_TI_vectors,
+    compute_direct_field_peak_hf,
+)
+
+RNG = np.random.default_rng(1234)
+
+
+# ---------------------------------------------------------------------------
+# Reference (pre-Hirata-rewrite) implementation, kept ONLY for the
+# equivalence check below. This is a verbatim copy of get_TI_vectors as it
+# existed on `main` before tracks/active/mti-focality-core.md Phase 4 task 3
+# rewrote it to the Hirata sign-agnostic closed form. Do not use elsewhere.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_get_TI_vectors(E1_org, E2_org):
+    assert E1_org.shape == E2_org.shape, "E1 and E2 must have same shape"
+    assert E1_org.shape[1] == 3, "Vectors must be 3D"
+
+    E1 = E1_org.copy()
+    E2 = E2_org.copy()
+
+    idx_swap = np.linalg.norm(E2, axis=1) > np.linalg.norm(E1, axis=1)
+    E1[idx_swap], E2[idx_swap] = E2[idx_swap], E1_org[idx_swap]
+
+    idx_flip = np.sum(E1 * E2, axis=1) < 0
+    E2[idx_flip] = -E2[idx_flip]
+
+    normE1 = np.linalg.norm(E1, axis=1)
+    normE2 = np.linalg.norm(E2, axis=1)
+
+    denom = normE1 * normE2
+    denom[denom == 0] = 1.0
+    cosalpha = np.clip(np.sum(E1 * E2, axis=1) / denom, -1.0, 1.0)
+
+    regime1_mask = normE2 <= normE1 * cosalpha
+
+    TI_vectors = np.zeros_like(E1)
+
+    TI_vectors[regime1_mask] = 2.0 * E2[regime1_mask]
+
+    regime2_mask = ~regime1_mask
+    if np.any(regime2_mask):
+        h = E1[regime2_mask] - E2[regime2_mask]
+        h_norm = np.linalg.norm(h, axis=1)
+        h_norm[h_norm == 0] = 1.0
+        e_h = h / h_norm[:, None]
+        E2_parallel_component = np.sum(E2[regime2_mask] * e_h, axis=1)[:, None] * e_h
+        E2_perp = E2[regime2_mask] - E2_parallel_component
+        TI_vectors[regime2_mask] = 2.0 * E2_perp
+
+    return TI_vectors
+
+
+# ---------------------------------------------------------------------------
+# TestHirataFormEquivalence -- Task 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHirataFormEquivalence:
+    """get_TI_vectors (Hirata sign-agnostic form) must exactly reproduce
+    _legacy_get_TI_vectors (the old preprocess-then-branch form)."""
+
+    def test_bulk_random_pairs_1e12(self):
+        """>= 1e4 random field pairs, spanning several magnitude scales,
+        must match to 1e-12."""
+        n_total = 0
+        for scale in (1e-3, 1.0, 1e3):
+            for _ in range(20):
+                n = 200
+                E1 = scale * RNG.standard_normal((n, 3))
+                E2 = scale * RNG.standard_normal((n, 3))
+                new = get_TI_vectors(E1, E2)
+                old = _legacy_get_TI_vectors(E1, E2)
+                np.testing.assert_allclose(new, old, atol=1e-12, rtol=0)
+                n_total += n
+        assert n_total >= 10_000
+
+    def test_near_boundary_pairs(self):
+        """Random pairs constructed to sit close to the regime boundary
+        min(|E1|,|E2|) == sqrt(|E1.E2|), where the two formulations are
+        most likely to diverge numerically."""
+        n = 2000
+        # Build E2 as a small rotation/scaling of E1 so many pairs land
+        # near-parallel (a common near-boundary configuration).
+        E1 = RNG.standard_normal((n, 3))
+        jitter = 0.05 * RNG.standard_normal((n, 3))
+        E2 = 0.9 * E1 + jitter
+        new = get_TI_vectors(E1, E2)
+        old = _legacy_get_TI_vectors(E1, E2)
+        np.testing.assert_allclose(new, old, atol=1e-12, rtol=0)
+
+    def test_random_signs_and_orthogonality(self):
+        """Mix of near-orthogonal and near-antiparallel pairs."""
+        n = 2000
+        E1 = RNG.standard_normal((n, 3))
+        # Orthogonal complement (Gram-Schmidt against E1) plus small noise
+        E2_raw = RNG.standard_normal((n, 3))
+        proj = np.sum(E1 * E2_raw, axis=1, keepdims=True) / np.sum(
+            E1 * E1, axis=1, keepdims=True
+        )
+        E2_orth = E2_raw - proj * E1
+        new = get_TI_vectors(E1, E2_orth)
+        old = _legacy_get_TI_vectors(E1, E2_orth)
+        np.testing.assert_allclose(new, old, atol=1e-12, rtol=0)
+
+        E2_anti = -E1 + 0.01 * RNG.standard_normal((n, 3))
+        new2 = get_TI_vectors(E1, E2_anti)
+        old2 = _legacy_get_TI_vectors(E1, E2_anti)
+        np.testing.assert_allclose(new2, old2, atol=1e-12, rtol=0)
+
+    @pytest.mark.parametrize(
+        "E1,E2",
+        [
+            (np.array([[1.0, 0.0, 0.0]]), np.array([[0.0, 0.0, 0.0]])),
+            (np.array([[0.0, 0.0, 0.0]]), np.array([[1.0, 0.0, 0.0]])),
+            (np.array([[0.0, 0.0, 0.0]]), np.array([[0.0, 0.0, 0.0]])),
+            (np.array([[1.0, 0.0, 0.0]]), np.array([[1.0, 0.0, 0.0]])),
+            (np.array([[1.0, 0.0, 0.0]]), np.array([[-1.0, 0.0, 0.0]])),
+            (np.array([[2.0, 0.0, 0.0]]), np.array([[0.0, 3.0, 0.0]])),
+            (np.array([[1.0, 0.0, 0.0]]), np.array([[0.0, 1.0, 0.0]])),
+            (np.array([[1.0, 2.0, 3.0]]), np.array([[1.0, 2.0, 3.0]]) * 1e-9),
+        ],
+    )
+    def test_hand_picked_degenerate_cases(self, E1, E2):
+        new = get_TI_vectors(E1, E2)
+        old = _legacy_get_TI_vectors(E1, E2)
+        np.testing.assert_allclose(new, old, atol=1e-12, rtol=0)
+
+    def test_existing_regime1_and_regime2_fixtures_still_pass(self):
+        """Sanity cross-check against tests/test_calc.py's own fixtures --
+        the rewrite must not change get_TI_vectors's public behaviour."""
+        cases = [
+            (np.array([[2.0, 0.0, 0.0]]), np.array([[1.0, 0.0, 0.0]])),
+            (np.array([[1.0, 0.0, 0.0]]), np.array([[0.0, 1.0, 0.0]])),
+            (
+                np.array([[2.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 3.0, 0.0]]),
+                np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
+            ),
+        ]
+        for E1, E2 in cases:
+            new = get_TI_vectors(E1, E2)
+            old = _legacy_get_TI_vectors(E1, E2)
+            np.testing.assert_allclose(new, old, atol=1e-12, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# TestDirectFieldPeakHF -- Task 3 (ported from albantakis collaborator
+# branches, tests/test_calc.py::TestDirectFieldMagnitude /
+# TestDirectFieldDirectional)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDirectFieldPeakHF:
+    """Tests for compute_direct_field_peak_hf, adapted from the
+    albantakis collaborator branches' tests/test_calc.py."""
+
+    def test_parallel_pairs_have_expected_amplitude(self):
+        """Adapted from TestDirectFieldMagnitude::
+        test_parallel_pairs_have_expected_amplitude (mTI_testing /
+        mti_formain_cleanup). Signed vector sum of
+        [[2,0,0],[1,0,0],[4,0,0],[3,0,0]] -> [10,0,0], norm 10."""
+        fields = [
+            np.array([[2.0, 0.0, 0.0]]),
+            np.array([[1.0, 0.0, 0.0]]),
+            np.array([[4.0, 0.0, 0.0]]),
+            np.array([[3.0, 0.0, 0.0]]),
+        ]
+        peak = compute_direct_field_peak_hf(fields)
+        np.testing.assert_allclose(peak, [10.0], atol=1e-12)
+
+    def test_two_field_case_matches_direct_sum(self):
+        """K=1 (two fields): peak_hf = |E1 + E2|."""
+        E1 = np.array([[3.0, 0.0, 0.0]])
+        E2 = np.array([[0.0, 4.0, 0.0]])
+        peak = compute_direct_field_peak_hf([E1, E2])
+        np.testing.assert_allclose(peak, [5.0], atol=1e-12)
+
+    def test_cancelling_pairs_give_zero(self):
+        """Opposing pairs cancel exactly in the signed sum."""
+        fields = [
+            np.array([[1.0, 0.0, 0.0]]),
+            np.array([[-1.0, 0.0, 0.0]]),
+        ]
+        peak = compute_direct_field_peak_hf(fields)
+        np.testing.assert_allclose(peak, [0.0], atol=1e-12)
+
+    def test_multi_element_arrays(self):
+        n = 25
+        fields = [RNG.standard_normal((n, 3)) for _ in range(4)]
+        peak = compute_direct_field_peak_hf(fields)
+        expected = np.linalg.norm(sum(fields), axis=1)
+        assert peak.shape == (n,)
+        np.testing.assert_allclose(peak, expected, atol=1e-12)
+
+    def test_no_nans_for_random_inputs(self):
+        fields = [RNG.standard_normal((50, 3)) for _ in range(6)]
+        peak = compute_direct_field_peak_hf(fields)
+        assert not np.any(np.isnan(peak))
+        assert not np.any(np.isinf(peak))
+        assert np.all(peak >= 0)
+
+    def test_odd_number_of_fields_raises(self):
+        fields = [RNG.standard_normal((5, 3)) for _ in range(3)]
+        with pytest.raises(ValueError, match="even number"):
+            compute_direct_field_peak_hf(fields)
+
+    def test_single_field_raises(self):
+        with pytest.raises(ValueError, match="even number"):
+            compute_direct_field_peak_hf([RNG.standard_normal((5, 3))])
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="even number"):
+            compute_direct_field_peak_hf([])
+
+    def test_shape_mismatch_raises(self):
+        E1 = np.ones((5, 3))
+        E2 = np.ones((3, 3))
+        with pytest.raises(ValueError, match="identical shape"):
+            compute_direct_field_peak_hf([E1, E2])
+
+    def test_wrong_dimension_raises(self):
+        bad = np.array([[1.0, 2.0]])  # (1, 2), not (N, 3)
+        with pytest.raises(ValueError, match="shape"):
+            compute_direct_field_peak_hf([bad, bad])
+
+    def test_bounded_by_sum_of_norms(self):
+        """Triangle inequality: peak_hf <= sum(|field_i|)."""
+        for _ in range(20):
+            fields = [RNG.standard_normal((10, 3)) for _ in range(4)]
+            peak = compute_direct_field_peak_hf(fields)
+            upper_bound = sum(np.linalg.norm(f, axis=1) for f in fields)
+            np.testing.assert_array_less(peak, upper_bound + 1e-10)

--- a/tit/calc.py
+++ b/tit/calc.py
@@ -13,6 +13,25 @@ get_nTI_vectors
     Generalised N-channel TI via recursive binary-tree pairing.
 get_mTI_vectors
     4-channel mTI (convenience wrapper around :func:`get_TI_vectors`).
+compute_direct_field_peak_hf
+    Peak instantaneous carrier-field magnitude across N electrode pairs
+    (direction-free, worst-case phase-aligned carrier-exposure metric).
+
+Attribution
+-----------
+``compute_direct_field_peak_hf`` / ``_direct_field_peak_hf_actual`` were
+authored by a collaborator on the ``albantakis`` remote's ``mTI_testing`` /
+``mti_formain_cleanup`` branches (Larissa Albantakis; ``alba`` and
+``albantakis`` are two remote URLs for the same fork) and are **ported here
+with attribution**, not reimplemented -- see
+``tracks/active/mti-focality-core.md`` Phase 4. Her sibling function on the
+same branches, ``compute_full_field_directional_am_vectors`` /
+``_full_field_directional_am_components``, was deliberately **not** ported:
+it is a simplified precursor to the Fibonacci-sphere/chunked-projection
+directional-AM machinery landing separately, missing the
+``max(env_psi0, env_psi_pi) - min(env_psi0, env_psi_pi)`` swap that makes
+that version robust to per-pair envelope sign flips -- without the swap the
+amplitude can go non-physically negative in some configurations.
 """
 
 import numpy as np
@@ -22,9 +41,13 @@ def get_TI_vectors(E1_org, E2_org):
     """
     Calculate the temporal interference (TI) modulation amplitude vectors.
 
-    This function implements the Grossman et al. 2017 algorithm for computing
-    TI vectors that represent both the direction and magnitude of maximum
-    modulation amplitude when two sinusoidal electric fields interfere.
+    Implements the sign-agnostic closed form of the Grossman et al. 2017
+    TI algorithm (Hirata et al. 2024), which is exactly equivalent to the
+    original preprocess-then-branch formulation but needs no explicit
+    magnitude-ordering swap or acute-angle sign flip of the inputs, and no
+    redundant negated copy of ``E2`` inside the cross-product-equivalent
+    term: the regime boundary and both branches are expressed directly in
+    terms of ``|E1.E2|`` and ``min(|E1-E2|, |E1+E2|)``.
 
     PHYSICAL INTERPRETATION:
     When two electric fields E1(t) = E1*cos(2πf1*t) and E2(t) = E2*cos(2πf2*t)
@@ -33,12 +56,14 @@ def get_TI_vectors(E1_org, E2_org):
     - DIRECTION: Spatial direction of maximum envelope modulation
     - MAGNITUDE: Maximum envelope amplitude = 2 * effective_amplitude
 
-    ALGORITHM (Grossman et al. 2017):
-    1. Preprocessing: Ensure |E1| ≥ |E2| and acute angle α < π/2
-    2. Regime selection based on geometric relationship:
-       - Regime 1 (parallel): |E2| ≤ |E1|cos(α) → TI = 2*E2
-       - Regime 2 (oblique): |E2| > |E1|cos(α) → TI = 2*E2_perpendicular_to_h
-       where h = E1 - E2
+    ALGORITHM (Hirata et al. 2024 sign-agnostic form, equivalent to
+    Grossman et al. 2017):
+    ::
+
+        if min(|E1|,|E2|) <= sqrt(|E1.E2|):
+            TIamp = 2 * min(|E1|,|E2|)
+        else:
+            TIamp = 2 * |E1 x E2| / min(|E1-E2|, |E1+E2|)
 
     Parameters
     ----------
@@ -58,6 +83,11 @@ def get_TI_vectors(E1_org, E2_org):
     ----------
     Grossman, N. et al. (2017). Noninvasive Deep Brain Stimulation via
     Temporally Interfering Electric Fields. Cell, 169(6), 1029-1041.
+    Hirata, A. et al. (2024). Computationally efficient formula for
+    temporal interference stimulation. Computers in Biology and Medicine,
+    178, 108697. (sign-agnostic closed form adopted here; verified
+    equivalent to this function's previous implementation to <1e-12 over
+    >=1e4 random field pairs, see ``tests/test_calc_mti.py``.)
 
     See Also
     --------
@@ -68,79 +98,78 @@ def get_TI_vectors(E1_org, E2_org):
     assert E1_org.shape == E2_org.shape, "E1 and E2 must have same shape"
     assert E1_org.shape[1] == 3, "Vectors must be 3D"
 
-    # Work with copies to avoid modifying input arrays
-    E1 = E1_org.copy()
-    E2 = E2_org.copy()
+    E1 = E1_org
+    E2 = E2_org
 
-    # =================================================================
-    # PREPROCESSING STEP 1: Magnitude ordering |E1| ≥ |E2|
-    # =================================================================
-    # Ensures consistency by always treating E1 as the "stronger" field
-    # This simplifies the subsequent regime analysis
-    idx_swap = np.linalg.norm(E2, axis=1) > np.linalg.norm(E1, axis=1)
-    E1[idx_swap], E2[idx_swap] = E2[idx_swap], E1_org[idx_swap]
-
-    # =================================================================
-    # PREPROCESSING STEP 2: Acute angle constraint α < π/2
-    # =================================================================
-    # Ensures constructive interference by flipping E2 if dot product < 0
-    # This avoids destructive interference scenarios
-    idx_flip = np.sum(E1 * E2, axis=1) < 0
-    E2[idx_flip] = -E2[idx_flip]
-
-    # =================================================================
-    # GEOMETRIC PARAMETERS CALCULATION
-    # =================================================================
-    # Calculate field magnitudes and angle between vectors
     normE1 = np.linalg.norm(E1, axis=1)
     normE2 = np.linalg.norm(E2, axis=1)
-
-    # Safe cosine calculation to avoid division by zero and numerical errors
-    denom = normE1 * normE2
-    denom[denom == 0] = 1.0  # Prevent division by zero
-    cosalpha = np.clip(np.sum(E1 * E2, axis=1) / denom, -1.0, 1.0)
+    dot = np.sum(E1 * E2, axis=1)
 
     # =================================================================
-    # REGIME SELECTION CRITERION
+    # REGIME SELECTION -- sign-agnostic: min(|E1|,|E2|) <= sqrt(|E1.E2|)
     # =================================================================
-    # Critical condition from Grossman 2017: |E2| ≤ |E1| * cos(α)
-    # This determines whether E2 is "small" relative to E1's projection
-    regime1_mask = normE2 <= normE1 * cosalpha
+    min_norm = np.minimum(normE1, normE2)
+    regime1_mask = min_norm <= np.sqrt(np.abs(dot))
 
-    # Initialize output array
+    # The "small" field, raw (un-negated); ties go to E2, matching the
+    # strict '>' swap convention of the original preprocess-then-branch
+    # form (so this stays exactly equivalent, not just close).
+    use_E1_as_small = normE1 < normE2
+    Es_raw = np.where(use_E1_as_small[:, None], E1, E2)
+
+    # Acute-angle sign correction: this single scalar replaces the old
+    # explicit array swap + E2 negation -- both branches below apply it
+    # to the same "Es", so there is no separate canonicalization branch.
+    sign = np.where(dot < 0, -1.0, 1.0)
+    Es = sign[:, None] * Es_raw
+
     TI_vectors = np.zeros_like(E1)
 
     # =================================================================
-    # REGIME 1: PARALLEL ALIGNMENT (|E2| ≤ |E1| cos(α))
+    # REGIME 1: PARALLEL ALIGNMENT (min(|E1|,|E2|) <= sqrt(|E1.E2|))
     # =================================================================
-    # Physical interpretation: E2 is effectively "contained" within E1's projection
-    # The TI amplitude is determined entirely by E2's magnitude and direction
-    # Formula: TI = 2 * E2
-    TI_vectors[regime1_mask] = 2.0 * E2[regime1_mask]
+    # Formula: TI = 2 * Es
+    TI_vectors[regime1_mask] = 2.0 * Es[regime1_mask]
 
     # =================================================================
-    # REGIME 2: OBLIQUE CONFIGURATION (|E2| > |E1| cos(α))
+    # REGIME 2: OBLIQUE CONFIGURATION (min(|E1|,|E2|) > sqrt(|E1.E2|))
     # =================================================================
-    # Physical interpretation: E2 has significant perpendicular component to E1
-    # The TI is determined by the component of E2 perpendicular to h = E1 - E2
-    # Formula: TI = 2 * E2_perpendicular_to_h
+    # TI = 2 * component of Es perpendicular to h, where h is whichever
+    # of (E1-E2), (E1+E2) has the smaller norm -- equal in magnitude to
+    # 2*|E1 x E2| / min(|E1-E2|, |E1+E2|), with no negated-E2 copy needed
+    # to build the cross-product-equivalent term.
     regime2_mask = ~regime1_mask
     if np.any(regime2_mask):
-        # Calculate difference vector h = E1 - E2
-        h = E1[regime2_mask] - E2[regime2_mask]
+        a2 = E1[regime2_mask]
+        b2 = E2[regime2_mask]
+        dot2 = dot[regime2_mask]
+        h_minus = a2 - b2
+        h_plus = a2 + b2
+        # Which of (E1-E2), (E1+E2) has the smaller norm is decided from
+        # sign(dot) directly (dot>=0 -> h_minus, dot<0 -> h_plus; exactly
+        # equivalent to comparing the two norms, since
+        # |E1-E2|^2 - |E1+E2|^2 == -4*dot), NOT by comparing the two
+        # computed norms themselves: |E1-E2| and |E1+E2| differ by O(dot),
+        # so when dot is tiny relative to |E1|,|E2| (near-orthogonal
+        # fields) that comparison loses the sign to floating-point
+        # cancellation inside the two sqrt()s, while `dot` itself still
+        # carries it exactly.
+        use_minus = dot2 >= 0
+        h = np.where(use_minus[:, None], h_minus, h_plus)
         h_norm = np.linalg.norm(h, axis=1)
 
         # Handle degenerate case (h = 0) by setting unit norm
-        h_norm[h_norm == 0] = 1.0
-        e_h = h / h_norm[:, None]  # Unit vector along h
+        h_norm_safe = np.where(h_norm == 0, 1.0, h_norm)
+        e_h = h / h_norm_safe[:, None]  # Unit vector along h
 
-        # Project E2 onto h, then subtract to get perpendicular component
-        # E2_perp = E2 - proj_h(E2) = E2 - (E2·ĥ)ĥ
-        E2_parallel_component = np.sum(E2[regime2_mask] * e_h, axis=1)[:, None] * e_h
-        E2_perp = E2[regime2_mask] - E2_parallel_component
+        # Project Es onto h, then subtract to get perpendicular component
+        # Es_perp = Es - proj_h(Es) = Es - (Es.ĥ)ĥ
+        Es_r2 = Es[regime2_mask]
+        Es_parallel_component = np.sum(Es_r2 * e_h, axis=1)[:, None] * e_h
+        Es_perp = Es_r2 - Es_parallel_component
 
         # The TI vector in regime 2 is twice the perpendicular component
-        TI_vectors[regime2_mask] = 2.0 * E2_perp
+        TI_vectors[regime2_mask] = 2.0 * Es_perp
 
     return TI_vectors
 
@@ -258,3 +287,94 @@ def get_mTI_vectors(E1_org, E2_org, E3_org, E4_org):
     mTI_vectors = get_TI_vectors(TI_A, TI_B)
 
     return mTI_vectors
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Peak instantaneous carrier-field magnitude (ported from the albantakis
+# collaborator branches with attribution -- see module docstring
+# "Attribution"). This is additive: a new, direction-free carrier-exposure
+# metric, not an envelope/TI quantity, and does not change the behaviour of
+# anything above.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def compute_direct_field_peak_hf(fields):
+    """Peak instantaneous carrier-field magnitude across N electrode pairs.
+
+    A direction-free, worst-case *phase-aligned* carrier-exposure metric:
+    the norm of the signed vector sum of every pair field, i.e.::
+
+        peak_hf = |sum_i field_i|
+
+    assuming all HF carriers happen to line up at their peak instant. This
+    is a genuinely different quantity from everything else in this module
+    -- it is not an envelope/TI amplitude at all, it is a raw carrier
+    load/exposure bound (Finding F4 in ``tracks/active/mti-focality-core.md``:
+    carrier exposure is not currently reported by any TI-Toolbox optimizer).
+
+    Note this is distinct from :func:`tit.fields.hf_peak`, which is the
+    worst case *over both relative signs* of a single electrode pair
+    (``max(|E1+E2|, |E1-E2|)``). This function instead sums every pair's
+    field with one fixed sign, generalised to N >= 2 pairs.
+
+    Parameters
+    ----------
+    fields : sequence of np.ndarray, each shape (N, 3)
+        One field array per electrode pair, in the same ``[E1a, E1b, E2a,
+        E2b, ...]`` convention as :func:`get_nTI_vectors`; must be an even
+        count of at least 2.
+
+    Returns
+    -------
+    np.ndarray, shape (N,)
+        Peak instantaneous carrier-field magnitude [V/m].
+
+    Raises
+    ------
+    ValueError
+        If the field list has an odd length, fewer than 2 fields, or
+        mismatched/invalid shapes.
+
+    References
+    ----------
+    Ported with attribution from the ``albantakis`` collaborator branches
+    (``mTI_testing`` commit ``925a3e99``, ``mti_formain_cleanup``); see
+    module docstring "Attribution".
+
+    See Also
+    --------
+    tit.fields.hf_peak : The 2-pair, sign-maximised carrier-peak metric.
+    """
+    return _direct_field_peak_hf_actual(fields)
+
+
+def _direct_field_peak_hf_actual(fields):
+    """Return the peak instantaneous magnitude of the full carrier sum.
+
+    For the direct-field workflow we assume the HF carriers are
+    phase-aligned at the peak instant, so the peak field is the norm of
+    the signed vector sum of the pair fields.
+    """
+    arrs = _validate_field_list(fields)
+    total = np.sum(np.stack(arrs, axis=0), axis=0)
+    return np.linalg.norm(total, axis=1)
+
+
+def _validate_field_list(fields):
+    """Validate a list of (N, 3) field arrays for the direct-field metrics."""
+    arrs = [np.asarray(field, dtype=np.float64) for field in fields]
+    n = len(arrs)
+    if n < 2 or n % 2 != 0:
+        raise ValueError(
+            f"Direct-field mTI requires an even number of fields >= 2, got {n}"
+        )
+    ref_shape = arrs[0].shape
+    if len(ref_shape) != 2 or ref_shape[1] != 3:
+        raise ValueError(f"Fields must have shape (N, 3), got {ref_shape}")
+    for i, arr in enumerate(arrs[1:], start=2):
+        if arr.shape != ref_shape:
+            raise ValueError(
+                f"All fields must have identical shape; field 1 has "
+                f"{ref_shape}, field {i} has {arr.shape}"
+            )
+    return arrs


### PR DESCRIPTION
## Summary

Small, self-contained PR implementing Phase 4 tasks 3-5 of `tracks/active/mti-focality-core.md`
(local planning doc, gitignored). Branches off `main` directly — independent of PR #136
(`fix/mti-main-bugs`), which is still open, not merged, so nothing here depends on it.

## Task 1: Hirata 2024 sign-agnostic closed form in `get_TI_vectors`

Rewrote `tit/calc.py`'s `get_TI_vectors` from the old preprocess-then-branch form (explicit
magnitude-ordering swap + acute-angle sign flip of the inputs) to the closed form:

```
if min(|E1|,|E2|) <= sqrt(|E1.E2|):  TIamp = 2*min(|E1|,|E2|)
else:                                 TIamp = 2*|E1 x E2| / min(|E1-E2|, |E1+E2|)
```

No canonicalization branch or redundant negated-`E2` copy is needed.

**Equivalence test result:** `tests/test_calc_mti.py::TestHirataFormEquivalence` keeps a verbatim
copy of the old implementation (`_legacy_get_TI_vectors`, test-only) and compares outputs to the
new one. Result: **bit-identical (max abs diff = 0.0) over 400,000 random field pairs** across 200
seeds x 4 stress modes (plain random, near-orthogonal via Gram-Schmidt, near-parallel, near-
antiparallel) and magnitude scales spanning 1e-4 to 1e4. The committed test suite itself asserts
`atol=1e-12` over >=10,000 pairs plus a battery of hand-picked degenerate cases (zero fields,
identical fields, antiparallel, swapped magnitudes, near-parallel jitter).

One real bug surfaced by the equivalence test itself, fixed before landing: naively choosing
between `h = E1-E2` and `h = E1+E2` (regime 2) by comparing their two computed norms loses the
sign to floating-point cancellation when `E1.E2` is tiny relative to `|E1|,|E2|` (near-orthogonal
fields) — `|E1-E2|` and `|E1+E2|` round to the same float64 value even though the true difference
is `-4*(E1.E2)`. Fixed by deciding directly from `sign(E1.E2)` (exact, no cancellation), which is
also what the old swap+flip preprocessing effectively did. All existing `tests/test_calc.py`
tests for `get_TI_vectors`/`get_nTI_vectors`/`get_mTI_vectors` pass unchanged (same public
behaviour, not just close).

## Task 2: `get_dirTI` docstring typo — not present in this repo

Searched `resources/map-electrodes/tes_flex_optimization.py` and all of `tit/` for the typo
pattern `|(E1-E1)*n|` — **zero occurrences**. `get_dirTI` is only ever *imported and called* in
this repo (`resources/map-electrodes/tes_flex_optimization.py:38,3163,3167,3172` and
`tit/sim/TI.py:226`); it is never *defined or documented* here. The typo is real, but it lives in
the docstring of `simnibs.utils.TI_utils.get_dirTI` inside the **upstream SimNIBS package itself**
(confirmed at line 153 of `TI_utils.py`, both via a local SimNIBS 4.6 install and inside
`idossha/simnibs:v2.4.0`):

```python
TIamp = | |(E1+E2)*n| - |(E1-E1)*n| |   # docstring, wrong
...
TIamp = np.abs(
    np.abs(np.sum((E1 + E2) * dirvec, axis=1))
    - np.abs(np.sum((E1 - E2) * dirvec, axis=1))   # code, correct
)
```

TI-Toolbox vendors/patches `simnibs/optimization/tes_flex_optimization/tes_flex_optimization.py`
at Docker build time (`container/blueprint/Dockerfile.simnibs:183-184`), but does **not** vendor or
patch `simnibs/utils/TI_utils.py` at all. There is no existing mechanism in this repo to fix an
upstream-only docstring typo, and adding one (a new build-time monkeypatch script plus wiring into
`Dockerfile.simnibs`, mirroring `resources/patches/patch_nan_to_num.py`) felt like disproportionate
scope for a cosmetic, code-unaffecting typo, so this task is a documented no-op here rather than a
speculative new patch. Flagging so it isn't re-investigated as "still open" — it's confirmed real,
just out of this repo's reach without new infrastructure.

## Task 3: Port `compute_direct_field_peak_hf` (peak-HF carrier metric)

Ported `compute_direct_field_peak_hf` / `_direct_field_peak_hf_actual` from the `albantakis`
collaborator branches (`mTI_testing` commit `925a3e99`, `mti_formain_cleanup`; `alba` and
`albantakis` are two remote URLs for the same fork — Larissa Albantakis) into `tit/calc.py`,
additively, with a new "Attribution" section in the module docstring (this repo's `main` doesn't
yet have PR #136's `MTI_METRIC_*` port / its own Attribution section, since that PR is independent
and still open — this PR adds its own, scoped to what it actually contains).

The ported metric is a direction-free, worst-case *phase-aligned* carrier-exposure metric — the
norm of the signed vector sum of all pair fields (`peak_hf = |sum_i field_i|`) — genuinely
different from any envelope/TI quantity already in `tit/calc.py`. Dropped the collaborator's
`MTIFieldMethod` dispatch parameter (that enum/dispatch system doesn't exist in this repo's
`tit/calc.py`, and isn't needed for the port itself); `compute_direct_field_peak_hf(fields)` now
just takes the field list directly. Added a `See Also` cross-reference to the existing, related but
distinct `tit.fields.hf_peak` (2-pair, `max(|E1+E2|,|E1-E2|)`, worst case over *both* relative
signs) to avoid future confusion between the two.

Ported and adapted her tests from `tests/test_calc.py::TestDirectFieldMagnitude` /
`TestDirectFieldDirectional` into `tests/test_calc_mti.py::TestDirectFieldPeakHF`, dropping the
`MTIFieldMethod` argument and the calls to functions not ported here (`compute_botzanowski_*`,
`compute_grossman_ext_*`), and adding this repo's own edge-case coverage (odd/empty field lists,
shape mismatches, multi-element arrays, triangle-inequality bound).

**Explicitly not ported:** her sibling `compute_full_field_directional_am_vectors` /
`_full_field_directional_am_components` (same branches). Checked and confirmed it is a simplified
precursor to what's landing separately as `_grossman_ext_directional_am_components` — same
Fibonacci-sphere/chunked-projection structure, but missing the
`max(env_psi0, env_psi_pi) - min(env_psi0, env_psi_pi)` swap that makes that version robust to
per-pair envelope sign flips. Without the swap the amplitude can go non-physically negative in some
configurations. This repo's `mti_modulation_depth` (landing separately, verified <0.01% vs.
time-domain ground truth) already supersedes both in rigor. Documented in `tit/calc.py`'s module
docstring "Attribution" section so this isn't re-proposed later without this context.

## Quality gates

- `black tit/calc.py tests/` — clean, no changes needed.
- `pytest tests/ -q` — **host** (macOS, Python 3.14, mocked SimNIBS): 1959 passed, 8 skipped, 0
  failed. **Container** (`idossha/simnibs:v2.4.0`, real SimNIBS 4.6.0, Python 3.11.14, numpy
  1.26.4): 1962 passed, 5 skipped, 0 failed (the 3-test delta is PyQt5 GUI-import tests, skipped on
  host where PyQt5 isn't installed, run in-container where it is — same total either way).
  `tests/test_calc.py` + `tests/test_calc_mti.py` (70 tests) pass identically in both.
- Verified in-container per the track's request, since this touches core field math used by every
  2-pair TI simulation.

## Scope notes

- Only `tit/calc.py` and the new `tests/test_calc_mti.py` change. Nothing from Phase 1-3 or
  Phase 5-6 of `mti-focality-core.md` is touched (`mti_modulation_depth`, `MTI_METRIC_*`, the
  Botzanowski/Grossman-ext directional-AM machinery, flex-search focality goals, etc. all land
  separately).
- `get_nTI_vectors` / `get_mTI_vectors` / `tit/sim/mTI.py` / `tit/blender/vector_field_exporter.py`
  are unaffected in behavior — they all call through `get_TI_vectors`, which is exactly equivalent
  post-rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)