### PR TITLE
Add multipolar (4-pair) exhaustive search with a TI/mTI toggle

### DIFF
--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -23,6 +23,26 @@ def _all_py_sources() -> list[Path]:
     return sorted(GUI_ROOT.rglob("*.py"))
 
 
+def _mock_simnibs_ti_utils() -> None:
+    """Install minimal ``simnibs.utils.TI_utils`` stand-ins.
+
+    ``tit.gui.ex_search_tab`` imports ``tit.opt.ex.engine.ExSearchEngine``,
+    which does ``from simnibs.utils import TI_utils as TI`` at module level.
+    conftest.py's global mock hierarchy doesn't cover that specific
+    submodule, so tests that import ``tit.gui.ex_search_tab`` need this
+    stand-in first (real SimNIBS is unavailable outside Docker).
+    """
+    simnibs_mod = sys.modules.setdefault("simnibs", types.ModuleType("simnibs"))
+    utils_mod = sys.modules.setdefault(
+        "simnibs.utils", types.ModuleType("simnibs.utils")
+    )
+    ti_utils_mod = sys.modules.setdefault(
+        "simnibs.utils.TI_utils", types.ModuleType("simnibs.utils.TI_utils")
+    )
+    setattr(simnibs_mod, "utils", utils_mod)
+    setattr(utils_mod, "TI_utils", ti_utils_mod)
+
+
 # ============================================================================
 # Source-code hygiene checks (no Qt import needed)
 # ============================================================================
@@ -89,16 +109,7 @@ class TestGuiImports:
     def test_ex_search_config_writer_includes_project_dir(self):
         """GUI Ex-Search JSON includes project_dir required by backend CLI."""
         pytest.importorskip("PyQt5")
-
-        simnibs_mod = sys.modules.setdefault("simnibs", types.ModuleType("simnibs"))
-        utils_mod = sys.modules.setdefault(
-            "simnibs.utils", types.ModuleType("simnibs.utils")
-        )
-        ti_utils_mod = sys.modules.setdefault(
-            "simnibs.utils.TI_utils", types.ModuleType("simnibs.utils.TI_utils")
-        )
-        setattr(simnibs_mod, "utils", utils_mod)
-        setattr(utils_mod, "TI_utils", ti_utils_mod)
+        _mock_simnibs_ti_utils()
 
         from tit.gui.ex_search_tab import ExSearchTab
         from tit.opt.config import ExConfig
@@ -124,3 +135,16 @@ class TestGuiImports:
 
         assert data["project_dir"] == "/project"
         assert data["electrodes"]["_type"] == "BucketElectrodes"
+
+    @pytest.mark.unit
+    def test_ex_search_tab_compiles(self):
+        """tit/gui/ex_search_tab.py is syntactically valid Python.
+
+        Unlike the other tests in this class, this one needs no PyQt5 (or
+        any other import) at all -- py_compile only parses/compiles to
+        bytecode, it never executes module-level code -- so it actually
+        runs (not skips) on hosts without PyQt5 installed.
+        """
+        import py_compile
+
+        py_compile.compile(str(GUI_ROOT / "ex_search_tab.py"), doraise=True)

--- a/tests/test_opt_config.py
+++ b/tests/test_opt_config.py
@@ -592,3 +592,36 @@ class TestExResult:
         )
         assert result.results_csv is None
         assert result.config_json is None
+
+
+@pytest.mark.unit
+class TestSearchModeBackend:
+    """The TI/mTI mode -> backend mapping.
+
+    Lives in ``tit.opt.config`` rather than the GUI so the wiring is testable
+    without a display; PyQt5 is absent from the host test environment.
+    """
+
+    def test_ti_mode_selects_ex_backend(self):
+        from tit.opt.config import SEARCH_MODE_TI, ExConfig, search_backend_for_mode
+
+        assert search_backend_for_mode(SEARCH_MODE_TI) == ("tit.opt.ex", ExConfig)
+
+    def test_mti_mode_selects_mex_backend(self):
+        from tit.opt.config import SEARCH_MODE_MTI, MExConfig, search_backend_for_mode
+
+        assert search_backend_for_mode(SEARCH_MODE_MTI) == ("tit.opt.mex", MExConfig)
+
+    def test_unknown_mode_raises(self):
+        from tit.opt.config import search_backend_for_mode
+
+        with pytest.raises(ValueError, match="Unknown search mode"):
+            search_backend_for_mode("nope")
+
+    def test_two_carrier_architecture_maps_to_paired_channels(self):
+        """Pairs 1&3 share one carrier, 2&4 the other (Lee et al. 2022)."""
+        from tit.opt.config import MTI_CHANNEL_ARCHITECTURES
+
+        arch = dict(MTI_CHANNEL_ARCHITECTURES)
+        assert arch["Two independent channels"] is None
+        assert arch["Four pairs, two carriers"] == [([0, 2], [1, 3])]

--- a/tests/test_opt_mex.py
+++ b/tests/test_opt_mex.py
@@ -1,0 +1,578 @@
+"""Tests for tit/opt/mex/ -- multipolar (4-pair, 8-electrode) exhaustive search.
+
+Covers candidate generation (logic.py), the electrode mirror map and
+generalized bucket loader (ex/buckets.py), MExConfig round trips through
+config_io, the engine's ROI metric computation, and the carrier-grouping
+(``channels``) behavior that replaces the rejected recursive mTI dispatch.
+"""
+
+import json
+import math
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+# Ensure simnibs.utils.TI_utils is mocked before tit.opt.mex.engine (or
+# tit.opt.ex.engine, which it subclasses) is imported.
+for mod_name in ("simnibs.utils.TI_utils",):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# tit.opt.mex.logic -- candidate generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateMultipolarCombinations:
+    def test_bucket_cartesian_filters_non_distinct_electrodes(self):
+        from tit.opt.mex.logic import generate_multipolar_combinations
+
+        # e1_plus has two options; one ("X") collides with e4_minus, so only
+        # the combination built from "A" survives the all-distinct filter.
+        buckets = {
+            "e1_plus": ["A", "X"],
+            "e1_minus": ["B"],
+            "e2_plus": ["C"],
+            "e2_minus": ["D"],
+            "e3_plus": ["E"],
+            "e3_minus": ["F"],
+            "e4_plus": ["G"],
+            "e4_minus": ["X"],
+        }
+        combos = list(generate_multipolar_combinations(buckets, all_combinations=False))
+        assert combos == [("A", "B", "C", "D", "E", "F", "G", "X")]
+
+    def test_pool_mode_generates_permutations(self):
+        from tit.opt.mex.logic import (
+            count_multipolar_combinations,
+            generate_multipolar_combinations,
+        )
+
+        pool = [f"E{i}" for i in range(1, 9)]
+        count = count_multipolar_combinations(pool, all_combinations=True)
+        assert count == math.factorial(8)
+
+        combos = list(generate_multipolar_combinations(pool, all_combinations=True))
+        assert len(combos) == count
+        # Every candidate uses each pool electrode exactly once.
+        for combo in combos[:50]:
+            assert len(combo) == 8
+            assert set(combo) == set(pool)
+
+    def test_symmetric_within_pairs_collapses_cartesian_to_linear(self):
+        """|e1+| x |e1-| candidates collapse to ~|e1+| under symmetric mode."""
+        from tit.opt.mex.logic import count_multipolar_combinations
+
+        # Every bucket's electrodes need a mirror partner: the within-pair
+        # matcher requires all four pairs to resolve simultaneously (it is a
+        # product across pairs), not just e1.
+        mirror_map = {
+            "L1": "R1",
+            "R1": "L1",
+            "L2": "R2",
+            "R2": "L2",
+            "X": "Y",
+            "Y": "X",
+            "P": "Q",
+            "Q": "P",
+            "M": "N",
+            "N": "M",
+        }
+        buckets = {
+            "e1_plus": ["L1", "L2"],
+            "e1_minus": ["R1", "R2"],
+            "e2_plus": ["X"],
+            "e2_minus": ["Y"],
+            "e3_plus": ["P"],
+            "e3_minus": ["Q"],
+            "e4_plus": ["M"],
+            "e4_minus": ["N"],
+        }
+
+        # Unrestricted: full 2x2 cartesian product of e1_plus x e1_minus.
+        unrestricted = count_multipolar_combinations(buckets, all_combinations=False)
+        assert unrestricted == 4
+
+        # Symmetric: only mirrored (L1,R1) and (L2,R2) pairs survive -- linear
+        # in |e1+|, not |e1+| x |e1-|.
+        symmetric = count_multipolar_combinations(
+            buckets, all_combinations=False, symmetry_mirror_map=mirror_map
+        )
+        assert symmetric == len(buckets["e1_plus"])
+        assert symmetric == 2
+
+
+# ---------------------------------------------------------------------------
+# tit.opt.ex.buckets -- build_electrode_mirror_map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildElectrodeMirrorMap:
+    def test_maps_left_right_pairs_and_midline_to_self(self, tmp_path):
+        from tit.opt.ex.buckets import build_electrode_mirror_map
+
+        csv_path = tmp_path / "net.csv"
+        csv_path.write_text(
+            "L1,-30,10,5\n"
+            "R1,30,10,5\n"
+            "L2,-20,-40,5\n"
+            "R2,20,-40,5\n"
+            "CZ,0,50,80\n"
+        )
+
+        mirror = build_electrode_mirror_map(csv_path)
+
+        assert mirror["L1"] == "R1"
+        assert mirror["R1"] == "L1"
+        assert mirror["L2"] == "R2"
+        assert mirror["R2"] == "L2"
+        assert mirror["CZ"] == "CZ"
+
+
+# ---------------------------------------------------------------------------
+# tit.opt.ex.buckets -- generalized bucket loader (4-key default, 8-key mex)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGeneralizedBucketLoader:
+    def test_default_4key_json_roundtrip_unchanged(self, tmp_path):
+        from tit.opt.ex.buckets import BUCKET_KEYS, load_bucket_file, save_bucket_file
+
+        buckets = {
+            "e1_plus": ["A", "B"],
+            "e1_minus": ["C"],
+            "e2_plus": ["D"],
+            "e2_minus": ["E", "F"],
+        }
+        path = tmp_path / "buckets.json"
+        save_bucket_file(path, buckets)
+        loaded = load_bucket_file(path)
+
+        assert loaded == buckets
+        assert set(loaded) == set(BUCKET_KEYS)
+
+    def test_default_4key_aliases_still_curated(self):
+        """Existing 4-key callers keep the hand-curated BUCKET_ALIASES table."""
+        from tit.opt.ex.buckets import normalize_buckets
+
+        result = normalize_buckets({"e1_": ["Z"], "E2+": ["Y"]})
+        assert result["e1_minus"] == ["Z"]
+        assert result["e2_plus"] == ["Y"]
+
+    def test_8key_json_roundtrip(self, tmp_path):
+        from tit.opt.ex.buckets import load_bucket_file, save_bucket_file
+        from tit.opt.mex.logic import MEX_BUCKET_KEYS
+
+        buckets = {key: [f"{key}_A", f"{key}_B"] for key in MEX_BUCKET_KEYS}
+        path = tmp_path / "mex_buckets.json"
+        save_bucket_file(path, buckets, keys=MEX_BUCKET_KEYS)
+        loaded = load_bucket_file(path, keys=MEX_BUCKET_KEYS)
+
+        assert loaded == buckets
+        assert set(loaded) == set(MEX_BUCKET_KEYS)
+
+    def test_8key_csv_roundtrip_with_symbol_aliases(self, tmp_path):
+        from tit.opt.ex.buckets import load_bucket_file
+        from tit.opt.mex.logic import MEX_BUCKET_KEYS
+
+        csv_path = tmp_path / "mex_buckets.csv"
+        csv_path.write_text(
+            "e1+,A,B\n"
+            "e1-,C\n"
+            "e2+,D\n"
+            "e2-,E\n"
+            "e3+,F\n"
+            "e3-,G\n"
+            "e4+,H\n"
+            "e4-,I\n"
+        )
+        loaded = load_bucket_file(csv_path, keys=MEX_BUCKET_KEYS)
+
+        assert loaded["e1_plus"] == ["A", "B"]
+        assert loaded["e3_minus"] == ["G"]
+        assert loaded["e4_plus"] == ["H"]
+
+
+# ---------------------------------------------------------------------------
+# MExConfig -- construction and config_io round trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMExConfigValidation:
+    def _bucket_electrodes(self, **overrides):
+        defaults = dict(
+            e1_plus=["A"],
+            e1_minus=["B"],
+            e2_plus=["C"],
+            e2_minus=["D"],
+            e3_plus=["E"],
+            e3_minus=["F"],
+            e4_plus=["G"],
+            e4_minus=["H"],
+        )
+        defaults.update(overrides)
+        from tit.opt.config import MExConfig
+
+        return MExConfig.BucketElectrodes(**defaults)
+
+    def test_defaults(self):
+        from tit.opt.config import MExConfig
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="lf.hdf5",
+            roi_name="target",
+            electrodes=self._bucket_electrodes(),
+        )
+        assert config.roi_name == "target.csv"
+        assert config.current_mA == 2.0
+        assert config.channels is None
+        assert config.symmetric_bucket is False
+
+    def test_rejects_non_positive_current(self):
+        from tit.opt.config import MExConfig
+
+        with pytest.raises(ValueError):
+            MExConfig(
+                subject_id="001",
+                leadfield_hdf="lf.hdf5",
+                roi_name="target",
+                electrodes=self._bucket_electrodes(),
+                current_mA=0.0,
+            )
+
+    def test_symmetric_bucket_rejects_pool_electrodes(self):
+        from tit.opt.config import MExConfig
+
+        with pytest.raises(ValueError):
+            MExConfig(
+                subject_id="001",
+                leadfield_hdf="lf.hdf5",
+                roi_name="target",
+                electrodes=MExConfig.PoolElectrodes(electrodes=["E1"] * 8),
+                symmetric_bucket=True,
+            )
+
+    def test_rejects_unknown_symmetry_pairing(self):
+        from tit.opt.config import MExConfig
+
+        with pytest.raises(ValueError):
+            MExConfig(
+                subject_id="001",
+                leadfield_hdf="lf.hdf5",
+                roi_name="target",
+                electrodes=self._bucket_electrodes(),
+                symmetry_pairing="diagonal",
+            )
+
+
+@pytest.mark.unit
+class TestMExConfigConfigIO:
+    def test_bucket_electrodes_roundtrip(self, tmp_path):
+        from tit.config_io import read_config_json, write_config_json
+        from tit.opt.config import MExConfig
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="net_leadfield.hdf5",
+            roi_name="target",
+            electrodes=MExConfig.BucketElectrodes(
+                e1_plus=["A"],
+                e1_minus=["B"],
+                e2_plus=["C"],
+                e2_minus=["D"],
+                e3_plus=["E"],
+                e3_minus=["F"],
+                e4_plus=["G"],
+                e4_minus=["H"],
+            ),
+            current_mA=1.5,
+            channels=[([0, 2], [1, 3])],
+        )
+        path = write_config_json(config, prefix="mex_test")
+        try:
+            data = read_config_json(path)
+            assert data["electrodes"]["_type"] == "BucketElectrodes"
+            assert data["electrodes"]["e3_minus"] == ["F"]
+            assert data["roi_name"] == "target.csv"
+            assert data["current_mA"] == 1.5
+            assert data["channels"] == [[[0, 2], [1, 3]]]
+        finally:
+            os.unlink(path)
+
+    def test_pool_electrodes_and_channels_survive_main_rebuild(self):
+        from tit.config_io import serialize_config
+        from tit.opt.config import MExConfig
+        from tit.opt.mex.__main__ import _build_channels, _build_electrodes
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="net_leadfield.hdf5",
+            roi_name="target",
+            electrodes=MExConfig.PoolElectrodes(
+                electrodes=[f"E{i}" for i in range(1, 9)]
+            ),
+            channels=[([0, 2], [1, 3])],
+        )
+        data = json.loads(json.dumps(serialize_config(config)))
+
+        electrodes = _build_electrodes(data.pop("electrodes"))
+        channels = _build_channels(data.pop("channels"))
+
+        assert isinstance(electrodes, MExConfig.PoolElectrodes)
+        assert electrodes.electrodes == [f"E{i}" for i in range(1, 9)]
+        assert channels == [([0, 2], [1, 3])]
+
+    def test_absent_channels_rebuild_to_none(self):
+        from tit.config_io import serialize_config
+        from tit.opt.config import MExConfig
+        from tit.opt.mex.__main__ import _build_channels
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="lf.hdf5",
+            roi_name="target",
+            electrodes=MExConfig.PoolElectrodes(electrodes=["E1"] * 8),
+        )
+        data = json.loads(json.dumps(serialize_config(config)))
+        assert _build_channels(data.get("channels")) is None
+
+
+# ---------------------------------------------------------------------------
+# tit.opt.ex.results.save_run_config -- ExConfig/MExConfig polymorphism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSaveRunConfigPolymorphism:
+    """save_run_config (unchanged elsewhere) was generalized to accept either
+    ExConfig's total_current/current_step/channel_limit or MExConfig's flat
+    current_mA, and to build electrode_info from dataclass fields instead of
+    a hard-coded 4-key dict.
+    """
+
+    def test_ex_config_bucket_mode_unaffected(self, tmp_path):
+        from tit.opt.config import ExConfig
+        from tit.opt.ex.results import save_run_config
+
+        config = ExConfig(
+            subject_id="001",
+            leadfield_hdf="lf.hdf5",
+            roi_name="roi",
+            electrodes=ExConfig.BucketElectrodes(
+                e1_plus=["A"], e1_minus=["B"], e2_plus=["C"], e2_minus=["D"]
+            ),
+            total_current=2.0,
+            current_step=0.5,
+        )
+        path = save_run_config(config, 4, str(tmp_path), MagicMock())
+        data = json.loads(Path(path).read_text())
+
+        assert data["electrodes"] == {
+            "e1_plus": ["A"],
+            "e1_minus": ["B"],
+            "e2_plus": ["C"],
+            "e2_minus": ["D"],
+        }
+        assert data["total_current_mA"] == 2.0
+        assert "current_mA" not in data
+
+    def test_mex_config_bucket_mode_has_eight_keys_and_current_mA(self, tmp_path):
+        from tit.opt.config import MExConfig
+        from tit.opt.ex.results import save_run_config
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="lf.hdf5",
+            roi_name="roi",
+            electrodes=MExConfig.BucketElectrodes(
+                e1_plus=["A"],
+                e1_minus=["B"],
+                e2_plus=["C"],
+                e2_minus=["D"],
+                e3_plus=["E"],
+                e3_minus=["F"],
+                e4_plus=["G"],
+                e4_minus=["H"],
+            ),
+            current_mA=2.0,
+        )
+        path = save_run_config(config, 8, str(tmp_path), MagicMock())
+        data = json.loads(Path(path).read_text())
+
+        assert set(data["electrodes"]) == {
+            "e1_plus",
+            "e1_minus",
+            "e2_plus",
+            "e2_minus",
+            "e3_plus",
+            "e3_minus",
+            "e4_plus",
+            "e4_minus",
+        }
+        assert data["current_mA"] == 2.0
+        assert "total_current_mA" not in data
+
+
+# ---------------------------------------------------------------------------
+# tit.calc.get_mTI_vectors -- channels grouping changes the field (critical
+# correctness requirement: no recursive-envelope dispatch was reintroduced)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestChannelsGroupingAffectsField:
+    def test_shared_carrier_channels_differ_from_independent_pairs(self):
+        from tit.calc import get_mTI_vectors
+
+        rng = np.random.default_rng(0)
+        fields = [rng.normal(size=(20, 3)) for _ in range(4)]
+
+        independent = get_mTI_vectors(fields, channels=None)
+        shared_carrier = get_mTI_vectors(fields, channels=[([0, 2], [1, 3])])
+
+        assert independent.shape == (20, 3)
+        assert shared_carrier.shape == (20, 3)
+        assert not np.allclose(independent, shared_carrier)
+
+    def test_no_recursive_mti_dispatch_reintroduced(self):
+        """MExSearchEngine must not depend on compute_mti_metric_field/MTIMetric."""
+        import tit.calc as calc_mod
+        import tit.opt.config as config_mod
+        import tit.opt.mex.engine as engine_mod
+
+        assert not hasattr(calc_mod, "compute_mti_metric_field")
+        assert not hasattr(config_mod, "MTIMetric")
+        assert not hasattr(config_mod.MExConfig, "MTIMetric")
+        assert not hasattr(engine_mod, "compute_mti_metric_field")
+
+
+# ---------------------------------------------------------------------------
+# MExSearchEngine.compute_mti_field -- ROI metric keys
+# ---------------------------------------------------------------------------
+
+
+def _make_mex_engine(channels=None, logger=None):
+    if logger is None:
+        logger = MagicMock()
+    from tit.opt.mex.engine import MExSearchEngine
+
+    return MExSearchEngine(
+        leadfield_hdf="/fake/leadfield.hdf5",
+        roi_file="/fake/roi.csv",
+        roi_name="TestROI",
+        logger=logger,
+        channels=channels,
+    )
+
+
+def _setup_engine_fields(engine):
+    engine.leadfield = MagicMock()
+    engine.idx_lf = MagicMock()
+    engine.mesh = MagicMock()
+    engine.roi_indices = np.array([0, 1, 2])
+    engine.roi_volumes = np.array([1.0, 1.0, 1.0])
+    engine.gm_indices = np.array([0, 1, 2, 3, 4])
+    engine.gm_volumes = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+
+
+@pytest.mark.unit
+class TestMExSearchEngineInit:
+    def test_stores_channels(self):
+        engine = _make_mex_engine(channels=[([0, 2], [1, 3])])
+        assert engine.channels == [([0, 2], [1, 3])]
+        assert engine.roi_name == "TestROI"
+
+    def test_defaults_to_no_channels(self):
+        engine = _make_mex_engine()
+        assert engine.channels is None
+
+
+@pytest.mark.unit
+class TestComputeMtiField:
+    def test_computes_expected_roi_metric_keys(self):
+        import tit.opt.mex.engine as engine_mod
+
+        engine = _make_mex_engine(channels=[([0, 2], [1, 3])])
+        _setup_engine_fields(engine)
+
+        engine_mod.TI.get_field = MagicMock(
+            side_effect=[np.zeros((5, 3)) for _ in range(4)]
+        )
+        metric_vectors = np.array(
+            [
+                [0.1, 0.0, 0.0],
+                [0.2, 0.0, 0.0],
+                [0.3, 0.0, 0.0],
+                [0.15, 0.0, 0.0],
+                [0.25, 0.0, 0.0],
+            ]
+        )
+        engine_mod.get_mTI_vectors = MagicMock(return_value=metric_vectors)
+
+        electrodes = ("A1", "A2", "B1", "B2", "C1", "C2", "D1", "D2")
+        result = engine.compute_mti_field(electrodes, current_mA=2.0)
+
+        expected_keys = {
+            "TestROI_TImax_ROI",
+            "TestROI_TImean_ROI",
+            "TestROI_TImean_GM",
+            "TestROI_Focality",
+            "TestROI_n_elements",
+            "current_ch1_mA",
+            "current_ch2_mA",
+            "current_ch3_mA",
+            "current_ch4_mA",
+        }
+        assert set(result) == expected_keys
+        # roi_indices=[0,1,2] -> field_roi norms=[0.1,0.2,0.3]
+        assert result["TestROI_TImax_ROI"] == pytest.approx(0.3)
+        assert result["TestROI_TImean_ROI"] == pytest.approx(0.2)
+        assert result["TestROI_n_elements"] == 3
+        for i in range(1, 5):
+            assert result[f"current_ch{i}_mA"] == 2.0
+
+        assert engine_mod.TI.get_field.call_count == 4
+        engine_mod.TI.get_field.assert_any_call(
+            ["A1", "A2", 0.002], engine.leadfield, engine.idx_lf
+        )
+        engine_mod.TI.get_field.assert_any_call(
+            ["D1", "D2", 0.002], engine.leadfield, engine.idx_lf
+        )
+
+        call = engine_mod.get_mTI_vectors.call_args
+        assert call.kwargs["channels"] == [([0, 2], [1, 3])]
+        assert len(call.args[0]) == 4
+
+    def test_zero_roi_elements_returns_zeros(self):
+        import tit.opt.mex.engine as engine_mod
+
+        engine = _make_mex_engine()
+        _setup_engine_fields(engine)
+        engine.roi_indices = np.array([], dtype=int)
+        engine.roi_volumes = np.array([])
+
+        engine_mod.TI.get_field = MagicMock(
+            side_effect=[np.zeros((5, 3)) for _ in range(4)]
+        )
+        engine_mod.get_mTI_vectors = MagicMock(return_value=np.zeros((5, 3)))
+
+        electrodes = ("A1", "A2", "B1", "B2", "C1", "C2", "D1", "D2")
+        result = engine.compute_mti_field(electrodes, current_mA=1.0)
+
+        assert result["TestROI_TImax_ROI"] == 0.0
+        assert result["TestROI_TImean_ROI"] == 0.0
+        assert result["TestROI_n_elements"] == 0

--- a/tit/config_io.py
+++ b/tit/config_io.py
@@ -33,7 +33,7 @@ from dataclasses import asdict, fields, is_dataclass
 from enum import Enum
 from typing import Any
 
-from tit.opt.config import ExConfig, FlexConfig
+from tit.opt.config import ExConfig, FlexConfig, MExConfig
 from tit.sim.config import Montage
 
 # Mapping from class to discriminator string.
@@ -46,6 +46,8 @@ _TYPE_DISCRIMINATED: dict[type, str] = {
     FlexConfig.SubcorticalROI: "SubcorticalROI",
     ExConfig.PoolElectrodes: "PoolElectrodes",
     ExConfig.BucketElectrodes: "BucketElectrodes",
+    MExConfig.PoolElectrodes: "PoolElectrodes",
+    MExConfig.BucketElectrodes: "BucketElectrodes",
     Montage: "Montage",
 }
 

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -40,11 +40,78 @@ from tit.gui.components.help_icon import HelpIcon
 from tit.paths import get_path_manager
 from tit import logger as logging_util
 from tit.opt.ex.engine import ExSearchEngine
-from tit.opt.config import ExConfig
+from tit.opt.config import (
+    SEARCH_MODE_TI,
+    SEARCH_MODE_MTI,
+    MTI_CHANNEL_ARCHITECTURES,
+    search_backend_for_mode,
+)
+from tit.opt.config import ExConfig, MExConfig
+from tit.config_io import write_config_json
 from tit.gui.style import (
     FONT_HELP,
     FONT_MONOSPACE,
     FONT_SUBHEADING,
+)
+
+# ── TI / mTI search-mode wiring ──────────────────────────────────────────────
+#
+# One tab, one mode toggle: TI (2-pair, ExConfig, tit.opt.ex) or mTI (4-pair,
+# MExConfig, tit.opt.mex). These are module-level (not class) constants and
+# functions so the mode -> backend wiring is unit-testable without
+# instantiating any Qt widgets (PyQt5 is unavailable on some dev/CI hosts).
+
+
+#: Bucket key -> display label, shared by the mTI bucket editor and its
+#: pipeline-configuration log output.
+MEX_BUCKET_LABELS = {
+    "e1_plus": "E1+",
+    "e1_minus": "E1-",
+    "e2_plus": "E2+",
+    "e2_minus": "E2-",
+    "e3_plus": "E3+",
+    "e3_minus": "E3-",
+    "e4_plus": "E4+",
+    "e4_minus": "E4-",
+}
+
+#: Named carrier-architecture choices for ``MExConfig.channels``, shown in
+#: the mTI "Carrier Wiring" combo as (label, value) pairs. Four bipolar pairs
+#: can be wired as two independent TI channels or as one channel sharing two
+#: carriers (Lee et al. 2022) -- the two give materially different fields
+#: (differ in ~92% of mesh elements, up to 6x), so this is exposed as a
+#: deliberate named choice rather than raw index groups.
+MTI_MODE_HELP = (
+    "mTI (4-pair) mode searches four bipolar electrode pairs together and "
+    "scores each candidate with the multipolar TI envelope "
+    "(tit.calc.get_mTI_vectors), instead of the single interference "
+    "pattern TI mode gets from two pairs.\n\n"
+    "It needs eight electrode buckets (E1..E4, each +/-) instead of four, "
+    "and one current per pair instead of a total/step/limit sweep. Runs "
+    "go through tit.opt.mex (MExConfig) instead of tit.opt.ex (ExConfig)."
+)
+
+MTI_CHANNELS_HELP = (
+    "How the four current pairs are grouped into TI carriers:\n\n"
+    "Two independent channels (default): pairs 1&2 form one TI channel "
+    "and pairs 3&4 form a second, independent TI channel -- equivalent to "
+    "running two ordinary 2-pair TI searches together.\n\n"
+    "Four pairs, two carriers: all four pairs share two carriers, e.g. "
+    "pairs 1&3 vs 2&4 (Lee et al. 2022).\n\n"
+    "These two wirings are not interchangeable: they produce materially "
+    "different fields, differing in about 92% of mesh elements and up to "
+    "6x in places. Pick deliberately."
+)
+
+MTI_SYMMETRY_HELP = (
+    "When checked, only left/right mirrored electrode-pair candidates are "
+    "evaluated (mirroring derived from the selected leadfield's EEG net), "
+    "instead of the full combination of all eight buckets.\n\n"
+    "Symmetry pairing controls which pairs must mirror each other:\n"
+    "- Within each pair: each pair's own +/- electrodes mirror across the "
+    "midline.\n"
+    "- Cross pairs: additionally requires pair 1 <-> 3 and pair 2 <-> 4 to "
+    "mirror each other."
 )
 
 
@@ -524,7 +591,14 @@ class ExSearchTab(QtWidgets.QWidget):
             config_logger.info("")
             config_logger.info("Electrode Configuration:")
             config_logger.info("-" * 40)
-            if self.use_all_combinations:
+            if self._current_search_mode() == SEARCH_MODE_MTI:
+                config_logger.info(f"  Mode: mTI (4-pair, Bucketed)")
+                for key, values in getattr(self, "mex_buckets", {}).items():
+                    config_logger.info(
+                        f"  {MEX_BUCKET_LABELS[key]} electrodes ({len(values)}): "
+                        f"{', '.join(values)}"
+                    )
+            elif self.use_all_combinations:
                 config_logger.info(f"  Mode: All-Combinations (Exhaustive Search)")
                 config_logger.info(f"  Electrode Pool: {', '.join(self.e1_plus)}")
                 config_logger.info(f"  Total Electrodes: {len(self.e1_plus)}")
@@ -831,12 +905,32 @@ class ExSearchTab(QtWidgets.QWidget):
         # ROW 0, COLUMN 1: Electrode Selection
         # ============================================================
         electrode_container = QtWidgets.QGroupBox("Electrode Selection")
-        electrode_container.setFixedHeight(180)  # Fixed height for balance
+        electrode_container.setFixedHeight(
+            220
+        )  # Fixed height for balance (+search-mode row)
         electrode_main_layout = QtWidgets.QVBoxLayout(electrode_container)
         electrode_main_layout.setContentsMargins(10, 10, 10, 10)
         electrode_main_layout.setSpacing(8)
 
-        # Radio buttons for mode selection
+        # Search mode toggle: TI (2-pair, default) vs mTI (4-pair)
+        mode_layout = QtWidgets.QHBoxLayout()
+        mode_label = QtWidgets.QLabel("Search Mode:")
+        mode_label.setFixedWidth(90)
+        self.search_mode_combo = QtWidgets.QComboBox()
+        self.search_mode_combo.addItem("TI (2-pair)", SEARCH_MODE_TI)
+        self.search_mode_combo.addItem("mTI (4-pair)", SEARCH_MODE_MTI)
+        self.search_mode_combo.setToolTip(
+            "TI: standard 2-pair temporal interference. mTI: 4-pair "
+            "multipolar search scored with the N>2 mTI envelope."
+        )
+        mode_layout.addWidget(mode_label)
+        mode_layout.addWidget(self.search_mode_combo)
+        mode_layout.addWidget(HelpIcon(MTI_MODE_HELP, title="mTI Mode"))
+        mode_layout.addStretch()
+        electrode_main_layout.addLayout(mode_layout)
+
+        # Radio buttons for mode selection (TI only -- mTI is bucketed-only,
+        # see _build_mti_bucketed_panel)
         radio_layout = QtWidgets.QHBoxLayout()
         self.rb_bucketed = QtWidgets.QRadioButton("Bucketed Mode")
         self.rb_bucketed.setToolTip(
@@ -858,9 +952,10 @@ class ExSearchTab(QtWidgets.QWidget):
         self.electrode_stack = QtWidgets.QStackedWidget()
         electrode_main_layout.addWidget(self.electrode_stack)
 
-        # Build the two panels
+        # Build the panels: TI bucketed (0), TI all-combinations (1), mTI bucketed (2)
         self._build_bucketed_panel()
         self._build_all_combinations_panel()
+        self._build_mti_bucketed_panel()
 
         # Connect radio buttons to mode switching
         self.rb_bucketed.toggled.connect(lambda v: self._on_electrode_mode_changed())
@@ -868,6 +963,12 @@ class ExSearchTab(QtWidgets.QWidget):
             lambda v: self._on_electrode_mode_changed()
         )
         self._on_electrode_mode_changed()  # Initialize to correct panel
+
+        # Connect search-mode combo; the initial call to _on_search_mode_changed()
+        # happens at the end of setup_ui(), once every widget it touches exists.
+        self.search_mode_combo.currentIndexChanged.connect(
+            lambda _i: self._on_search_mode_changed()
+        )
 
         # Add electrode container to grid - Row 0, Column 1
         main_grid_layout.addWidget(electrode_container, 0, 1)
@@ -945,66 +1046,23 @@ class ExSearchTab(QtWidgets.QWidget):
         # ============================================================
         # ROW 1, COLUMN 1: Current Configuration
         # ============================================================
-        current_container = QtWidgets.QGroupBox("Current Configuration")
-        current_container.setFixedHeight(190)  # Match ROI selection height
-        current_layout = QtWidgets.QVBoxLayout(current_container)
+        self.current_container = QtWidgets.QGroupBox("Current Configuration")
+        self.current_container.setFixedHeight(
+            220
+        )  # Match ROI selection height (+mTI page)
+        current_layout = QtWidgets.QVBoxLayout(self.current_container)
         current_layout.setContentsMargins(10, 10, 10, 10)
         current_layout.setSpacing(8)
 
-        # Total current input
-        total_current_layout = QtWidgets.QHBoxLayout()
-        total_current_label = QtWidgets.QLabel("Total Current (mA):")
-        total_current_label.setFixedWidth(120)
-        self.total_current_spinbox = QtWidgets.QDoubleSpinBox()
-        self.total_current_spinbox.setRange(0.1, 10.0)
-        self.total_current_spinbox.setValue(2.0)  # Default 2mA (per user example)
-        self.total_current_spinbox.setSingleStep(0.1)
-        self.total_current_spinbox.setDecimals(1)
-        self.total_current_spinbox.setToolTip(
-            "Total current to distribute between channels"
-        )
-        total_current_layout.addWidget(total_current_label)
-        total_current_layout.addWidget(self.total_current_spinbox)
-        total_current_layout.addStretch()
-        current_layout.addLayout(total_current_layout)
+        # Stacked widget: TI current sweep (0) vs mTI per-pair current (1)
+        self.current_config_stack = QtWidgets.QStackedWidget()
+        current_layout.addWidget(self.current_config_stack)
 
-        # Current step size input
-        current_step_layout = QtWidgets.QHBoxLayout()
-        current_step_label = QtWidgets.QLabel("Current Step (mA):")
-        current_step_label.setFixedWidth(120)
-        self.current_step_spinbox = QtWidgets.QDoubleSpinBox()
-        self.current_step_spinbox.setRange(0.01, 2.0)
-        self.current_step_spinbox.setValue(0.2)  # Default 0.2mA (per user example)
-        self.current_step_spinbox.setSingleStep(0.01)
-        self.current_step_spinbox.setDecimals(2)
-        self.current_step_spinbox.setToolTip("Step size for current ratio iterations")
-        current_step_layout.addWidget(current_step_label)
-        current_step_layout.addWidget(self.current_step_spinbox)
-        current_step_layout.addStretch()
-        current_layout.addLayout(current_step_layout)
-
-        # Channel limit input
-        channel_limit_layout = QtWidgets.QHBoxLayout()
-        channel_limit_label = QtWidgets.QLabel("Channel Limit (mA):")
-        channel_limit_label.setFixedWidth(120)
-        self.channel_limit_spinbox = QtWidgets.QDoubleSpinBox()
-        self.channel_limit_spinbox.setRange(0.1, 10.0)
-        self.channel_limit_spinbox.setValue(1.6)  # Default 1.6mA (per user example)
-        self.channel_limit_spinbox.setSingleStep(0.1)
-        self.channel_limit_spinbox.setDecimals(1)
-        self.channel_limit_spinbox.setToolTip(
-            "Maximum current per channel (must be ≤ total current)"
-        )
-        channel_limit_layout.addWidget(channel_limit_label)
-        channel_limit_layout.addWidget(self.channel_limit_spinbox)
-        channel_limit_layout.addStretch()
-        current_layout.addLayout(channel_limit_layout)
-
-        # Add stretch to push content to top
-        current_layout.addStretch()
+        self._build_ti_current_panel()
+        self._build_mti_current_panel()
 
         # Add current container to grid - Row 1, Column 1
-        main_grid_layout.addWidget(current_container, 1, 1)
+        main_grid_layout.addWidget(self.current_container, 1, 1)
 
         # ============================================================
         # ROW 2, COLUMN 0-1: Leadfield Management (spanning both columns)
@@ -1106,6 +1164,11 @@ class ExSearchTab(QtWidgets.QWidget):
         # After self.subject_combo is created and added:
         self.subject_combo.currentTextChanged.connect(self.on_subject_selection_changed)
 
+        # Initialize mode-dependent panels/controls (TI is the default mode).
+        # Deferred to the very end: it touches run_btn/stop_btn/current_container,
+        # all created above.
+        self._on_search_mode_changed()
+
     def _build_bucketed_panel(self):
         """Build the bucketed mode electrode input panel (original mode)."""
         panel = QtWidgets.QWidget()
@@ -1169,6 +1232,256 @@ class ExSearchTab(QtWidgets.QWidget):
             self.electrode_stack.setCurrentIndex(0)  # Bucketed panel
         elif self.rb_all_combinations.isChecked():
             self.electrode_stack.setCurrentIndex(1)  # All combinations panel
+
+    def _build_mti_bucketed_panel(self):
+        """Build the mTI bucketed-mode electrode input panel (four pairs, eight buckets).
+
+        mTI only supports bucketed search -- there is no all-combinations
+        page for it, since the pool-permutation search space for eight
+        electrode positions is combinatorially far larger than for TI's
+        four. These are separate widgets from the TI bucketed panel's
+        e1_plus_input/etc. (a widget cannot live in two layouts at once).
+        """
+        panel = QtWidgets.QWidget()
+        layout = QtWidgets.QGridLayout(panel)
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setHorizontalSpacing(16)
+        layout.setVerticalSpacing(8)
+
+        self.mti_e1_plus_input = QtWidgets.QLineEdit()
+        self.mti_e1_minus_input = QtWidgets.QLineEdit()
+        self.mti_e2_plus_input = QtWidgets.QLineEdit()
+        self.mti_e2_minus_input = QtWidgets.QLineEdit()
+        self.mti_e3_plus_input = QtWidgets.QLineEdit()
+        self.mti_e3_minus_input = QtWidgets.QLineEdit()
+        self.mti_e4_plus_input = QtWidgets.QLineEdit()
+        self.mti_e4_minus_input = QtWidgets.QLineEdit()
+
+        # Keyed by MExConfig.BucketElectrodes field name so _current_mti_buckets()
+        # and _build_mex_config() can build the dataclass directly from this dict.
+        self.mti_bucket_inputs = {
+            "e1_plus": self.mti_e1_plus_input,
+            "e1_minus": self.mti_e1_minus_input,
+            "e2_plus": self.mti_e2_plus_input,
+            "e2_minus": self.mti_e2_minus_input,
+            "e3_plus": self.mti_e3_plus_input,
+            "e3_minus": self.mti_e3_minus_input,
+            "e4_plus": self.mti_e4_plus_input,
+            "e4_minus": self.mti_e4_minus_input,
+        }
+
+        placeholders = {
+            "e1_plus": "E.g., O1, F7",
+            "e1_minus": "E.g., Fp1, T7",
+            "e2_plus": "E.g., T8, P4",
+            "e2_minus": "E.g., Fz, Cz",
+            "e3_plus": "E.g., O2, F8",
+            "e3_minus": "E.g., Fp2, T7",
+            "e4_plus": "E.g., T7, P3",
+            "e4_minus": "E.g., Fz, Cz",
+        }
+        for key, field_widget in self.mti_bucket_inputs.items():
+            field_widget.setFixedHeight(30)
+            field_widget.setPlaceholderText(placeholders[key])
+            field_widget.setToolTip(
+                f"Electrodes for pair {key[1]} "
+                f"{'positive pole (anodes)' if key.endswith('plus') else 'negative pole (cathodes)'}"
+            )
+
+        left_keys = ["e1_plus", "e1_minus", "e2_plus", "e2_minus"]
+        right_keys = ["e3_plus", "e3_minus", "e4_plus", "e4_minus"]
+        for row, (lkey, rkey) in enumerate(zip(left_keys, right_keys)):
+            layout.addWidget(QtWidgets.QLabel(f"{MEX_BUCKET_LABELS[lkey]}:"), row, 0)
+            layout.addWidget(self.mti_bucket_inputs[lkey], row, 1)
+            layout.addWidget(QtWidgets.QLabel(f"{MEX_BUCKET_LABELS[rkey]}:"), row, 2)
+            layout.addWidget(self.mti_bucket_inputs[rkey], row, 3)
+
+        self.electrode_stack.addWidget(panel)
+
+    def _build_ti_current_panel(self):
+        """Build the TI (2-pair) current-configuration page.
+
+        Exact same widgets/defaults as before this tab grew an mTI mode --
+        only moved from directly on the group box into a QStackedWidget page.
+        """
+        panel = QtWidgets.QWidget()
+        current_layout = QtWidgets.QVBoxLayout(panel)
+        current_layout.setContentsMargins(0, 0, 0, 0)
+        current_layout.setSpacing(8)
+
+        # Total current input
+        total_current_layout = QtWidgets.QHBoxLayout()
+        total_current_label = QtWidgets.QLabel("Total Current (mA):")
+        total_current_label.setFixedWidth(120)
+        self.total_current_spinbox = QtWidgets.QDoubleSpinBox()
+        self.total_current_spinbox.setRange(0.1, 10.0)
+        self.total_current_spinbox.setValue(2.0)  # Default 2mA (per user example)
+        self.total_current_spinbox.setSingleStep(0.1)
+        self.total_current_spinbox.setDecimals(1)
+        self.total_current_spinbox.setToolTip(
+            "Total current to distribute between channels"
+        )
+        total_current_layout.addWidget(total_current_label)
+        total_current_layout.addWidget(self.total_current_spinbox)
+        total_current_layout.addStretch()
+        current_layout.addLayout(total_current_layout)
+
+        # Current step size input
+        current_step_layout = QtWidgets.QHBoxLayout()
+        current_step_label = QtWidgets.QLabel("Current Step (mA):")
+        current_step_label.setFixedWidth(120)
+        self.current_step_spinbox = QtWidgets.QDoubleSpinBox()
+        self.current_step_spinbox.setRange(0.01, 2.0)
+        self.current_step_spinbox.setValue(0.2)  # Default 0.2mA (per user example)
+        self.current_step_spinbox.setSingleStep(0.01)
+        self.current_step_spinbox.setDecimals(2)
+        self.current_step_spinbox.setToolTip("Step size for current ratio iterations")
+        current_step_layout.addWidget(current_step_label)
+        current_step_layout.addWidget(self.current_step_spinbox)
+        current_step_layout.addStretch()
+        current_layout.addLayout(current_step_layout)
+
+        # Channel limit input
+        channel_limit_layout = QtWidgets.QHBoxLayout()
+        channel_limit_label = QtWidgets.QLabel("Channel Limit (mA):")
+        channel_limit_label.setFixedWidth(120)
+        self.channel_limit_spinbox = QtWidgets.QDoubleSpinBox()
+        self.channel_limit_spinbox.setRange(0.1, 10.0)
+        self.channel_limit_spinbox.setValue(1.6)  # Default 1.6mA (per user example)
+        self.channel_limit_spinbox.setSingleStep(0.1)
+        self.channel_limit_spinbox.setDecimals(1)
+        self.channel_limit_spinbox.setToolTip(
+            "Maximum current per channel (must be ≤ total current)"
+        )
+        channel_limit_layout.addWidget(channel_limit_label)
+        channel_limit_layout.addWidget(self.channel_limit_spinbox)
+        channel_limit_layout.addStretch()
+        current_layout.addLayout(channel_limit_layout)
+
+        # Add stretch to push content to top
+        current_layout.addStretch()
+
+        self.current_config_stack.addWidget(panel)
+
+    def _build_mti_current_panel(self):
+        """Build the mTI (4-pair) current-configuration page.
+
+        One current per pair (MExConfig.current_mA) instead of TI's
+        total/step/limit sweep, plus the carrier-architecture (channels)
+        and symmetric-bucket-search controls that only apply to mTI.
+        """
+        panel = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(panel)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        # Pair current input
+        pair_current_layout = QtWidgets.QHBoxLayout()
+        pair_current_label = QtWidgets.QLabel("Pair Current (mA):")
+        pair_current_label.setFixedWidth(120)
+        self.mex_current_spinbox = QtWidgets.QDoubleSpinBox()
+        self.mex_current_spinbox.setRange(0.1, 10.0)
+        self.mex_current_spinbox.setValue(2.0)  # MExConfig.current_mA default
+        self.mex_current_spinbox.setSingleStep(0.1)
+        self.mex_current_spinbox.setDecimals(1)
+        self.mex_current_spinbox.setToolTip(
+            "Current delivered by each of the four bipolar electrode pairs"
+        )
+        pair_current_layout.addWidget(pair_current_label)
+        pair_current_layout.addWidget(self.mex_current_spinbox)
+        pair_current_layout.addStretch()
+        layout.addLayout(pair_current_layout)
+
+        # Carrier architecture (MExConfig.channels)
+        channels_layout = QtWidgets.QHBoxLayout()
+        channels_label = QtWidgets.QLabel("Carrier Wiring:")
+        channels_label.setFixedWidth(120)
+        self.mex_channels_combo = QtWidgets.QComboBox()
+        for label, value in MTI_CHANNEL_ARCHITECTURES:
+            self.mex_channels_combo.addItem(label, value)
+        channels_layout.addWidget(channels_label)
+        channels_layout.addWidget(self.mex_channels_combo)
+        channels_layout.addWidget(HelpIcon(MTI_CHANNELS_HELP, title="Carrier Wiring"))
+        channels_layout.addStretch()
+        layout.addLayout(channels_layout)
+
+        # Symmetric bucket search (MExConfig.symmetric_bucket / symmetry_pairing)
+        symmetric_layout = QtWidgets.QHBoxLayout()
+        self.mex_symmetric_bucket_cb = QtWidgets.QCheckBox("Force left/right symmetry")
+        self.mex_symmetric_bucket_cb.setToolTip(
+            "Only evaluate candidates whose electrode pairs mirror left/right"
+        )
+        self.mex_symmetry_pairing_combo = QtWidgets.QComboBox()
+        self.mex_symmetry_pairing_combo.addItem("Within each pair", "within_pairs")
+        self.mex_symmetry_pairing_combo.addItem(
+            "Cross pairs (E1<->E3, E2<->E4)", "cross_pairs"
+        )
+        self.mex_symmetry_pairing_combo.setEnabled(False)
+        self.mex_symmetric_bucket_cb.toggled.connect(
+            self.mex_symmetry_pairing_combo.setEnabled
+        )
+        symmetric_layout.addWidget(self.mex_symmetric_bucket_cb)
+        symmetric_layout.addWidget(
+            HelpIcon(MTI_SYMMETRY_HELP, title="Symmetric Bucket Search")
+        )
+        symmetric_layout.addSpacing(12)
+        symmetric_layout.addWidget(self.mex_symmetry_pairing_combo)
+        symmetric_layout.addStretch()
+        layout.addLayout(symmetric_layout)
+
+        layout.addStretch()
+        self.current_config_stack.addWidget(panel)
+
+    def _current_search_mode(self):
+        """Return the active search mode: SEARCH_MODE_TI or SEARCH_MODE_MTI."""
+        return self.search_mode_combo.currentData()
+
+    def _current_mti_buckets(self):
+        """Return the eight mTI bucket fields as parsed electrode-name lists.
+
+        Mirrors the TI ``parse_electrode_input`` semantics: invalid text
+        (bad characters) parses to ``None``, normalised here to ``[]`` so
+        callers can uniformly treat "invalid" and "empty" as "not filled in".
+        """
+        return {
+            key: self.parse_electrode_input(field_widget.text()) or []
+            for key, field_widget in self.mti_bucket_inputs.items()
+        }
+
+    def _selected_roi_csv_names(self):
+        """Return .csv-suffixed ROI names for the currently selected ROI list items."""
+        names = []
+        for item in self.roi_list.selectedItems():
+            name = item.text().split(":")[0].strip()
+            if not name.endswith(".csv"):
+                name += ".csv"
+            names.append(name)
+        return names
+
+    def _on_search_mode_changed(self):
+        """Swap electrode/current panels and toggle mode-specific controls."""
+        is_mti = self._current_search_mode() == SEARCH_MODE_MTI
+
+        self.rb_bucketed.setVisible(not is_mti)
+        self.rb_all_combinations.setVisible(not is_mti)
+        if is_mti:
+            self.electrode_stack.setCurrentIndex(2)  # mTI bucketed panel
+        else:
+            self._on_electrode_mode_changed()  # Restore TI bucketed/all-combos choice
+
+        self.current_config_stack.setCurrentIndex(1 if is_mti else 0)
+        self.current_container.setTitle(
+            "mTI Configuration" if is_mti else "Current Configuration"
+        )
+
+        # MExConfig has no ROI-union equivalent to ExConfig.roi_names, so
+        # Combine ROIs only applies in TI mode.
+        self.combine_rois_cb.setEnabled(not is_mti)
+        if is_mti:
+            self.combine_rois_cb.setChecked(False)
+
+        self.run_btn.setText("Run mTI Search" if is_mti else "Run Ex-Search")
+        self.stop_btn.setText("Stop mTI Search" if is_mti else "Stop Ex-Search")
 
     def initial_setup(self):
         """Initial setup when the tab is first loaded."""
@@ -1568,6 +1881,20 @@ class ExSearchTab(QtWidgets.QWidget):
             )
             return False
 
+        # mTI validates its own eight electrode buckets; the TI
+        # all-combinations / bucketed validation below doesn't apply to it
+        # (mTI has no all-combinations page).
+        if self._current_search_mode() == SEARCH_MODE_MTI:
+            buckets = self._current_mti_buckets()
+            if not all(buckets.values()):
+                self.update_status(
+                    "Please enter valid electrodes for all eight mTI bucket "
+                    "categories (E1..E4, +/-)",
+                    error=True,
+                )
+                return False
+            return True
+
         # Validate electrode inputs based on mode
         if self.rb_all_combinations.isChecked():
             # All-combinations mode: validate single electrode list
@@ -1608,6 +1935,10 @@ class ExSearchTab(QtWidgets.QWidget):
     def run_optimization(self):
         """Run the ex-search optimization for selected subjects."""
         if not self.validate_inputs():
+            return
+
+        if self._current_search_mode() == SEARCH_MODE_MTI:
+            self._run_mti_optimization()
             return
 
         subject_id = self.subject_combo.currentText()
@@ -1736,6 +2067,86 @@ class ExSearchTab(QtWidgets.QWidget):
         # Run the pipeline for the first ROI
         self.run_roi_pipeline(subject_id, project_dir, ex_search_dir, env)
 
+    def _run_mti_optimization(self):
+        """Run the mTI (multipolar, 4-pair) exhaustive search for selected ROIs.
+
+        Mirrors the TI flow in ``run_optimization`` above: same
+        subject/leadfield/ROI plumbing, confirmation dialog, and per-ROI
+        pipeline via ``run_roi_pipeline``. mTI always searches bucketed
+        (there is no all-combinations page) and ``MExConfig`` has no
+        ROI-union equivalent to ``ExConfig.roi_names``, so ROIs are always
+        processed separately here (no Combine ROIs path).
+        """
+        subject_id = self.subject_combo.currentText()
+        project_dir = self.pm.project_dir
+        pm = self.pm
+        mex_search_dir = pm.m_ex_search(subject_id)
+
+        self.mex_buckets = self._current_mti_buckets()
+        self.use_all_combinations = False
+
+        selected_rois = self.roi_list.selectedItems()
+        roi_names = [item.text().split(":")[0].strip() for item in selected_rois]
+
+        bucket_counts = ", ".join(
+            f"{MEX_BUCKET_LABELS[key]}: {len(values)}"
+            for key, values in self.mex_buckets.items()
+        )
+        n_combos_upper = 1
+        for values in self.mex_buckets.values():
+            n_combos_upper *= len(values)
+
+        details = (
+            f"Subject: {subject_id}\n"
+            f"Mode: mTI (4-pair)\n"
+            f"{bucket_counts}\n"
+            f"Current per Pair: {self.mex_current_spinbox.value():.1f} mA\n"
+            f"Carrier Wiring: {self.mex_channels_combo.currentText()}\n"
+            f"Search Space: up to {n_combos_upper:,} eight-electrode combinations\n"
+            f"ROIs: {', '.join(roi_names)}\n"
+            f"Total ROIs: {len(roi_names)}"
+        )
+        if self.mex_symmetric_bucket_cb.isChecked():
+            details += (
+                f"\nSymmetric bucket search: "
+                f"{self.mex_symmetry_pairing_combo.currentText()}"
+            )
+
+        if not ConfirmationDialog.confirm(
+            self,
+            title="Confirm mTI Search",
+            message="Are you sure you want to start the mTI (multipolar) search?",
+            details=details,
+        ):
+            return
+
+        # Create m_ex_search directory if it doesn't exist
+        os.makedirs(mex_search_dir, exist_ok=True)
+
+        selected_roi_names = self._selected_roi_csv_names()
+        if self.debug_mode:
+            self.update_output(f"Selected ROI(s): {', '.join(selected_roi_names)}")
+
+        # Set up environment variables
+        env = os.environ.copy()
+        env["SUBJECTS_DIR"] = project_dir
+
+        # Disable controls and show status
+        self.disable_controls()
+        self.update_status(f"Running mTI search for subject {subject_id}...")
+
+        self._combine_rois = False
+        self._combined_roi_names = []
+        self.roi_processing_queue = selected_roi_names.copy()
+        self.current_roi_index = 0
+        self._exsearch_had_errors = False
+
+        # Log mTI search start
+        self.log_exsearch_start(subject_id, len(selected_roi_names))
+
+        # Run the pipeline for the first ROI
+        self.run_roi_pipeline(subject_id, project_dir, mex_search_dir, env)
+
     def _build_ex_config(
         self, subject_id, roi_name, leadfield_hdf, eeg_net, roi_names=None
     ):
@@ -1803,6 +2214,55 @@ class ExSearchTab(QtWidgets.QWidget):
         with os.fdopen(fd, "w") as f:
             json.dump(data, f, indent=2)
         return path
+
+    def _build_mex_config(self, subject_id, roi_name, leadfield_hdf, eeg_net):
+        """Build an MExConfig dataclass from current UI widget values (mTI mode).
+
+        Mirrors ``_build_ex_config`` above for the multipolar (4-pair)
+        backend: same subject/leadfield/roi/run_name shape, but electrodes
+        are always bucketed (eight buckets), current is a single
+        per-pair value, and channels/symmetric_bucket/symmetry_pairing
+        replace TI's total/step/limit sweep.
+
+        Args:
+            subject_id: Subject identifier.
+            roi_name: ROI name (with or without .csv extension).
+            leadfield_hdf: Full path to the leadfield HDF5 file.
+            eeg_net: Name of the selected EEG net.
+
+        Returns:
+            MExConfig instance ready for serialization.
+        """
+        electrodes = MExConfig.BucketElectrodes(**self.mex_buckets)
+        return MExConfig(
+            subject_id=subject_id,
+            leadfield_hdf=leadfield_hdf,
+            roi_name=roi_name,
+            electrodes=electrodes,
+            current_mA=self.mex_current_spinbox.value(),
+            channels=self.mex_channels_combo.currentData(),
+            roi_radius=self.roi_radius_spinbox.value(),
+            run_name=eeg_net,
+            symmetric_bucket=self.mex_symmetric_bucket_cb.isChecked(),
+            symmetry_pairing=self.mex_symmetry_pairing_combo.currentData(),
+        )
+
+    @staticmethod
+    def _write_mex_config(config):
+        """Serialize an MExConfig to a temporary JSON file.
+
+        Unlike TI's bespoke ``_write_ex_config`` (which predates it), this
+        delegates to the shared ``tit.config_io`` helper -- MExConfig's
+        electrode union types are already registered there, and it injects
+        ``project_dir`` from the active PathManager automatically.
+
+        Args:
+            config: MExConfig dataclass instance.
+
+        Returns:
+            Path to the written JSON config file.
+        """
+        return write_config_json(config, prefix="m_ex_config")
 
     def run_roi_pipeline(self, subject_id, project_dir, ex_search_dir, env):
         """Run the ex-search pipeline for the current ROI in the queue."""
@@ -1882,14 +2342,21 @@ class ExSearchTab(QtWidgets.QWidget):
                 self.run_roi_pipeline(subject_id, project_dir, ex_search_dir, env)
                 return
 
-        # Build ExConfig dataclass from UI state
-        ex_config = self._build_ex_config(
-            subject_id,
-            roi_name,
-            selected_hdf5_path,
-            selected_net_name,
-            roi_names=roi_names_for_config,
-        )
+        # Build the backend config dataclass from UI state: TI -> ExConfig via
+        # tit.opt.ex, mTI -> MExConfig via tit.opt.mex (see search_backend_for_mode).
+        search_mode = self._current_search_mode()
+        if search_mode == SEARCH_MODE_MTI:
+            ex_config = self._build_mex_config(
+                subject_id, roi_name, selected_hdf5_path, selected_net_name
+            )
+        else:
+            ex_config = self._build_ex_config(
+                subject_id,
+                roi_name,
+                selected_hdf5_path,
+                selected_net_name,
+                roi_names=roi_names_for_config,
+            )
 
         # Minimal env — only pass through what downstream steps still need
         env = os.environ.copy()
@@ -1901,7 +2368,10 @@ class ExSearchTab(QtWidgets.QWidget):
 
         # Create shared log file for the entire ex-search pipeline (only on first ROI)
         if self.current_roi_index == 0:
-            log_file = self.create_log_file_env("ex_search", subject_id)
+            log_process_name = (
+                "m_ex_search" if search_mode == SEARCH_MODE_MTI else "ex_search"
+            )
+            log_file = self.create_log_file_env(log_process_name, subject_id)
             if log_file:
                 env["TI_LOG_FILE"] = log_file
                 self._shared_log_file = log_file
@@ -1960,8 +2430,12 @@ class ExSearchTab(QtWidgets.QWidget):
             self.update_output("Step 1: Running exhaustive search...")
 
         # Serialize config to JSON and build command
-        config_path = self._write_ex_config(ex_config, project_dir)
-        cmd = ["simnibs_python", "-m", "tit.opt.ex", config_path]
+        module_path, _config_cls = search_backend_for_mode(search_mode)
+        if search_mode == SEARCH_MODE_MTI:
+            config_path = self._write_mex_config(ex_config)
+        else:
+            config_path = self._write_ex_config(ex_config, project_dir)
+        cmd = ["simnibs_python", "-m", module_path, config_path]
 
         if self.debug_mode:
             self.update_output(f"[DEBUG] Config file: {config_path}", "debug")
@@ -2199,9 +2673,16 @@ class ExSearchTab(QtWidgets.QWidget):
         # Log completion summary
         self.log_pipeline_completion()
 
+        is_mti = self._current_search_mode() == SEARCH_MODE_MTI
+
         if self._exsearch_had_errors:
             self.enable_controls()
-            self.update_status("Ex-search stopped after an error", error=True)
+            status = (
+                "mTI search stopped after an error"
+                if is_mti
+                else "Ex-search stopped after an error"
+            )
+            self.update_status(status, error=True)
             return
 
         # Log final completion with summary
@@ -2209,16 +2690,21 @@ class ExSearchTab(QtWidgets.QWidget):
         total_rois = len(self.roi_processing_queue)
         project_dir = self.pm.project_dir
         pm = self.pm
-        ex_search_dir = pm.ex_search(subject_id)
+        output_dir = pm.m_ex_search(subject_id) if is_mti else pm.ex_search(subject_id)
 
-        self.log_exsearch_complete(subject_id, total_rois, ex_search_dir)
+        self.log_exsearch_complete(subject_id, total_rois, output_dir)
 
         # Final message for debug mode
         if self.debug_mode:
             self.update_output("\nOptimization process completed!")
 
         self.enable_controls()
-        self.update_status("Ex-search optimization completed successfully")
+        status = (
+            "mTI search completed successfully"
+            if is_mti
+            else "Ex-search optimization completed successfully"
+        )
+        self.update_status(status)
         self.ex_search_completed.emit()
 
     def stop_optimization(self):
@@ -2318,6 +2804,13 @@ class ExSearchTab(QtWidgets.QWidget):
         self.total_current_spinbox.setEnabled(False)
         self.current_step_spinbox.setEnabled(False)
         self.channel_limit_spinbox.setEnabled(False)
+        self.search_mode_combo.setEnabled(False)
+        for field_widget in self.mti_bucket_inputs.values():
+            field_widget.setEnabled(False)
+        self.mex_current_spinbox.setEnabled(False)
+        self.mex_channels_combo.setEnabled(False)
+        self.mex_symmetric_bucket_cb.setEnabled(False)
+        self.mex_symmetry_pairing_combo.setEnabled(False)
         self.run_btn.setEnabled(False)
         self.stop_btn.setEnabled(True)
         self.list_subjects_btn.setEnabled(False)
@@ -2356,6 +2849,15 @@ class ExSearchTab(QtWidgets.QWidget):
         self.total_current_spinbox.setEnabled(True)
         self.current_step_spinbox.setEnabled(True)
         self.channel_limit_spinbox.setEnabled(True)
+        self.search_mode_combo.setEnabled(True)
+        for field_widget in self.mti_bucket_inputs.values():
+            field_widget.setEnabled(True)
+        self.mex_current_spinbox.setEnabled(True)
+        self.mex_channels_combo.setEnabled(True)
+        self.mex_symmetric_bucket_cb.setEnabled(True)
+        self.mex_symmetry_pairing_combo.setEnabled(
+            self.mex_symmetric_bucket_cb.isChecked()
+        )
         self.run_btn.setEnabled(True)
         self.stop_btn.setEnabled(False)
         self.list_subjects_btn.setEnabled(True)

--- a/tit/opt/__init__.py
+++ b/tit/opt/__init__.py
@@ -9,6 +9,9 @@ interference (TI) brain stimulation:
   user-defined ROI.
 * **Exhaustive search** -- brute-force grid evaluation over a discrete
   electrode pool, sweeping current amplitudes at fixed step sizes.
+* **Multipolar exhaustive search** -- the same brute-force evaluation
+  extended to four bipolar electrode pairs (eight electrodes), scored
+  with the N>2 mTI envelope.
 
 Public API
 ----------
@@ -20,15 +23,22 @@ ExConfig
     Configuration dataclass for exhaustive search.
 ExResult
     Result container returned by :func:`run_ex_search`.
+MExConfig
+    Configuration dataclass for multipolar exhaustive search.
+MExResult
+    Result container returned by :func:`run_m_ex_search`.
 run_flex_search
     Run differential-evolution electrode placement optimization.
 run_ex_search
     Run exhaustive grid search over electrode combinations.
+run_m_ex_search
+    Run multipolar exhaustive grid search over four electrode pairs.
 
 See Also
 --------
 tit.opt.flex : Flex-search subpackage with builder, manifest, and pareto utilities.
 tit.opt.ex : Exhaustive-search subpackage with engine and result handling.
+tit.opt.mex : Multipolar exhaustive-search subpackage.
 tit.opt.leadfield : Leadfield matrix generation via SimNIBS.
 """
 
@@ -37,9 +47,12 @@ from tit.opt.config import (
     FlexResult,
     ExConfig,
     ExResult,
+    MExConfig,
+    MExResult,
 )
 from tit.opt.ex.ex import run_ex_search
 from tit.opt.flex.flex import run_flex_search
+from tit.opt.mex.mex import run_m_ex_search
 
 __all__ = [
     # Config classes
@@ -47,7 +60,10 @@ __all__ = [
     "FlexResult",
     "ExConfig",
     "ExResult",
+    "MExConfig",
+    "MExResult",
     # Functions
     "run_flex_search",
     "run_ex_search",
+    "run_m_ex_search",
 ]

--- a/tit/opt/config.py
+++ b/tit/opt/config.py
@@ -950,3 +950,39 @@ class MExResult:
     n_combinations: int
     results_csv: str | None = None
     config_json: str | None = None
+
+
+#: Exhaustive-search modes. ``TI`` searches two bipolar pairs, ``mTI`` four.
+SEARCH_MODE_TI = "TI"
+SEARCH_MODE_MTI = "mTI"
+
+#: Carrier wiring for a four-pair montage, as (label, ``channels`` value).
+#: Four pairs can be two independent TI channels -- consecutive pairing, the
+#: default -- or four pairs sharing two carriers, where same-carrier fields
+#: superpose before the envelope is taken (Lee et al. 2022). The two give
+#: materially different fields, so it is a real choice rather than a detail.
+MTI_CHANNEL_ARCHITECTURES = [
+    ("Two independent channels", None),
+    ("Four pairs, two carriers", [([0, 2], [1, 3])]),
+]
+
+
+def search_backend_for_mode(mode):
+    """Return ``(module path, config class)`` for an exhaustive-search mode.
+
+    Args:
+        mode: :data:`SEARCH_MODE_TI` or :data:`SEARCH_MODE_MTI`.
+
+    Returns:
+        ``(module_path, config_class)``; *module_path* is passed to
+        ``simnibs_python -m <module_path>`` and *config_class* is the
+        dataclass to build for that mode.
+
+    Raises:
+        ValueError: If *mode* is not a known search mode.
+    """
+    if mode == SEARCH_MODE_TI:
+        return "tit.opt.ex", ExConfig
+    if mode == SEARCH_MODE_MTI:
+        return "tit.opt.mex", MExConfig
+    raise ValueError(f"Unknown search mode: {mode!r}")

--- a/tit/opt/config.py
+++ b/tit/opt/config.py
@@ -13,11 +13,16 @@ ExConfig
     Full configuration for exhaustive (grid) search optimization.
 ExResult
     Result container for a completed exhaustive search run.
+MExConfig
+    Full configuration for multipolar (4-pair) exhaustive search.
+MExResult
+    Result container for a completed multipolar exhaustive search run.
 
 See Also
 --------
 tit.opt.flex.flex.run_flex_search : Consumes :class:`FlexConfig`.
 tit.opt.ex.ex.run_ex_search : Consumes :class:`ExConfig`.
+tit.opt.mex.mex.run_m_ex_search : Consumes :class:`MExConfig`.
 """
 
 from dataclasses import dataclass, field
@@ -766,6 +771,178 @@ class ExResult:
     --------
     ExConfig : Configuration consumed by :func:`~tit.opt.ex.ex.run_ex_search`.
     tit.opt.ex.ex.run_ex_search : Returns this result.
+    """
+
+    success: bool
+    output_dir: str
+    n_combinations: int
+    results_csv: str | None = None
+    config_json: str | None = None
+
+
+# ── Multipolar exhaustive search config ──────────────────────────────────────
+
+
+@dataclass
+class MExConfig:
+    """Full configuration for multipolar (4-pair, 8-electrode) exhaustive search.
+
+    Evaluates every valid combination of four bipolar electrode pairs from
+    a user-defined pool or bucket set, at one fixed current per pair, and
+    scores each candidate with the verified N>2 mTI envelope
+    (:func:`tit.calc.get_mTI_vectors`).
+
+    Attributes
+    ----------
+    subject_id : str
+        Subject identifier matching the m2m directory name.
+    leadfield_hdf : str
+        Path to the precomputed leadfield HDF5 file.
+    roi_name : str
+        ROI CSV filename (e.g. ``"target.csv"``).  The ``".csv"`` suffix
+        is appended automatically if missing.
+    electrodes : BucketElectrodes or PoolElectrodes
+        Electrode specification, either a single shared pool
+        (:class:`PoolElectrodes`) or four separate per-pair buckets
+        (:class:`BucketElectrodes`).  A plain dict is auto-converted in
+        ``__post_init__``.
+    current_mA : float
+        Current in mA delivered by each of the four pairs.
+    channels : list of (list of int, list of int), or None
+        Carrier grouping passed to :func:`tit.calc.get_mTI_vectors`.
+        ``None`` treats the four pairs as two independent TI channels
+        (equivalent to ``[([0], [1]), ([2], [3])]``); an explicit grouping
+        such as ``[([0, 2], [1, 3])]`` instead treats all four pairs as
+        one channel sharing two carriers (Lee et al. 2022).  These give
+        materially different fields, so the grouping must be chosen
+        deliberately -- the quasi-static field solve has no frequency
+        term, so this grouping is the only place carrier assignment is
+        expressed.
+    roi_radius : float
+        Spherical ROI radius in mm for the target region.
+    run_name : str or None
+        Optional name for this run.  Defaults to a datetime stamp.
+    symmetric_bucket : bool
+        When True in bucket mode, evaluate only left/right mirrored
+        electrode pairs (see :func:`tit.opt.ex.buckets.build_electrode_mirror_map`).
+    symmetry_eeg_csv : str or None
+        EEG-position CSV used to derive mirrored electrode pairs.  If
+        unset, it is inferred from the leadfield's net name.
+    symmetry_pairing : str
+        Symmetry interpretation for bucket mode when *symmetric_bucket*
+        is True.  ``"within_pairs"`` mirrors each pair's plus/minus
+        electrodes independently; ``"cross_pairs"`` additionally mirrors
+        pair 1<->3 and pair 2<->4.
+
+    Raises
+    ------
+    ValueError
+        If *current_mA* is non-positive, if *symmetric_bucket* is set
+        with pool electrodes, or if *symmetry_pairing* is not one of
+        ``"within_pairs"``/``"cross_pairs"``.
+
+    See Also
+    --------
+    MExResult : Result container returned by :func:`~tit.opt.mex.mex.run_m_ex_search`.
+    tit.opt.mex.mex.run_m_ex_search : Consumes this config.
+    tit.calc.get_mTI_vectors : Modulation-amplitude envelope; consumes *channels*.
+    """
+
+    # ── Nested electrode types ─────────────────────────────────────────
+    @dataclass
+    class BucketElectrodes:
+        """Separate electrode lists for each of the four bipolar pairs.
+
+        Attributes
+        ----------
+        e1_plus, e1_minus, e2_plus, e2_minus, e3_plus, e3_minus, e4_plus, e4_minus : list of str
+            Candidate electrodes for each pair's anode/cathode position.
+        """
+
+        e1_plus: list[str]
+        e1_minus: list[str]
+        e2_plus: list[str]
+        e2_minus: list[str]
+        e3_plus: list[str]
+        e3_minus: list[str]
+        e4_plus: list[str]
+        e4_minus: list[str]
+
+    @dataclass
+    class PoolElectrodes:
+        """Single electrode pool -- all eight positions draw from the same set.
+
+        Attributes
+        ----------
+        electrodes : list of str
+            List of electrode names available for any pair position.
+        """
+
+        electrodes: list[str]
+
+    # ── Required fields ────────────────────────────────────────────────
+    subject_id: str
+    leadfield_hdf: str
+    roi_name: str
+    electrodes: "MExConfig.BucketElectrodes | MExConfig.PoolElectrodes"
+
+    # ── Current and carrier grouping ────────────────────────────────────
+    current_mA: float = 2.0
+    channels: list[tuple[list[int], list[int]]] | None = None
+
+    # ── ROI ────────────────────────────────────────────────────────────
+    roi_radius: float = 3.0
+
+    # ── Output naming (defaults to datetime stamp) ─────────────────────
+    run_name: str | None = None
+
+    # ── Symmetric bucket search ─────────────────────────────────────────
+    symmetric_bucket: bool = False
+    symmetry_eeg_csv: str | None = None
+    symmetry_pairing: str = "within_pairs"
+
+    def __post_init__(self):
+        if isinstance(self.electrodes, dict):
+            if "electrodes" in self.electrodes:
+                self.electrodes = MExConfig.PoolElectrodes(**self.electrodes)
+            else:
+                self.electrodes = MExConfig.BucketElectrodes(**self.electrodes)
+        if not self.roi_name.endswith(".csv"):
+            self.roi_name += ".csv"
+
+        if self.current_mA <= 0:
+            raise ValueError("current_mA must be positive")
+        if self.symmetric_bucket and isinstance(
+            self.electrodes, MExConfig.PoolElectrodes
+        ):
+            raise ValueError("symmetric_bucket is only supported for bucket electrodes")
+        if self.symmetry_pairing not in ("within_pairs", "cross_pairs"):
+            raise ValueError("symmetry_pairing must be 'within_pairs' or 'cross_pairs'")
+
+
+@dataclass
+class MExResult:
+    """Result from a multipolar exhaustive search run.
+
+    Attributes
+    ----------
+    success : bool
+        True if the search completed without error.
+    output_dir : str
+        Absolute path to the output directory.
+    n_combinations : int
+        Total number of eight-electrode combinations evaluated.
+    results_csv : str or None
+        Path to the CSV file containing ranked results.  ``None`` if the
+        run failed before writing results.
+    config_json : str or None
+        Path to the saved configuration JSON.  ``None`` if the run failed
+        before writing config.
+
+    See Also
+    --------
+    MExConfig : Configuration consumed by :func:`~tit.opt.mex.mex.run_m_ex_search`.
+    tit.opt.mex.mex.run_m_ex_search : Returns this result.
     """
 
     success: bool

--- a/tit/opt/ex/buckets.py
+++ b/tit/opt/ex/buckets.py
@@ -1,0 +1,319 @@
+"""Helpers for reusable exhaustive-search electrode buckets.
+
+Ported from collaborator Larissa Albantakis's branch
+``alba/ex-search-multipolar`` and generalized: the loader/saver/normalizer
+accept an arbitrary ordered bucket-key list instead of a hard-coded 4-key
+scheme, so both 2-pair (:data:`BUCKET_KEYS`) and 4-pair
+(:data:`tit.opt.mex.logic.MEX_BUCKET_KEYS`) bucket files share the same
+JSON/CSV/TSV round-trip.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from collections.abc import Sequence
+from pathlib import Path
+
+BUCKET_KEYS = ("e1_plus", "e1_minus", "e2_plus", "e2_minus")
+
+BUCKET_ALIASES = {
+    "e1_plus": "e1_plus",
+    "e1+": "e1_plus",
+    "e1plus": "e1_plus",
+    "e1 plus": "e1_plus",
+    "e1_minus": "e1_minus",
+    "e1-": "e1_minus",
+    "e1_": "e1_minus",
+    "e1minus": "e1_minus",
+    "e1 minus": "e1_minus",
+    "e2_plus": "e2_plus",
+    "e2+": "e2_plus",
+    "e2plus": "e2_plus",
+    "e2 plus": "e2_plus",
+    "e2_minus": "e2_minus",
+    "e2-": "e2_minus",
+    "e2_": "e2_minus",
+    "e2minus": "e2_minus",
+    "e2 minus": "e2_minus",
+}
+
+QUADRANT_BUCKET_LABELS = {
+    "e1_plus": "left anterior",
+    "e1_minus": "right anterior",
+    "e2_plus": "left posterior",
+    "e2_minus": "right posterior",
+}
+
+_RESOURCE_DIR = Path(__file__).resolve().parents[3] / "resources" / "amv"
+_CANONICAL_TEMPLATE_COORD_FILES = {
+    "GSN-HydroCel-185.csv": "GSN-256.csv",
+    "GSN-HydroCel-256.csv": "GSN-256.csv",
+    "GSN-HydroCel-185": "GSN-256.csv",
+    "GSN-HydroCel-256": "GSN-256.csv",
+    "GSN-256.csv": "GSN-256.csv",
+    "GSN-256": "GSN-256.csv",
+}
+
+
+def _generate_aliases(keys: Sequence[str]) -> dict[str, str]:
+    """Derive alias variants (``e3+``, ``e3 plus``, ...) for arbitrary bucket keys.
+
+    Used for any *keys* sequence other than the default :data:`BUCKET_KEYS`,
+    whose hand-curated aliases are :data:`BUCKET_ALIASES` instead. Only keys
+    shaped like ``e<n>_plus``/``e<n>_minus`` get alias variants; other key
+    shapes map only to themselves.
+    """
+    aliases: dict[str, str] = {}
+    for key in keys:
+        aliases[key] = key
+        match = re.match(r"^e(\d+)_(plus|minus)$", key)
+        if not match:
+            continue
+        n, sign = match.groups()
+        symbol = "+" if sign == "plus" else "-"
+        raw_symbol = f"e{n}{symbol}"
+        # _normalize_bucket_key replaces "-" with "_" before the alias lookup
+        # runs, so "e3-" arrives as "e3_" by the time it is looked up; include
+        # both the raw and the dash-normalized form so the lookup can't miss.
+        variants = {
+            raw_symbol,
+            raw_symbol.replace("-", "_"),
+            f"e{n}{sign}",
+            f"e{n} {sign}",
+        }
+        for variant in variants:
+            aliases[variant] = key
+    return aliases
+
+
+def _aliases_for(keys: Sequence[str]) -> dict[str, str]:
+    """Return the alias table for *keys* (curated for the default, derived otherwise)."""
+    return BUCKET_ALIASES if tuple(keys) == BUCKET_KEYS else _generate_aliases(keys)
+
+
+def _normalize_bucket_key(key: str, aliases: dict[str, str]) -> str:
+    normalized = key.strip().lower().replace("-", "_")
+    normalized = " ".join(normalized.split())
+    return aliases.get(normalized, normalized)
+
+
+def _split_electrodes(value) -> list[str]:
+    if isinstance(value, str):
+        parts = value.replace(";", ",").split(",")
+    else:
+        parts = list(value)
+    return [str(e).strip() for e in parts if str(e).strip()]
+
+
+def normalize_buckets(
+    raw: dict, keys: Sequence[str] = BUCKET_KEYS
+) -> dict[str, list[str]]:
+    """Normalize a bucket mapping to canonical bucket keys.
+
+    ``keys`` defaults to the four 2-pair ex-search bucket keys
+    (:data:`BUCKET_KEYS`); pass the eight m-ex-search keys
+    (:data:`tit.opt.mex.logic.MEX_BUCKET_KEYS`) to normalize a 4-pair
+    (8-electrode) bucket mapping through the same function.
+    """
+    aliases = _aliases_for(keys)
+    buckets = {key: [] for key in keys}
+    for key, value in raw.items():
+        bucket_key = _normalize_bucket_key(str(key), aliases)
+        if bucket_key in buckets:
+            buckets[bucket_key] = _split_electrodes(value)
+    return buckets
+
+
+def _bucket_json_payload(data: dict) -> dict:
+    """Return the bucket-shaped payload from a bucket file or full config."""
+    electrodes = data.get("electrodes")
+    if isinstance(electrodes, dict):
+        nested = dict(electrodes)
+        nested.pop("_type", None)
+        return nested
+    return data
+
+
+def load_bucket_file(
+    path: str | Path, keys: Sequence[str] = BUCKET_KEYS
+) -> dict[str, list[str]]:
+    """Load bucket definitions from JSON, CSV, or TSV.
+
+    JSON may use canonical keys (``e1_plus``) or GUI-style keys
+    (``E1+``). Full ex-search/m-ex-search config JSON files with nested
+    ``electrodes`` are also accepted. CSV/TSV files should have one row
+    per bucket, with the bucket name in the first column and electrodes
+    in the remaining columns or as a comma/semicolon separated second
+    column. ``keys`` selects the bucket scheme -- the four 2-pair keys by
+    default, or an arbitrary key list (e.g. the eight m-ex-search keys)
+    for other electrode-position counts.
+    """
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("Bucket JSON must contain an object")
+        return normalize_buckets(_bucket_json_payload(data), keys)
+
+    delimiter = "\t" if suffix == ".tsv" else ","
+    aliases = _aliases_for(keys)
+    rows = {}
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.reader(f, delimiter=delimiter)
+        for row in reader:
+            if not row or not row[0].strip() or row[0].strip().startswith("#"):
+                continue
+            bucket_key = _normalize_bucket_key(row[0], aliases)
+            if bucket_key not in keys:
+                continue
+            if len(row) == 2:
+                rows[bucket_key] = _split_electrodes(row[1])
+            else:
+                rows[bucket_key] = _split_electrodes(row[1:])
+    return normalize_buckets(rows, keys)
+
+
+def save_bucket_file(
+    path: str | Path,
+    buckets: dict[str, list[str]],
+    keys: Sequence[str] = BUCKET_KEYS,
+) -> None:
+    """Save bucket definitions as JSON."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(normalize_buckets(buckets, keys), f, indent=2)
+        f.write("\n")
+
+
+def _read_eeg_positions(eeg_csv_path: str | Path) -> dict[str, tuple[float, ...]]:
+    """Read electrode labels and positions from supported EEG CSV layouts."""
+    positions: dict[str, tuple[float, ...]] = {}
+    with open(eeg_csv_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 3:
+                continue
+            first = row[0].strip().lower()
+            if first in {"electrode_name", "name", "label"}:
+                try:
+                    label = row[0].strip()
+                    x = float(row[1])
+                    y = float(row[2])
+                    coords = (x, y)
+                except ValueError:
+                    continue
+            elif first == "electrode" and len(row) >= 5:
+                try:
+                    label = row[4].strip()
+                    x = float(row[1])
+                    y = float(row[2])
+                    z = float(row[3])
+                    coords = (x, y, z)
+                except ValueError:
+                    continue
+            elif len(row) >= 5:
+                continue
+            else:
+                try:
+                    label = row[0].strip()
+                    x = float(row[1])
+                    y = float(row[2])
+                    coords = (x, y)
+                    if len(row) >= 4:
+                        coords = (x, y, float(row[3]))
+                except ValueError:
+                    continue
+            if label:
+                positions[label] = coords
+    return positions
+
+
+def canonical_template_coord_path(eeg_net_name: str | Path | None) -> Path | None:
+    """Return a canonical 2D EEG-template coordinate file for known net names."""
+    if not eeg_net_name:
+        return None
+    name = Path(str(eeg_net_name)).name
+    coord_file = _CANONICAL_TEMPLATE_COORD_FILES.get(name)
+    if coord_file is None:
+        coord_file = _CANONICAL_TEMPLATE_COORD_FILES.get(Path(name).stem)
+    if coord_file is None:
+        return None
+    path = _RESOURCE_DIR / coord_file
+    return path if path.is_file() else None
+
+
+def build_electrode_mirror_map(
+    eeg_csv_path: str | Path,
+    *,
+    midline_tolerance: float = 1e-6,
+) -> dict[str, str]:
+    """Map each electrode to its closest left/right mirror in an EEG CSV.
+
+    The mirror is defined by reflecting the x-coordinate across the midline
+    while preserving the anterior/posterior coordinate. Midline electrodes
+    are mapped to themselves; downstream channel-pair validation still
+    prevents self-pairs from being evaluated.
+    """
+    positions = _read_eeg_positions(eeg_csv_path)
+    if not positions:
+        raise ValueError(f"No electrode positions found in {eeg_csv_path}")
+
+    xs = [coords[0] for coords in positions.values()]
+    x_midline = 0.0 if min(xs) < 0 < max(xs) else (min(xs) + max(xs)) / 2
+
+    mirror_map: dict[str, str] = {}
+    for label, coords in positions.items():
+        x = coords[0]
+        if abs(x - x_midline) <= midline_tolerance:
+            mirror_map[label] = label
+            continue
+
+        target = (2 * x_midline - x, *coords[1:])
+        candidates = []
+        for other_label, other_coords in positions.items():
+            other_x = other_coords[0]
+            if other_label == label:
+                continue
+            if (
+                x < x_midline - midline_tolerance
+                and other_x < x_midline - midline_tolerance
+            ):
+                continue
+            if (
+                x > x_midline + midline_tolerance
+                and other_x > x_midline + midline_tolerance
+            ):
+                continue
+            dist2 = sum(
+                (other_value - target_value) ** 2
+                for other_value, target_value in zip(other_coords, target)
+            )
+            candidates.append((dist2, other_label))
+        if candidates:
+            mirror_map[label] = min(candidates)[1]
+
+    return mirror_map
+
+
+def build_quadrant_buckets(eeg_csv_path: str | Path) -> dict[str, list[str]]:
+    """Split an EEG-position CSV into four RAS quadrants.
+
+    Mapping: ``E1+`` = left anterior, ``E1-`` = right anterior,
+    ``E2+`` = left posterior, ``E2-`` = right posterior.
+    """
+    buckets = {key: [] for key in BUCKET_KEYS}
+    for label, coords in _read_eeg_positions(eeg_csv_path).items():
+        x, y = coords[:2]
+        if x < 0 and y >= 0:
+            buckets["e1_plus"].append(label)
+        elif x >= 0 and y >= 0:
+            buckets["e1_minus"].append(label)
+        elif x < 0 and y < 0:
+            buckets["e2_plus"].append(label)
+        else:
+            buckets["e2_minus"].append(label)
+
+    return {key: sorted(values) for key, values in buckets.items()}

--- a/tit/opt/ex/results.py
+++ b/tit/opt/ex/results.py
@@ -26,6 +26,7 @@ import csv
 import json
 import os
 import re
+from dataclasses import fields as dataclass_fields
 from typing import Any
 
 
@@ -34,8 +35,11 @@ def save_run_config(config, n_combinations: int, output_dir: str, logger: Any) -
 
     Parameters
     ----------
-    config : ExConfig
-        Exhaustive-search configuration dataclass.
+    config : ExConfig or MExConfig
+        Exhaustive-search (2-pair) or multipolar exhaustive-search (4-pair)
+        configuration dataclass.  The current-parameter fields differ
+        between the two (``total_current``/``current_step``/``channel_limit``
+        vs. a flat ``current_mA``), so both are recorded when present.
     n_combinations : int
         Total number of montage combinations evaluated.
     output_dir : str
@@ -54,10 +58,8 @@ def save_run_config(config, n_combinations: int, output_dir: str, logger: Any) -
     else:
         electrode_mode = "bucket"
         electrode_info = {
-            "e1_plus": config.electrodes.e1_plus,
-            "e1_minus": config.electrodes.e1_minus,
-            "e2_plus": config.electrodes.e2_plus,
-            "e2_minus": config.electrodes.e2_minus,
+            f.name: getattr(config.electrodes, f.name)
+            for f in dataclass_fields(config.electrodes)
         }
 
     run_info = {
@@ -67,12 +69,15 @@ def save_run_config(config, n_combinations: int, output_dir: str, logger: Any) -
         "leadfield_hdf": config.leadfield_hdf,
         "electrode_mode": electrode_mode,
         "electrodes": electrode_info,
-        "total_current_mA": config.total_current,
-        "current_step_mA": config.current_step,
-        "channel_limit_mA": config.channel_limit,
         "n_combinations": n_combinations,
         "run_name": config.run_name,
     }
+    if hasattr(config, "total_current"):
+        run_info["total_current_mA"] = config.total_current
+        run_info["current_step_mA"] = config.current_step
+        run_info["channel_limit_mA"] = config.channel_limit
+    if hasattr(config, "current_mA"):
+        run_info["current_mA"] = config.current_mA
 
     path = os.path.join(output_dir, "run_config.json")
     with open(path, "w") as f:

--- a/tit/opt/mex/__init__.py
+++ b/tit/opt/mex/__init__.py
@@ -1,0 +1,12 @@
+"""TI Multipolar (4-pair) Exhaustive Search Module."""
+
+from tit.opt.config import MExConfig, MExResult
+from tit.opt.mex.engine import MExSearchEngine
+from tit.opt.mex.mex import run_m_ex_search
+
+__all__ = [
+    "MExConfig",
+    "MExResult",
+    "MExSearchEngine",
+    "run_m_ex_search",
+]

--- a/tit/opt/mex/__main__.py
+++ b/tit/opt/mex/__main__.py
@@ -1,0 +1,60 @@
+"""Entry point: simnibs_python -m tit.opt.mex config.json"""
+
+import json
+import sys
+
+from tit.opt.config import MExConfig
+from tit.opt.mex.mex import run_m_ex_search
+
+_ELECTRODE_BUILDERS = {
+    "PoolElectrodes": MExConfig.PoolElectrodes,
+    "BucketElectrodes": MExConfig.BucketElectrodes,
+}
+
+
+def _build_electrodes(data: dict):
+    data = dict(data)
+    electrode_type = data.pop("_type", None)
+    if electrode_type and electrode_type in _ELECTRODE_BUILDERS:
+        return _ELECTRODE_BUILDERS[electrode_type](**data)
+    if "electrodes" in data:
+        return MExConfig.PoolElectrodes(**data)
+    return MExConfig.BucketElectrodes(**data)
+
+
+def _build_channels(data):
+    """Restore ``MExConfig.channels`` from JSON, where tuples become lists."""
+    if data is None:
+        return None
+    return [(list(group_a), list(group_b)) for group_a, group_b in data]
+
+
+def _make_stdout_logger() -> None:
+    """Attach a stdout handler so log messages are captured by BaseProcessThread."""
+    from tit.logger import setup_logging, add_stream_handler
+
+    setup_logging()
+    add_stream_handler("tit.opt.m_ex_search")
+
+
+def main() -> None:
+    """Run multipolar exhaustive search from a JSON config passed as the first CLI argument."""
+    _make_stdout_logger()
+
+    config_path = sys.argv[1]
+    with open(config_path) as f:
+        data = json.load(f)
+
+    from tit.paths import get_path_manager
+
+    get_path_manager(data.pop("project_dir"))
+
+    electrodes = _build_electrodes(data.pop("electrodes"))
+    channels = _build_channels(data.pop("channels", None))
+    config = MExConfig(electrodes=electrodes, channels=channels, **data)
+    result = run_m_ex_search(config)
+    sys.exit(0 if result.success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tit/opt/mex/engine.py
+++ b/tit/opt/mex/engine.py
@@ -1,0 +1,205 @@
+"""Multipolar exhaustive-search engine."""
+
+import logging
+import signal
+import time
+
+import numpy as np
+from simnibs.utils import TI_utils as TI
+
+from tit.calc import get_mTI_vectors
+from tit.opt.ex.engine import ExSearchEngine
+
+from .logic import count_multipolar_combinations, generate_multipolar_combinations
+
+
+class MExSearchEngine(ExSearchEngine):
+    """Exhaustive search engine for four-pair (eight-electrode) mTI montages.
+
+    Scores each candidate with the verified N>2 mTI envelope
+    (:func:`tit.calc.get_mTI_vectors`), not a recursive envelope-of-envelopes
+    dispatch -- that path is not the TI envelope for N>2 fields (see the
+    ``get_mTI_vectors`` module docstring in ``tit/calc.py``).
+    """
+
+    def __init__(
+        self,
+        leadfield_hdf: str,
+        roi_file: str,
+        roi_name: str,
+        logger: logging.Logger,
+        channels: list[tuple[list[int], list[int]]] | None = None,
+    ):
+        super().__init__(leadfield_hdf, roi_file, roi_name, logger)
+        self.channels = channels
+
+    def compute_mti_field(
+        self,
+        electrodes: tuple[str, str, str, str, str, str, str, str],
+        current_mA: float,
+    ) -> dict[str, float]:
+        """Compute one four-pair mTI candidate and return ROI metrics."""
+        fields = [
+            TI.get_field(
+                [electrodes[idx], electrodes[idx + 1], current_mA / 1000.0],
+                self.leadfield,
+                self.idx_lf,
+            )
+            for idx in range(0, 8, 2)
+        ]
+
+        vectors = get_mTI_vectors(fields, channels=self.channels)
+        metric_full = np.linalg.norm(vectors, axis=1)
+        field_roi = metric_full[self.roi_indices]
+        field_gm = metric_full[self.gm_indices]
+
+        n_elements = int(len(field_roi))
+        if n_elements == 0:
+            roi_max = roi_mean = gm_mean = focality = 0.0
+        else:
+            roi_max = float(np.max(field_roi))
+            roi_mean = float(np.average(field_roi, weights=self.roi_volumes))
+            if len(field_gm) > 0:
+                gm_mean = float(np.average(field_gm, weights=self.gm_volumes))
+                focality = roi_mean / gm_mean if gm_mean > 0 else 0.0
+            else:
+                gm_mean = focality = 0.0
+
+        return {
+            f"{self.roi_name}_TImax_ROI": roi_max,
+            f"{self.roi_name}_TImean_ROI": roi_mean,
+            f"{self.roi_name}_TImean_GM": gm_mean,
+            f"{self.roi_name}_Focality": focality,
+            f"{self.roi_name}_n_elements": n_elements,
+            "current_ch1_mA": current_mA,
+            "current_ch2_mA": current_mA,
+            "current_ch3_mA": current_mA,
+            "current_ch4_mA": current_mA,
+        }
+
+    def run(
+        self,
+        buckets_or_pool,
+        all_combinations: bool,
+        output_dir: str,
+        current_mA: float,
+        symmetry_mirror_map: dict[str, str] | None = None,
+        symmetry_pairing: str = "within_pairs",
+    ) -> dict[str, dict[str, float]]:
+        """Run the full multipolar search loop."""
+        stop = False
+
+        def _on_signal(sig, frame):
+            nonlocal stop
+            stop = True
+
+        signal.signal(signal.SIGINT, _on_signal)
+        signal.signal(signal.SIGTERM, _on_signal)
+
+        total = count_multipolar_combinations(
+            buckets_or_pool,
+            all_combinations=all_combinations,
+            symmetry_mirror_map=symmetry_mirror_map,
+            symmetry_pairing=symmetry_pairing,
+        )
+        self.logger.info("%s", "\n" + "=" * 60)
+        mode = "All Combinations" if all_combinations else "Bucketed"
+        if symmetry_mirror_map is not None:
+            mode += f", left/right symmetric ({symmetry_pairing})"
+        self.logger.info("Multipolar Exhaustive Search (%s)", mode)
+        self.logger.info("Current per pair: %.3f mA", current_mA)
+        self.logger.info("Channels: %s", self.channels or "consecutive pairing")
+        self.logger.info("Total combinations: %d", total)
+        self.logger.info("%s", "=" * 60 + "\n")
+
+        results: dict[str, dict[str, float]] = {}
+        start_time = time.time()
+
+        for i, electrodes in enumerate(
+            generate_multipolar_combinations(
+                buckets_or_pool,
+                all_combinations=all_combinations,
+                symmetry_mirror_map=symmetry_mirror_map,
+                symmetry_pairing=symmetry_pairing,
+            ),
+            1,
+        ):
+            if stop:
+                self.logger.warning("Interrupted")
+                break
+
+            pair_names = [
+                f"{electrodes[idx]}_{electrodes[idx + 1]}" for idx in range(0, 8, 2)
+            ]
+            name = "_and_".join(pair_names) + f"_I-{current_mA:.1f}mA"
+            key = f"TI_field_{name}.msh"
+
+            elapsed = time.time() - start_time
+            rate = i / elapsed if elapsed > 0 else 0
+            eta = (total - i) / rate if rate > 0 else 0
+
+            self.logger.info("[%d/%d] %s", i, total, name)
+            if total:
+                self.logger.info(
+                    "  %.1f%% | %.2f/s | ETA %.1fmin",
+                    100 * i / total,
+                    rate,
+                    eta / 60,
+                )
+
+            sim_start = time.time()
+            data = self.compute_mti_field(electrodes, current_mA)
+            results[key] = data
+            self.logger.info(
+                "  %.2fs | Max=%.4f Mean=%.4f Foc=%.4f",
+                time.time() - sim_start,
+                data[f"{self.roi_name}_TImax_ROI"],
+                data[f"{self.roi_name}_TImean_ROI"],
+                data[f"{self.roi_name}_Focality"],
+            )
+            self._log_progress_estimate(i, total, start_time)
+
+        if results:
+            elapsed = time.time() - start_time
+            self.logger.info(
+                "Done: %d/%d in %.1fmin (%.2fs each)",
+                len(results),
+                total,
+                elapsed / 60,
+                elapsed / len(results),
+            )
+            self.logger.info("Output: %s", output_dir)
+
+        return results
+
+    def _log_progress_estimate(
+        self,
+        completed: int,
+        total: int,
+        start_time: float,
+        interval: int = 500,
+    ) -> None:
+        """Log a coarse progress/ETA line every *interval* candidates.
+
+        The combinatorial candidate count for four bucketed pairs (or pool
+        permutations) can run into the hundreds of thousands, where a
+        per-candidate log line (already emitted above) is too noisy to be
+        useful for tracking overall progress.
+        """
+        if not total or completed <= 0:
+            return
+        if completed != total and completed % interval != 0:
+            return
+
+        elapsed = time.time() - start_time
+        rate = completed / elapsed if elapsed > 0 else 0.0
+        eta = (total - completed) / rate if rate > 0 else 0.0
+        self.logger.info(
+            "Progress estimate: %d/%d (%.1f%%) | elapsed %.1fmin | ETA %.1fmin | %.2f/s",
+            completed,
+            total,
+            100 * completed / total,
+            elapsed / 60,
+            eta / 60,
+            rate,
+        )

--- a/tit/opt/mex/logic.py
+++ b/tit/opt/mex/logic.py
@@ -1,0 +1,143 @@
+"""Combination helpers for multipolar exhaustive search.
+
+Pure Python, no ``tit`` dependencies -- ported from collaborator Larissa
+Albantakis's branch ``alba/ex-search-multipolar`` as-is.
+"""
+
+from itertools import permutations, product
+
+MEX_BUCKET_KEYS = (
+    "e1_plus",
+    "e1_minus",
+    "e2_plus",
+    "e2_minus",
+    "e3_plus",
+    "e3_minus",
+    "e4_plus",
+    "e4_minus",
+)
+
+SYMMETRY_PAIRING_WITHIN_PAIRS = "within_pairs"
+SYMMETRY_PAIRING_CROSS_PAIRS = "cross_pairs"
+SYMMETRY_PAIRINGS = {
+    SYMMETRY_PAIRING_WITHIN_PAIRS,
+    SYMMETRY_PAIRING_CROSS_PAIRS,
+}
+
+
+def _valid_multipolar_tuple(electrodes):
+    """Return True when all eight electrode positions are unique."""
+    return len(electrodes) == 8 and len(set(electrodes)) == 8
+
+
+def _symmetric_pair_options(plus_bucket, minus_bucket, mirror_map):
+    minus_set = set(minus_bucket)
+    seen = set()
+    for plus in plus_bucket:
+        minus = mirror_map.get(plus)
+        pair = (plus, minus)
+        if minus in minus_set and plus != minus and pair not in seen:
+            seen.add(pair)
+            yield pair
+
+
+def _within_pair_symmetry_combinations(buckets, mirror_map):
+    pair_options = [
+        list(
+            _symmetric_pair_options(
+                buckets[f"e{idx}_plus"],
+                buckets[f"e{idx}_minus"],
+                mirror_map,
+            )
+        )
+        for idx in range(1, 5)
+    ]
+    for pairs in product(*pair_options):
+        combo = tuple(electrode for pair in pairs for electrode in pair)
+        if _valid_multipolar_tuple(combo):
+            yield combo
+
+
+def _cross_pair_symmetry_combinations(buckets, mirror_map):
+    e1p_e3p = list(
+        _symmetric_pair_options(buckets["e1_plus"], buckets["e3_plus"], mirror_map)
+    )
+    e1m_e3m = list(
+        _symmetric_pair_options(buckets["e1_minus"], buckets["e3_minus"], mirror_map)
+    )
+    e2p_e4p = list(
+        _symmetric_pair_options(buckets["e2_plus"], buckets["e4_plus"], mirror_map)
+    )
+    e2m_e4m = list(
+        _symmetric_pair_options(buckets["e2_minus"], buckets["e4_minus"], mirror_map)
+    )
+    for (e1p, e3p), (e1m, e3m), (e2p, e4p), (e2m, e4m) in product(
+        e1p_e3p,
+        e1m_e3m,
+        e2p_e4p,
+        e2m_e4m,
+    ):
+        combo = (e1p, e1m, e2p, e2m, e3p, e3m, e4p, e4m)
+        if _valid_multipolar_tuple(combo):
+            yield combo
+
+
+def _bucket_electrode_combinations(
+    buckets,
+    symmetry_mirror_map=None,
+    symmetry_pairing=SYMMETRY_PAIRING_WITHIN_PAIRS,
+):
+    if symmetry_mirror_map is None:
+        for combo in product(*(buckets[key] for key in MEX_BUCKET_KEYS)):
+            if _valid_multipolar_tuple(combo):
+                yield combo
+        return
+
+    if symmetry_pairing not in SYMMETRY_PAIRINGS:
+        raise ValueError(
+            f"Unsupported m-ex-search symmetry pairing: {symmetry_pairing}"
+        )
+    if symmetry_pairing == SYMMETRY_PAIRING_CROSS_PAIRS:
+        yield from _cross_pair_symmetry_combinations(buckets, symmetry_mirror_map)
+    else:
+        yield from _within_pair_symmetry_combinations(buckets, symmetry_mirror_map)
+
+
+def _pool_electrode_combinations(pool):
+    for combo in permutations(pool, 8):
+        yield combo
+
+
+def generate_multipolar_combinations(
+    buckets_or_pool,
+    all_combinations=False,
+    symmetry_mirror_map=None,
+    symmetry_pairing=SYMMETRY_PAIRING_WITHIN_PAIRS,
+):
+    """Yield valid eight-electrode candidates for four bipolar pairs."""
+    if all_combinations:
+        yield from _pool_electrode_combinations(buckets_or_pool)
+    else:
+        yield from _bucket_electrode_combinations(
+            buckets_or_pool,
+            symmetry_mirror_map=symmetry_mirror_map,
+            symmetry_pairing=symmetry_pairing,
+        )
+
+
+def count_multipolar_combinations(
+    buckets_or_pool,
+    all_combinations=False,
+    symmetry_mirror_map=None,
+    symmetry_pairing=SYMMETRY_PAIRING_WITHIN_PAIRS,
+):
+    """Count multipolar candidates without materializing them as a list."""
+    return sum(
+        1
+        for _ in generate_multipolar_combinations(
+            buckets_or_pool,
+            all_combinations=all_combinations,
+            symmetry_mirror_map=symmetry_mirror_map,
+            symmetry_pairing=symmetry_pairing,
+        )
+    )

--- a/tit/opt/mex/mex.py
+++ b/tit/opt/mex/mex.py
@@ -1,0 +1,124 @@
+"""Multipolar (4-pair) exhaustive search optimization.
+
+Public API: ``run_m_ex_search(config) -> MExResult``
+"""
+
+import logging
+import os
+import time
+from pathlib import Path
+
+from tit.logger import add_file_handler
+from tit.opt.config import MExConfig, MExResult
+from tit.opt.ex.buckets import build_electrode_mirror_map, canonical_template_coord_path
+from tit.opt.ex.results import process_and_save
+from tit.paths import get_path_manager
+
+from .engine import MExSearchEngine
+
+
+def run_m_ex_search(config: MExConfig) -> MExResult:
+    """Run multipolar exhaustive search from a typed config object."""
+    return _run_m_ex_search_inner(config)
+
+
+def _run_m_ex_search_inner(config: MExConfig) -> MExResult:
+    pm = get_path_manager()
+
+    logs_dir = pm.logs(config.subject_id)
+    os.makedirs(logs_dir, exist_ok=True)
+    log_file = os.path.join(
+        logs_dir, f'm_ex_search_{time.strftime("%Y%m%d_%H%M%S")}.log'
+    )
+    logger_name = f"tit.opt.m_ex_search.{config.subject_id}"
+    add_file_handler(log_file, logger_name=logger_name)
+    add_file_handler(log_file, logger_name="simnibs")
+    logger = logging.getLogger(logger_name)
+
+    logger.info("%s\nmTI Multipolar Exhaustive Search\n%s", "=" * 60, "=" * 60)
+    logger.info("Project: %s", pm.project_dir)
+    logger.info("Subject: %s", config.subject_id)
+
+    run_name = config.run_name or time.strftime("%Y%m%d_%H%M%S")
+    output_dir = pm.m_ex_search_run(config.subject_id, run_name)
+    os.makedirs(output_dir, exist_ok=True)
+    logger.info("Output: %s", output_dir)
+
+    roi_file = os.path.join(pm.rois(config.subject_id), config.roi_name)
+
+    if isinstance(config.electrodes, MExConfig.PoolElectrodes):
+        buckets_or_pool = config.electrodes.electrodes
+        all_combinations = True
+        symmetry_mirror_map = None
+    else:
+        buckets_or_pool = {
+            "e1_plus": config.electrodes.e1_plus,
+            "e1_minus": config.electrodes.e1_minus,
+            "e2_plus": config.electrodes.e2_plus,
+            "e2_minus": config.electrodes.e2_minus,
+            "e3_plus": config.electrodes.e3_plus,
+            "e3_minus": config.electrodes.e3_minus,
+            "e4_plus": config.electrodes.e4_plus,
+            "e4_minus": config.electrodes.e4_minus,
+        }
+        all_combinations = False
+        symmetry_mirror_map = _build_symmetry_mirror_map(config, pm, logger)
+
+    leadfield_path = os.path.join(
+        pm.leadfields(config.subject_id), config.leadfield_hdf
+    )
+
+    engine = MExSearchEngine(
+        leadfield_path, roi_file, config.roi_name, logger, channels=config.channels
+    )
+    engine.initialize(roi_radius=config.roi_radius)
+    results = engine.run(
+        buckets_or_pool,
+        all_combinations,
+        output_dir,
+        current_mA=config.current_mA,
+        symmetry_mirror_map=symmetry_mirror_map,
+        symmetry_pairing=config.symmetry_pairing,
+    )
+
+    output_info = process_and_save(results, config, output_dir, logger)
+    logger.info("Config: %s", output_info["config_json_path"])
+    logger.info("CSV: %s", output_info["csv_path"])
+
+    return MExResult(
+        success=True,
+        output_dir=output_dir,
+        n_combinations=len(results),
+        results_csv=output_info.get("csv_path"),
+        config_json=output_info.get("config_json_path"),
+    )
+
+
+def _infer_symmetry_eeg_csv(config: MExConfig, pm) -> Path | None:
+    """Guess the EEG-position CSV for symmetric bucket mode from the leadfield name."""
+    leadfield_name = Path(config.leadfield_hdf).name
+    net_name = leadfield_name.removesuffix(".hdf5").removesuffix("_leadfield")
+    if not net_name:
+        return None
+    canonical = canonical_template_coord_path(net_name)
+    if canonical is not None:
+        return canonical
+    candidate = Path(pm.eeg_positions(config.subject_id)) / f"{net_name}.csv"
+    return candidate if candidate.is_file() else None
+
+
+def _build_symmetry_mirror_map(config: MExConfig, pm, logger) -> dict[str, str] | None:
+    if not config.symmetric_bucket:
+        return None
+
+    eeg_csv = Path(config.symmetry_eeg_csv) if config.symmetry_eeg_csv else None
+    if eeg_csv is None or not eeg_csv.is_file():
+        eeg_csv = _infer_symmetry_eeg_csv(config, pm)
+    if eeg_csv is None or not eeg_csv.is_file():
+        raise ValueError(
+            "symmetric_bucket requires a valid symmetry_eeg_csv or an inferable "
+            "EEG-position CSV from the selected leadfield."
+        )
+
+    logger.info("Symmetric bucket mode: using EEG mirror map from %s", eeg_csv)
+    return build_electrode_mirror_map(eeg_csv)

--- a/tit/paths.py
+++ b/tit/paths.py
@@ -370,6 +370,10 @@ class PathManager:
         """Path to exhaustive-search results for *sid*."""
         return os.path.join(self.sub(sid), "ex-search")
 
+    def m_ex_search(self, sid: str) -> str:
+        """Path to multipolar exhaustive-search results for *sid*."""
+        return os.path.join(self.sub(sid), "m-ex-search")
+
     def flex_search(self, sid: str) -> str:
         """Path to flex-search results for *sid*."""
         return os.path.join(self.sub(sid), "flex-search")
@@ -443,6 +447,10 @@ class PathManager:
     def ex_search_run(self, sid: str, run: str) -> str:
         """Path to a specific exhaustive-search run directory."""
         return os.path.join(self.ex_search(sid), run)
+
+    def m_ex_search_run(self, sid: str, run: str) -> str:
+        """Path to a specific multipolar exhaustive-search run directory."""
+        return os.path.join(self.m_ex_search(sid), run)
 
     def flex_search_run(self, sid: str, name: str) -> str:
         """Path to a specific flex-search run directory."""


### PR DESCRIPTION
Brings the multipolar exhaustive search onto main. It existed only on the collaborator branch `alba/ex-search-multipolar`; nothing here provided it.

## Backend — `tit/opt/mex/`

New module plus `tit/opt/ex/buckets.py` (bucket file I/O, quadrant presets, and the symmetric mirror map that collapses `|e1+| x |e1-|` to roughly `|e1+|`).

**The rejected metric did not come back.** Her engine called `compute_mti_metric_field(..., "recursive_ti")`. That dispatch family was rejected on evidence: recursive envelope-of-envelopes is not the TI envelope for N > 2 (signed mean +38.6%, range -90% to +416% at four fields), and a literature review found no published method that combines pairs recursively — the field superposes same-carrier fields first and takes the envelope once. `MExSearchEngine` calls `tit.calc.get_mTI_vectors`, and a guard test asserts the rejected symbols stay absent.

`MExConfig` carries the carrier grouping through to that call. No frequency parameter: in the quasi-static approximation the field solve has no frequency term, so grouping is the whole content.

`buckets.py` is generalized to an arbitrary ordered key list rather than the hard-coded 4-key scheme — that limitation is why her multipolar tab hand-rolled its own JSON round-trip and lost CSV/TSV support.

## GUI — one tab, one toggle

Not the separate `MExSearchTab` subclass (541 lines, roughly half copy-adapted). A search-mode combo at the top of Electrode Selection, with two `QStackedWidget`s swapping the bucket editor (4 vs 8) and the current controls (total/step/limit vs one current per pair).

Carrier wiring is exposed as a named choice — "Two independent channels" vs "Four pairs, two carriers" — since the two give materially different fields (differing in 92% of elements, up to 6x) but nobody should be typing index groups.

The mode-to-backend mapping lives in `tit/opt/config.py`, not the tab: it is domain logic selecting between two config dataclasses that already live there, and behind a PyQt5 import the tests meant to verify it skipped rather than ran.

## Regressions avoided

Her branch predates work that has since landed, so shared files were ported forward, not adopted. Intact and verified: `ExSearchEngine.roi_file` remains `str | list[str]` (the multi-ROI union from #130, which she had narrowed to `str`), the Combine ROIs feature, the bucket-length validation, and the current defaults (2.0 / 0.2 / 1.6).

One shared file needed a real change: `save_run_config` read `total_current`/`current_step`/`channel_limit` unconditionally, which `MExConfig` lacks, so passing one would have crashed. Electrode info is now built from dataclass fields and the current parameters are presence-gated; 2-pair output is unchanged.

## Verification

Suite **2291 passed / 8 skipped / 0 failed** (baseline 2263). `black` clean. GUI module compiles.

**Not verified: rendering.** PyQt5 is absent on the host, so layout, box heights, spacing and tab order are unchecked. The container heights were bumped 180/190 -> 220 by line-count arithmetic, not by looking at it. That is the first thing to check in Docker.

## Known limitation

`build_csv_rows` still emits only `Current_Ch1_mA`/`Current_Ch2_mA`, so a multipolar run's per-pair current is recorded in the run config rather than `final_output.csv`.