### PR TITLE
ex-search: atlas-region and MNI-space ROIs

### DIFF
--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -140,3 +140,40 @@ class TestMeshAtlasManager:
         mgr = MeshAtlasManager(str(tmp_path))
         result = mgr.find_all_atlases("lh")
         assert "myatlas" in result
+
+
+@pytest.mark.unit
+class TestParseRegionLabel:
+    """Parsing the label out of ``VoxelAtlasManager.list_regions()`` output.
+
+    Lives here rather than in the GUI tests so it runs without PyQt5; the
+    ex-search tab imports it to turn a picked region into an AtlasROI label.
+    """
+
+    def test_parses_plain_entry(self):
+        from tit.atlas.voxel import parse_region_label
+
+        assert parse_region_label("Hippocampus (ID: 17)") == 17
+
+    def test_parses_name_containing_parentheses_and_digits(self):
+        from tit.atlas.voxel import parse_region_label
+
+        assert parse_region_label("Left-Cerebral-Cortex (area 3b) (ID: 1003)") == 1003
+
+    def test_parses_negative_and_zero_labels(self):
+        from tit.atlas.voxel import parse_region_label
+
+        assert parse_region_label("Unknown (ID: 0)") == 0
+        assert parse_region_label("Sentinel (ID: -1)") == -1
+
+    def test_tolerates_trailing_whitespace(self):
+        from tit.atlas.voxel import parse_region_label
+
+        assert parse_region_label("Amygdala (ID: 18)   ") == 18
+
+    def test_rejects_unparseable(self):
+        from tit.atlas.voxel import parse_region_label
+
+        for bad in ("Hippocampus", "Hippocampus (17)", "Hippocampus (ID: x)", ""):
+            with pytest.raises(ValueError, match="Could not parse"):
+                parse_region_label(bad)

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -137,6 +137,66 @@ class TestGuiImports:
         assert data["electrodes"]["_type"] == "BucketElectrodes"
 
     @pytest.mark.unit
+    def test_ex_search_coordinate_space_value(self):
+        """Subject/MNI radio state maps to ExConfig.roi_coordinate_space."""
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab
+
+        assert ExSearchTab.coordinate_space_value(False) == "subject"
+        assert ExSearchTab.coordinate_space_value(True) == "mni"
+
+    @pytest.mark.unit
+    def test_ex_search_atlas_roi_chip_key_roundtrip(self):
+        """Chip keys round-trip through atlas_roi_chip_key / atlas_roi_from_chip_key."""
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab
+
+        key = ExSearchTab.atlas_roi_chip_key("/atlas/aseg.mgz", 17)
+        assert ExSearchTab.atlas_roi_from_chip_key(key) == ("/atlas/aseg.mgz", 17)
+
+        # label=None -> whole file as a binary mask
+        key_whole = ExSearchTab.atlas_roi_chip_key("/atlas/mask.nii.gz", None)
+        assert ExSearchTab.atlas_roi_from_chip_key(key_whole) == (
+            "/atlas/mask.nii.gz",
+            None,
+        )
+
+    @pytest.mark.unit
+    def test_ex_search_build_roi_atlas_entries(self):
+        """Selected atlas-ROI chips become ExConfig.AtlasROI-shaped dicts."""
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab
+        from tit.opt.config import ExConfig
+
+        keys = [
+            ExSearchTab.atlas_roi_chip_key("/atlas/aseg.mgz", 17),
+            ExSearchTab.atlas_roi_chip_key("/atlas/mask.nii.gz", None),
+        ]
+        entries = ExSearchTab.build_roi_atlas_entries(keys)
+        assert entries == [
+            {"atlas_path": "/atlas/aseg.mgz", "label": 17},
+            {"atlas_path": "/atlas/mask.nii.gz", "label": None},
+        ]
+
+        # Feeds straight into ExConfig.roi_atlas without further conversion.
+        config = ExConfig(
+            subject_id="ernie",
+            leadfield_hdf="/leadfields/ernie_leadfield_easycap.hdf5",
+            roi_name="18_Left_Amyg.csv",
+            roi_atlas=entries,
+            electrodes=ExConfig.BucketElectrodes(
+                e1_plus=["E1"],
+                e1_minus=["E2"],
+                e2_plus=["E3"],
+                e2_minus=["E4"],
+            ),
+        )
+        assert config.roi_atlas == [
+            ExConfig.AtlasROI(atlas_path="/atlas/aseg.mgz", label=17),
+            ExConfig.AtlasROI(atlas_path="/atlas/mask.nii.gz", label=None),
+        ]
+
+    @pytest.mark.unit
     def test_ex_search_tab_compiles(self):
         """tit/gui/ex_search_tab.py is syntactically valid Python.
 

--- a/tests/test_opt_config.py
+++ b/tests/test_opt_config.py
@@ -24,6 +24,7 @@ from tit.opt.config import (
     ExResult,
     FlexConfig,
     FlexResult,
+    MExConfig,
 )
 
 # Convenience aliases for nested types
@@ -511,6 +512,166 @@ class TestExConfigValidation:
                 electrodes=ExConfig.PoolElectrodes(electrodes=["E1"]),
                 channel_limit=-0.5,
             )
+
+
+# ---------------------------------------------------------------------------
+# ExConfig / MExConfig -- volumetric atlas ROI + MNI coordinate space
+# ---------------------------------------------------------------------------
+
+
+def _pool_electrodes(n: int):
+    return [f"E{i}" for i in range(n)]
+
+
+@pytest.mark.unit
+class TestExConfigAtlasRoiAndCoordinateSpace:
+    def _cfg(self, **overrides):
+        defaults = dict(
+            subject_id="001",
+            leadfield_hdf="/lf.hdf5",
+            roi_name="region",
+            electrodes=ExConfig.PoolElectrodes(electrodes=_pool_electrodes(2)),
+        )
+        defaults.update(overrides)
+        return ExConfig(**defaults)
+
+    def test_defaults_unchanged(self):
+        cfg = self._cfg()
+        assert cfg.roi_atlas is None
+        assert cfg.roi_coordinate_space == "subject"
+
+    def test_roi_atlas_dict_converted_to_dataclass(self):
+        cfg = self._cfg(
+            roi_atlas=[
+                {"atlas_path": "/atlas/aseg.mgz", "label": 17},
+                {"atlas_path": "/mask.nii.gz"},
+            ]
+        )
+        assert all(isinstance(a, ExConfig.AtlasROI) for a in cfg.roi_atlas)
+        assert cfg.roi_atlas[0].atlas_path == "/atlas/aseg.mgz"
+        assert cfg.roi_atlas[0].label == 17
+        assert cfg.roi_atlas[1].label is None
+
+    def test_roi_atlas_accepts_dataclass_instances(self):
+        target = ExConfig.AtlasROI(atlas_path="/atlas.nii.gz", label=53)
+        cfg = self._cfg(roi_atlas=[target])
+        assert cfg.roi_atlas == [target]
+
+    def test_coordinate_space_accepts_mni_case_insensitive(self):
+        cfg = self._cfg(roi_coordinate_space="MNI")
+        assert cfg.roi_coordinate_space == "mni"
+
+    def test_coordinate_space_rejects_invalid_value(self):
+        with pytest.raises(ValueError, match="roi_coordinate_space"):
+            self._cfg(roi_coordinate_space="mri")
+
+    def test_empty_roi_names_allowed_for_atlas_only_roi(self):
+        # An explicit empty list (not None) means "no spherical centers".
+        cfg = self._cfg(
+            roi_names=[],
+            roi_atlas=[{"atlas_path": "/atlas.nii.gz", "label": 1}],
+        )
+        assert cfg.roi_names == []
+
+
+@pytest.mark.unit
+class TestMExConfigAtlasRoiAndCoordinateSpace:
+    def _cfg(self, **overrides):
+        defaults = dict(
+            subject_id="001",
+            leadfield_hdf="/lf.hdf5",
+            roi_name="region",
+            electrodes=MExConfig.PoolElectrodes(electrodes=_pool_electrodes(8)),
+        )
+        defaults.update(overrides)
+        return MExConfig(**defaults)
+
+    def test_defaults_unchanged(self):
+        cfg = self._cfg()
+        assert cfg.roi_atlas is None
+        assert cfg.roi_coordinate_space == "subject"
+
+    def test_roi_atlas_dict_converted_to_dataclass(self):
+        cfg = self._cfg(roi_atlas=[{"atlas_path": "/atlas/aseg.mgz", "label": 53}])
+        assert isinstance(cfg.roi_atlas[0], MExConfig.AtlasROI)
+        assert cfg.roi_atlas[0].label == 53
+
+    def test_coordinate_space_accepts_mni_case_insensitive(self):
+        cfg = self._cfg(roi_coordinate_space="Mni")
+        assert cfg.roi_coordinate_space == "mni"
+
+    def test_coordinate_space_rejects_invalid_value(self):
+        with pytest.raises(ValueError, match="roi_coordinate_space"):
+            self._cfg(roi_coordinate_space="mri")
+
+
+@pytest.mark.unit
+class TestAtlasRoiConfigIORoundtrip:
+    """config_io round trip for the new roi_atlas / roi_coordinate_space fields."""
+
+    def test_ex_config_roundtrip(self, tmp_path):
+        from tit.config_io import read_config_json, write_config_json
+
+        config = ExConfig(
+            subject_id="001",
+            leadfield_hdf="/lf.hdf5",
+            roi_name="region",
+            electrodes=ExConfig.PoolElectrodes(electrodes=_pool_electrodes(2)),
+            roi_atlas=[
+                ExConfig.AtlasROI(atlas_path="/atlas/aseg.mgz", label=17),
+                ExConfig.AtlasROI(atlas_path="/mask.nii.gz"),
+            ],
+            roi_coordinate_space="mni",
+        )
+        path = write_config_json(config, prefix="ex_atlas_test")
+        try:
+            data = read_config_json(path)
+            assert data["roi_atlas"] == [
+                {"atlas_path": "/atlas/aseg.mgz", "label": 17},
+                {"atlas_path": "/mask.nii.gz", "label": None},
+            ]
+            assert data["roi_coordinate_space"] == "mni"
+
+            data.pop("project_dir")
+            rebuilt = ExConfig(
+                electrodes=ExConfig.PoolElectrodes(electrodes=_pool_electrodes(2)),
+                **{k: v for k, v in data.items() if k != "electrodes"},
+            )
+            assert rebuilt.roi_atlas == config.roi_atlas
+            assert rebuilt.roi_coordinate_space == "mni"
+        finally:
+            import os
+
+            os.unlink(path)
+
+    def test_mex_config_roundtrip(self, tmp_path):
+        from tit.config_io import read_config_json, write_config_json
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="/lf.hdf5",
+            roi_name="region",
+            electrodes=MExConfig.PoolElectrodes(electrodes=_pool_electrodes(8)),
+            roi_atlas=[MExConfig.AtlasROI(atlas_path="/atlas/aseg.mgz", label=53)],
+            roi_coordinate_space="mni",
+        )
+        path = write_config_json(config, prefix="mex_atlas_test")
+        try:
+            data = read_config_json(path)
+            assert data["roi_atlas"] == [{"atlas_path": "/atlas/aseg.mgz", "label": 53}]
+            assert data["roi_coordinate_space"] == "mni"
+
+            data.pop("project_dir")
+            rebuilt = MExConfig(
+                electrodes=MExConfig.PoolElectrodes(electrodes=_pool_electrodes(8)),
+                **{k: v for k, v in data.items() if k != "electrodes"},
+            )
+            assert rebuilt.roi_atlas == config.roi_atlas
+            assert rebuilt.roi_coordinate_space == "mni"
+        finally:
+            import os
+
+            os.unlink(path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_opt_engine.py
+++ b/tests/test_opt_engine.py
@@ -197,6 +197,199 @@ class TestFindRoiElements:
 
 
 # ---------------------------------------------------------------------------
+# ExSearchEngine._is_nifti_roi
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsNiftiRoi:
+    def test_csv_path_is_not_nifti(self):
+        from tit.opt.ex.engine import ExSearchEngine
+
+        assert ExSearchEngine._is_nifti_roi("/rois/target.csv") is False
+
+    @pytest.mark.parametrize(
+        "path", ["/atlas/mask.nii", "/atlas/mask.nii.gz", "/atlas/aseg.mgz"]
+    )
+    def test_nifti_and_mgz_paths_are_nifti(self, path):
+        from tit.opt.ex.engine import ExSearchEngine
+
+        assert ExSearchEngine._is_nifti_roi(path) is True
+
+    def test_case_insensitive(self):
+        from tit.opt.ex.engine import ExSearchEngine
+
+        assert ExSearchEngine._is_nifti_roi("/ATLAS/MASK.NII.GZ") is True
+
+    def test_label_tuple_is_always_nifti(self):
+        from tit.opt.ex.engine import ExSearchEngine
+
+        assert ExSearchEngine._is_nifti_roi(("/atlas/aseg.mgz", 17)) is True
+
+
+# ---------------------------------------------------------------------------
+# ExSearchEngine._nifti_roi_mask
+# ---------------------------------------------------------------------------
+
+
+def _fake_nifti(data, affine=None):
+    """Build a MagicMock standing in for a nibabel image object."""
+    img = MagicMock()
+    img.get_fdata.return_value = data
+    img.affine = np.eye(4) if affine is None else affine
+    return img
+
+
+@pytest.mark.unit
+class TestNiftiRoiMask:
+    def test_whole_mask_selects_nonzero_voxels(self):
+        import nibabel as nib
+
+        engine = _make_engine()
+        data = np.zeros((10, 10, 10))
+        data[5, 5, 5] = 1
+        nib.load = MagicMock(return_value=_fake_nifti(data))
+
+        baricenters = np.array([[5.0, 5.0, 5.0], [0.0, 0.0, 0.0], [9.0, 9.0, 9.0]])
+        mask = engine._nifti_roi_mask("/mask.nii.gz", baricenters)
+
+        np.testing.assert_array_equal(mask, [True, False, False])
+        nib.load.assert_called_once_with("/mask.nii.gz")
+
+    def test_atlas_label_selects_only_that_label(self):
+        """data == label must exclude other nonzero labels in the same atlas."""
+        import nibabel as nib
+
+        engine = _make_engine()
+        data = np.zeros((10, 10, 10))
+        data[2, 2, 2] = 17  # target label
+        data[3, 3, 3] = 53  # a different, non-target label
+        nib.load = MagicMock(return_value=_fake_nifti(data))
+
+        baricenters = np.array([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0], [0.0, 0.0, 0.0]])
+        mask = engine._nifti_roi_mask(("/atlas.mgz", 17), baricenters)
+
+        np.testing.assert_array_equal(mask, [True, False, False])
+
+    def test_out_of_bounds_voxels_excluded(self):
+        import nibabel as nib
+
+        engine = _make_engine()
+        data = np.ones((5, 5, 5))
+        nib.load = MagicMock(return_value=_fake_nifti(data))
+
+        baricenters = np.array([[2.0, 2.0, 2.0], [100.0, 100.0, 100.0]])
+        mask = engine._nifti_roi_mask("/mask.nii.gz", baricenters)
+
+        np.testing.assert_array_equal(mask, [True, False])
+
+    def test_squeezes_4d_mask(self):
+        import nibabel as nib
+
+        engine = _make_engine()
+        data = np.zeros((4, 4, 4, 1))
+        data[1, 1, 1, 0] = 1
+        nib.load = MagicMock(return_value=_fake_nifti(data))
+
+        baricenters = np.array([[1.0, 1.0, 1.0]])
+        mask = engine._nifti_roi_mask("/mask.nii.gz", baricenters)
+
+        np.testing.assert_array_equal(mask, [True])
+
+    def test_rejects_non_3d_mask(self):
+        import nibabel as nib
+
+        engine = _make_engine()
+        data = np.zeros((4, 4))  # invalid: not 3D and not squeezable-4D
+        nib.load = MagicMock(return_value=_fake_nifti(data))
+
+        with pytest.raises(ValueError, match="3D"):
+            engine._nifti_roi_mask("/mask.nii.gz", np.array([[0.0, 0.0, 0.0]]))
+
+
+# ---------------------------------------------------------------------------
+# ExSearchEngine -- mixed CSV + NIfTI/atlas ROI lists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMixedRoiList:
+    def test_load_roi_coordinates_skips_nifti_entries(self, tmp_path):
+        csv_path = tmp_path / "center.csv"
+        with open(csv_path, "w", newline="") as f:
+            csv.writer(f).writerow([1.0, 2.0, 3.0])
+
+        engine = _make_engine()
+        engine.roi_file = [str(csv_path), "/atlas.mgz", ("/atlas2.mgz", 17)]
+        engine._load_roi_coordinates()
+
+        assert engine.roi_centers == [[1.0, 2.0, 3.0]]
+        assert engine.roi_coords == [1.0, 2.0, 3.0]
+
+    def test_load_roi_coordinates_all_nifti_yields_no_centers(self):
+        engine = _make_engine()
+        engine.roi_file = ["/atlas.mgz", ("/atlas2.mgz", 5)]
+        engine._load_roi_coordinates()
+
+        assert engine.roi_centers == []
+        assert engine.roi_coords is None
+
+    def test_mixed_csv_and_mask_union(self, tmp_path):
+        """One CSV sphere + one NIfTI mask, unioned into a single ROI."""
+        import nibabel as nib
+
+        csv_path = tmp_path / "center.csv"
+        with open(csv_path, "w", newline="") as f:
+            csv.writer(f).writerow([0.0, 0.0, 0.0])
+
+        data = np.zeros((10, 10, 10))
+        data[9, 9, 9] = 1  # far from the CSV sphere -- only reachable via the mask
+        nib.load = MagicMock(return_value=_fake_nifti(data))
+
+        engine = _make_engine()
+        engine.roi_file = [str(csv_path), "/mask.nii.gz"]
+        engine._load_roi_coordinates()
+
+        centers = np.array(
+            [
+                [0.0, 0.0, 0.0],  # inside CSV sphere
+                [9.0, 9.0, 9.0],  # inside mask only
+                [50.0, 50.0, 50.0],  # outside both
+            ]
+        )
+        volumes = np.array([1.0, 1.0, 1.0])
+        mesh = MagicMock()
+        mesh.elements_baricenters.return_value = MagicMock(value=centers)
+        mesh.elements_volumes_and_areas.return_value = MagicMock(value=volumes)
+        engine.mesh = mesh
+
+        engine._find_roi_elements(roi_radius=3.0)
+
+        assert set(engine.roi_indices.tolist()) == {0, 1}
+
+    def test_pure_spherical_path_unaffected_by_mask_support(self):
+        """Regression guard: a plain CSV-only roi_file behaves exactly as before."""
+        engine = _make_engine()
+        engine.roi_coords = [0.0, 0.0, 0.0]
+
+        centers = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [5.0, 0.0, 0.0], [10.0, 0.0, 0.0]]
+        )
+        volumes = np.array([1.0, 2.0, 3.0, 4.0])
+        mesh = MagicMock()
+        mesh.elements_baricenters.return_value = MagicMock(value=centers)
+        mesh.elements_volumes_and_areas.return_value = MagicMock(value=volumes)
+        engine.mesh = mesh
+
+        engine._find_roi_elements(roi_radius=3.0)
+
+        assert len(engine.roi_indices) == 2
+        assert 0 in engine.roi_indices
+        assert 1 in engine.roi_indices
+        np.testing.assert_array_equal(engine.roi_volumes, [1.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
 # ExSearchEngine._find_gm_elements
 # ---------------------------------------------------------------------------
 

--- a/tests/test_opt_ex.py
+++ b/tests/test_opt_ex.py
@@ -1,10 +1,12 @@
 """Tests for tit/opt/ex/ex.py -- run_ex_search orchestrator."""
 
+import csv
 import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 project_root = Path(__file__).resolve().parent.parent
@@ -374,3 +376,157 @@ class TestEngineUnion:
 
         assert set(engine.roi_indices.tolist()) == {0, 1}
         np.testing.assert_array_equal(engine.roi_volumes, [1.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# run_ex_search -- volumetric atlas ROI targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunExSearchAtlasRoi:
+    def _pm(self, tmp_path):
+        pm = MagicMock()
+        pm.logs.return_value = str(tmp_path / "logs")
+        pm.ex_search_run.return_value = str(tmp_path / "output")
+        pm.rois.return_value = str(tmp_path / "rois")
+        return pm
+
+    @patch("tit.opt.ex.ex.process_and_save")
+    @patch("tit.opt.ex.ex.ExSearchEngine")
+    @patch("tit.opt.ex.ex.add_file_handler")
+    @patch("tit.opt.ex.ex.get_path_manager")
+    def test_atlas_targets_appended_to_roi_files(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {"m1": {}}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.ex.ex import run_ex_search
+
+        config = _make_ex_config(
+            roi_atlas=[
+                {"atlas_path": "/atlas/aseg.mgz", "label": 17},
+                {"atlas_path": "/mask.nii.gz"},
+            ]
+        )
+        run_ex_search(config)
+
+        roi_files = mock_engine_cls.call_args[0][1]
+        assert roi_files == [
+            os.path.join(str(tmp_path / "rois"), "motor.csv"),
+            ("/atlas/aseg.mgz", 17),
+            "/mask.nii.gz",
+        ]
+
+    @patch("tit.opt.ex.ex.process_and_save")
+    @patch("tit.opt.ex.ex.ExSearchEngine")
+    @patch("tit.opt.ex.ex.add_file_handler")
+    @patch("tit.opt.ex.ex.get_path_manager")
+    def test_no_roi_atlas_leaves_roi_files_unchanged(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.ex.ex import run_ex_search
+
+        run_ex_search(_make_ex_config())
+
+        roi_files = mock_engine_cls.call_args[0][1]
+        assert roi_files == [os.path.join(str(tmp_path / "rois"), "motor.csv")]
+
+
+# ---------------------------------------------------------------------------
+# run_ex_search -- MNI coordinate space
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunExSearchMniSpace:
+    def _pm(self, tmp_path):
+        pm = MagicMock()
+        pm.logs.return_value = str(tmp_path / "logs")
+        pm.ex_search_run.return_value = str(tmp_path / "output")
+        pm.rois.return_value = str(tmp_path / "rois")
+        pm.m2m.return_value = str(tmp_path / "m2m_001")
+        return pm
+
+    @patch("tit.opt.ex.ex.process_and_save")
+    @patch("tit.opt.ex.ex.ExSearchEngine")
+    @patch("tit.opt.ex.ex.add_file_handler")
+    @patch("tit.opt.ex.ex.get_path_manager")
+    def test_mni_space_transforms_and_writes_subject_space_csv(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        rois_dir = tmp_path / "rois"
+        rois_dir.mkdir()
+        with open(rois_dir / "motor.csv", "w", newline="") as f:
+            csv.writer(f).writerow([10.0, 20.0, 30.0])
+
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.ex.ex import run_ex_search
+
+        config = _make_ex_config(roi_coordinate_space="mni")
+
+        with patch(
+            "simnibs.mni2subject_coords",
+            return_value=np.array([[1.0, 2.0, 3.0]]),
+        ) as mock_transform:
+            run_ex_search(config)
+
+        mock_transform.assert_called_once()
+        call_args = mock_transform.call_args[0]
+        np.testing.assert_array_equal(call_args[0], np.array([[10.0, 20.0, 30.0]]))
+        assert call_args[1] == str(tmp_path / "m2m_001")
+
+        roi_files = mock_engine_cls.call_args[0][1]
+        assert len(roi_files) == 1
+        subject_space_csv = roi_files[0]
+        assert subject_space_csv != str(rois_dir / "motor.csv")
+        with open(subject_space_csv) as f:
+            row = next(csv.reader(f))
+        assert [float(v) for v in row] == pytest.approx([1.0, 2.0, 3.0])
+
+    @patch("tit.opt.ex.ex.process_and_save")
+    @patch("tit.opt.ex.ex.ExSearchEngine")
+    @patch("tit.opt.ex.ex.add_file_handler")
+    @patch("tit.opt.ex.ex.get_path_manager")
+    def test_subject_space_does_not_call_transform(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.ex.ex import run_ex_search
+
+        config = _make_ex_config()  # default roi_coordinate_space="subject"
+
+        with patch("simnibs.mni2subject_coords") as mock_transform:
+            run_ex_search(config)
+
+        mock_transform.assert_not_called()
+        roi_files = mock_engine_cls.call_args[0][1]
+        assert roi_files == [os.path.join(str(tmp_path / "rois"), "motor.csv")]

--- a/tests/test_opt_mex.py
+++ b/tests/test_opt_mex.py
@@ -6,12 +6,13 @@ config_io, the engine's ROI metric computation, and the carrier-grouping
 (``channels``) behavior that replaces the rejected recursive mTI dispatch.
 """
 
+import csv
 import json
 import math
 import os
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -576,3 +577,144 @@ class TestComputeMtiField:
         assert result["TestROI_TImax_ROI"] == 0.0
         assert result["TestROI_TImean_ROI"] == 0.0
         assert result["TestROI_n_elements"] == 0
+
+
+# ---------------------------------------------------------------------------
+# run_m_ex_search -- volumetric atlas ROI + MNI coordinate space
+# ---------------------------------------------------------------------------
+
+
+def _mex_pool_config(**overrides):
+    from tit.opt.config import MExConfig
+
+    defaults = dict(
+        subject_id="001",
+        leadfield_hdf="net_leadfield.hdf5",
+        roi_name="motor.csv",
+        electrodes=MExConfig.PoolElectrodes(electrodes=[f"E{i}" for i in range(1, 9)]),
+    )
+    defaults.update(overrides)
+    return MExConfig(**defaults)
+
+
+@pytest.mark.unit
+class TestRunMExSearchAtlasAndMni:
+    def _pm(self, tmp_path):
+        pm = MagicMock()
+        pm.logs.return_value = str(tmp_path / "logs")
+        pm.m_ex_search_run.return_value = str(tmp_path / "output")
+        pm.rois.return_value = str(tmp_path / "rois")
+        pm.m2m.return_value = str(tmp_path / "m2m_001")
+        return pm
+
+    @patch("tit.opt.mex.mex.process_and_save")
+    @patch("tit.opt.mex.mex.MExSearchEngine")
+    @patch("tit.opt.mex.mex.add_file_handler")
+    @patch("tit.opt.mex.mex.get_path_manager")
+    def test_atlas_targets_build_a_roi_list(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {"m1": {}}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.mex.mex import run_m_ex_search
+
+        config = _mex_pool_config(
+            roi_atlas=[{"atlas_path": "/atlas/aseg.mgz", "label": 53}]
+        )
+        run_m_ex_search(config)
+
+        roi_arg = mock_engine_cls.call_args[0][1]
+        assert roi_arg == [
+            os.path.join(str(tmp_path / "rois"), "motor.csv"),
+            ("/atlas/aseg.mgz", 53),
+        ]
+
+    @patch("tit.opt.mex.mex.process_and_save")
+    @patch("tit.opt.mex.mex.MExSearchEngine")
+    @patch("tit.opt.mex.mex.add_file_handler")
+    @patch("tit.opt.mex.mex.get_path_manager")
+    def test_no_roi_atlas_passes_bare_roi_file_string(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        """Regression guard: default config keeps the pre-existing bare-string call."""
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.mex.mex import run_m_ex_search
+
+        run_m_ex_search(_mex_pool_config())
+
+        roi_arg = mock_engine_cls.call_args[0][1]
+        assert roi_arg == os.path.join(str(tmp_path / "rois"), "motor.csv")
+
+    @patch("tit.opt.mex.mex.process_and_save")
+    @patch("tit.opt.mex.mex.MExSearchEngine")
+    @patch("tit.opt.mex.mex.add_file_handler")
+    @patch("tit.opt.mex.mex.get_path_manager")
+    def test_mni_space_transforms_roi_center(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        rois_dir = tmp_path / "rois"
+        rois_dir.mkdir()
+        with open(rois_dir / "motor.csv", "w", newline="") as f:
+            csv.writer(f).writerow([5.0, 6.0, 7.0])
+
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.mex.mex import run_m_ex_search
+
+        config = _mex_pool_config(roi_coordinate_space="mni")
+
+        with patch(
+            "simnibs.mni2subject_coords",
+            return_value=np.array([[9.0, 8.0, 7.0]]),
+        ) as mock_transform:
+            run_m_ex_search(config)
+
+        mock_transform.assert_called_once()
+        assert mock_transform.call_args[0][1] == str(tmp_path / "m2m_001")
+
+        roi_arg = mock_engine_cls.call_args[0][1]
+        assert roi_arg != str(rois_dir / "motor.csv")
+        with open(roi_arg) as f:
+            row = next(csv.reader(f))
+        assert [float(v) for v in row] == pytest.approx([9.0, 8.0, 7.0])
+
+    @patch("tit.opt.mex.mex.process_and_save")
+    @patch("tit.opt.mex.mex.MExSearchEngine")
+    @patch("tit.opt.mex.mex.add_file_handler")
+    @patch("tit.opt.mex.mex.get_path_manager")
+    def test_subject_space_does_not_call_transform(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.mex.mex import run_m_ex_search
+
+        with patch("simnibs.mni2subject_coords") as mock_transform:
+            run_m_ex_search(_mex_pool_config())
+
+        mock_transform.assert_not_called()

--- a/tit/atlas/voxel.py
+++ b/tit/atlas/voxel.py
@@ -1,9 +1,31 @@
 """Voxel (volumetric) atlas discovery and region listing."""
 
 import os
+import re
 import subprocess
 
 from tit.atlas.constants import VOXEL_ATLAS_FILES, MNI_ATLAS_FILES
+
+
+def parse_region_label(region_display: str) -> int:
+    """Extract the integer label from a :meth:`VoxelAtlasManager.list_regions`
+    entry, e.g. ``"Hippocampus (ID: 17)"`` -> ``17``.
+
+    Args:
+        region_display: A ``"RegionName (ID: N)"`` string.
+
+    Returns:
+        The integer label.
+
+    Raises:
+        ValueError: If *region_display* does not end in ``"(ID: <int>)"``.
+    """
+    match = re.search(r"\(ID:\s*(-?\d+)\)\s*$", region_display)
+    if not match:
+        raise ValueError(
+            f"Could not parse an atlas region label from {region_display!r}"
+        )
+    return int(match.group(1))
 
 
 class VoxelAtlasManager:

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -37,6 +37,10 @@ from tit.gui.components.console import (
 from tit.gui.components.action_buttons import RunStopButtons
 from tit.gui.components.base_thread import BaseProcessThread
 from tit.gui.components.help_icon import HelpIcon
+from tit.gui.components.atlas_region_finder import AtlasRegionFinderDialog
+from tit.gui.components.region_chips import RegionChipsWidget
+from tit.atlas import MNI_ATLAS_DIR, VoxelAtlasManager
+from tit.atlas.voxel import parse_region_label
 from tit.paths import get_path_manager
 from tit import logger as logging_util
 from tit.opt.ex.engine import ExSearchEngine
@@ -112,6 +116,27 @@ MTI_SYMMETRY_HELP = (
     "midline.\n"
     "- Cross pairs: additionally requires pair 1 <-> 3 and pair 2 <-> 4 to "
     "mirror each other."
+)
+
+COORD_SPACE_HELP = (
+    "Space of the ROI center coordinates used for the spherical ROI(s) "
+    "selected above.\n\n"
+    "Subject Space (default): coordinates are already in this subject's "
+    "native RAS space.\n\n"
+    "MNI Space: coordinates are treated as MNI152 and transformed to each "
+    "subject's native space before the search runs.\n\n"
+    "This does not affect any Atlas ROI target below -- atlas/mask targets "
+    "are always read directly from the subject's own segmentation."
+)
+
+ATLAS_ROI_HELP = (
+    "Adds a volumetric atlas region (or a whole mask file) as an additional "
+    "search target, unioned together with the spherical ROI(s) selected "
+    "above -- the field is evaluated over their combined coverage.\n\n"
+    "Region: only the voxels equal to the chosen atlas label are included. "
+    "Whole File: every nonzero voxel in the file is included (binary mask).\n\n"
+    "Atlas targets are always read in the subject's own space, regardless "
+    "of the Coordinate Space setting above."
 )
 
 
@@ -356,6 +381,47 @@ class ExSearchTab(QtWidgets.QWidget):
     """
 
     ex_search_completed = QtCore.pyqtSignal()
+
+    # ------------------------------------------------------------------
+    # Pure helpers (atlas ROI / coordinate space) -- no Qt state, kept
+    # testable without instantiating any widget. See ExConfig.AtlasROI /
+    # ExConfig.roi_coordinate_space in tit/opt/config.py.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def coordinate_space_value(is_mni: bool) -> str:
+        """Map the Subject/MNI radio state to ``ExConfig.roi_coordinate_space``."""
+        return "mni" if is_mni else "subject"
+
+    @staticmethod
+    def atlas_roi_chip_key(atlas_path: str, label: int | None) -> str:
+        """Build the opaque chip key encoding an atlas ROI selection.
+
+        Uses a control character as separator (never valid in a filesystem
+        path or an integer) so the key round-trips exactly through
+        :meth:`atlas_roi_from_chip_key`.
+        """
+        return f"{atlas_path}\x1f{'' if label is None else label}"
+
+    @staticmethod
+    def atlas_roi_from_chip_key(key: str) -> tuple[str, int | None]:
+        """Inverse of :meth:`atlas_roi_chip_key`."""
+        atlas_path, _, label_str = key.partition("\x1f")
+        return atlas_path, (int(label_str) if label_str else None)
+
+    @classmethod
+    def build_roi_atlas_entries(cls, chip_keys: list[str]) -> list[dict]:
+        """Map selected atlas-ROI chip keys to ``ExConfig.AtlasROI``-shaped dicts.
+
+        ``ExConfig``/``MExConfig`` accept a plain dict for each entry (see
+        their ``__post_init__``), so callers can hand this straight to
+        ``roi_atlas=`` without importing the dataclass here.
+        """
+        entries = []
+        for key in chip_keys:
+            atlas_path, label = cls.atlas_roi_from_chip_key(key)
+            entries.append({"atlas_path": atlas_path, "label": label})
+        return entries
 
     def __init__(self, parent=None):
         super(ExSearchTab, self).__init__(parent)
@@ -978,8 +1044,8 @@ class ExSearchTab(QtWidgets.QWidget):
         # ============================================================
         roi_container = QtWidgets.QGroupBox("ROI Selection")
         roi_container.setFixedHeight(
-            220
-        )  # Fixed height for balance (includes radius + combine controls)
+            220 + 68
+        )  # Fixed height for balance (includes radius + combine + atlas controls)
         roi_layout = QtWidgets.QVBoxLayout(roi_container)
         roi_layout.setContentsMargins(10, 10, 10, 10)
         roi_layout.setSpacing(8)
@@ -1039,6 +1105,57 @@ class ExSearchTab(QtWidgets.QWidget):
         combine_layout.addWidget(HelpIcon(combine_tooltip, title="Combine ROIs"))
         combine_layout.addStretch()
         roi_layout.addLayout(combine_layout)
+
+        # Coordinate space toggle (governs the spherical ROI centers only).
+        space_layout = QtWidgets.QHBoxLayout()
+        space_layout.addWidget(QtWidgets.QLabel("Coordinate Space:"))
+        self.coord_space_subject = QtWidgets.QRadioButton("Subject Space")
+        self.coord_space_mni = QtWidgets.QRadioButton("MNI Space")
+        self.coord_space_subject.setChecked(True)
+        space_group = QtWidgets.QButtonGroup(self)
+        space_group.addButton(self.coord_space_subject)
+        space_group.addButton(self.coord_space_mni)
+        space_layout.addWidget(self.coord_space_subject)
+        space_layout.addWidget(self.coord_space_mni)
+        space_layout.addWidget(HelpIcon(COORD_SPACE_HELP, title="Coordinate Space"))
+        space_layout.addStretch()
+        roi_layout.addLayout(space_layout)
+
+        # Atlas ROI: optional volumetric atlas/mask target(s), unioned with
+        # the spherical ROI(s) selected above.
+        atlas_layout = QtWidgets.QHBoxLayout()
+        atlas_layout.addWidget(QtWidgets.QLabel("Atlas ROI:"))
+        self.atlas_roi_combo = QtWidgets.QComboBox()
+        self.atlas_roi_combo.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
+        atlas_layout.addWidget(self.atlas_roi_combo)
+        self.refresh_atlas_roi_btn = QtWidgets.QPushButton("Refresh")
+        self.refresh_atlas_roi_btn.clicked.connect(self._refresh_atlas_roi_combo)
+        atlas_layout.addWidget(self.refresh_atlas_roi_btn)
+        self.add_atlas_region_btn = QtWidgets.QPushButton("Add Region…")
+        self.add_atlas_region_btn.setToolTip(
+            "Browse and select one or more labeled regions from the chosen atlas."
+        )
+        self.add_atlas_region_btn.clicked.connect(self._on_add_atlas_region)
+        atlas_layout.addWidget(self.add_atlas_region_btn)
+        self.add_atlas_whole_btn = QtWidgets.QPushButton("Add Whole File")
+        self.add_atlas_whole_btn.setToolTip(
+            "Use every nonzero voxel in the selected file as a binary mask."
+        )
+        self.add_atlas_whole_btn.clicked.connect(self._on_add_atlas_whole_file)
+        atlas_layout.addWidget(self.add_atlas_whole_btn)
+        atlas_layout.addWidget(HelpIcon(ATLAS_ROI_HELP, title="Atlas ROI"))
+        roi_layout.addLayout(atlas_layout)
+
+        self.atlas_roi_chips = RegionChipsWidget(
+            placeholder="No atlas ROI targets — optional"
+        )
+        self.atlas_roi_chips.setToolTip(
+            "Selected atlas ROI target(s), unioned with the spherical ROI(s) "
+            "above. Press ✕ on a chip to remove it."
+        )
+        roi_layout.addWidget(self.atlas_roi_chips)
 
         # Add ROI container to grid - Row 1, Column 0
         main_grid_layout.addWidget(roi_container, 1, 0)
@@ -1801,6 +1918,137 @@ class ExSearchTab(QtWidgets.QWidget):
         except OSError as e:
             self.update_status(f"Error updating ROI list: {str(e)}", error=True)
 
+    def _current_voxel_atlas_manager(self) -> VoxelAtlasManager | None:
+        """Build a VoxelAtlasManager for the currently selected subject.
+
+        Returns ``None`` when no subject is selected or its m2m directory
+        cannot be resolved, so callers can no-op gracefully.
+        """
+        subject_id = self.subject_combo.currentText()
+        if not subject_id:
+            return None
+        pm = self.pm
+        m2m_dir = pm.m2m(subject_id)
+        if not m2m_dir:
+            return None
+        seg_dir = os.path.join(m2m_dir, "segmentation")
+        return VoxelAtlasManager(
+            freesurfer_mri_dir=pm.freesurfer_mri(subject_id), seg_dir=seg_dir
+        )
+
+    def _refresh_atlas_roi_combo(self):
+        """Discover volumetric atlas/mask files for the selected subject.
+
+        Cheap discovery only (file listing) -- does not shell out to
+        FreeSurfer. Region listing (``list_regions``) only happens lazily,
+        when the user clicks "Add Region…".
+        """
+        self.atlas_roi_combo.clear()
+        mgr = self._current_voxel_atlas_manager()
+        if mgr is None:
+            return
+        try:
+            atlases = mgr.list_atlases()
+        except OSError:
+            return
+        # Also offer the bundled MNI atlases (mirrors flex-search's
+        # subcortical picker); these are read-only reference files, always
+        # subject-independent, and unaffected by the coordinate-space toggle.
+        try:
+            atlases = list(atlases) + [
+                (os.path.basename(p), p)
+                for p in VoxelAtlasManager.detect_mni_atlases(MNI_ATLAS_DIR)
+            ]
+        except OSError:
+            pass
+        for display_name, path in atlases:
+            self.atlas_roi_combo.addItem(display_name, path)
+
+    def _on_add_atlas_whole_file(self):
+        """Add the currently selected atlas/mask file as a whole-file (label=None) target."""
+        atlas_path = self.atlas_roi_combo.currentData()
+        if not atlas_path:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Atlas Selected",
+                "Select an atlas or mask file first (use Refresh to discover files).",
+            )
+            return
+        atlas_path = str(atlas_path)
+        display = self.atlas_roi_combo.currentText()
+        key = self.atlas_roi_chip_key(atlas_path, None)
+        self.atlas_roi_chips.add_item(key=key, display=f"{display}: whole file")
+
+    def _on_add_atlas_region(self):
+        """Browse regions in the selected atlas and add chosen ones as targets.
+
+        ``list_regions`` shells out to FreeSurfer's ``mri_segstats`` (and
+        caches a label file next to the atlas), so it is only invoked here,
+        on explicit user action -- never at tab load or on subject change.
+        Failures (e.g. FreeSurfer unavailable) are reported and swallowed
+        rather than raised.
+        """
+        atlas_path = self.atlas_roi_combo.currentData()
+        if not atlas_path:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "No Atlas Selected",
+                "Select an atlas or mask file first (use Refresh to discover files).",
+            )
+            return
+        atlas_path = str(atlas_path)
+        display = self.atlas_roi_combo.currentText()
+
+        try:
+            mgr = VoxelAtlasManager()
+            region_strings = mgr.list_regions(atlas_path)
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Could Not List Regions",
+                f"Could not list regions for '{display}'. This atlas may not "
+                f"be a labeled segmentation, or FreeSurfer (mri_segstats) may "
+                f"not be available.\n\nDetails: {e}",
+            )
+            return
+
+        entries = []
+        for region_str in region_strings:
+            try:
+                label = parse_region_label(region_str)
+            except ValueError:
+                continue
+            name = region_str.rsplit(" (ID:", 1)[0].strip()
+            entries.append((label, name, None))
+
+        if not entries:
+            QtWidgets.QMessageBox.warning(
+                self, "No Regions Found", f"No labeled regions found in '{display}'."
+            )
+            return
+
+        preselected = [
+            str(label)
+            for key in self.atlas_roi_chips.keys()
+            for path, label in [self.atlas_roi_from_chip_key(key)]
+            if path == atlas_path and label is not None
+        ]
+
+        dlg = AtlasRegionFinderDialog(
+            self,
+            f"Atlas Regions - {display}",
+            entries,
+            return_field="id",
+            multi=True,
+            preselected=preselected,
+        )
+        if dlg.exec_() == QtWidgets.QDialog.Accepted:
+            for label, name in zip(dlg.selected_ids(), dlg.selected_names()):
+                key = self.atlas_roi_chip_key(atlas_path, label)
+                self.atlas_roi_chips.add_item(
+                    key=key, display=f"{display}: {name} (ID: {label})"
+                )
+
     def show_add_roi_dialog(self):
         """Show dialog for adding a new ROI."""
         dialog = AddROIDialog(self)
@@ -1854,6 +2102,19 @@ class ExSearchTab(QtWidgets.QWidget):
         if not all(pattern.match(e) for e in electrodes):
             return None
         return electrodes
+
+    def _confirm_mni_coordinate_space(self) -> bool:
+        """Ask the user to confirm before running with MNI-space ROI centers."""
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            "MNI Coordinates",
+            "You have selected MNI space for the ROI coordinate space.\n\n"
+            "The selected ROI(s)' coordinates will be treated as MNI space "
+            "and automatically transformed to this subject's native space.\n\n"
+            "Do you want to continue?",
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+        )
+        return reply == QtWidgets.QMessageBox.Yes
 
     def validate_inputs(self):
         """Validate all input fields before running optimization."""
@@ -1935,6 +2196,12 @@ class ExSearchTab(QtWidgets.QWidget):
     def run_optimization(self):
         """Run the ex-search optimization for selected subjects."""
         if not self.validate_inputs():
+            return
+
+        if (
+            self.coord_space_mni.isChecked()
+            and not self._confirm_mni_coordinate_space()
+        ):
             return
 
         if self._current_search_mode() == SEARCH_MODE_MTI:
@@ -2179,6 +2446,10 @@ class ExSearchTab(QtWidgets.QWidget):
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
             roi_names=roi_names,
+            roi_atlas=self.build_roi_atlas_entries(self.atlas_roi_chips.keys()) or None,
+            roi_coordinate_space=self.coordinate_space_value(
+                self.coord_space_mni.isChecked()
+            ),
             electrodes=electrodes,
             total_current=self.total_current_spinbox.value(),
             current_step=self.current_step_spinbox.value(),
@@ -2238,6 +2509,10 @@ class ExSearchTab(QtWidgets.QWidget):
             subject_id=subject_id,
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
+            roi_atlas=self.build_roi_atlas_entries(self.atlas_roi_chips.keys()) or None,
+            roi_coordinate_space=self.coordinate_space_value(
+                self.coord_space_mni.isChecked()
+            ),
             electrodes=electrodes,
             current_mA=self.mex_current_spinbox.value(),
             channels=self.mex_channels_combo.currentData(),
@@ -2881,6 +3156,7 @@ class ExSearchTab(QtWidgets.QWidget):
         """Handle subject selection changes."""
         self.refresh_leadfields()
         self.update_roi_list()
+        self._refresh_atlas_roi_combo()
 
 
 class AddROIDialog(QtWidgets.QDialog):

--- a/tit/opt/config.py
+++ b/tit/opt/config.py
@@ -643,8 +643,19 @@ class ExConfig:
         Optional list of ROI CSV filenames to **union** into a single
         target.  When provided (combined mode), the spherical masks of
         every listed ROI are OR-folded into one region.  ``None``
-        (default) keeps single-ROI behavior driven by *roi_name*.  Each
-        entry gets the ``".csv"`` suffix appended if missing.
+        (default) keeps single-ROI behavior driven by *roi_name*.  An
+        explicit empty list means "no spherical centers at all" -- useful
+        for a purely atlas-driven ROI (*roi_atlas* only).  Each entry gets
+        the ``".csv"`` suffix appended if missing.
+    roi_atlas : list of AtlasROI or None
+        Volumetric atlas or mask ROI(s) to union with the spherical
+        centers from *roi_name*/*roi_names*.  ``None`` (default) keeps
+        the existing spherical-only behavior.
+    roi_coordinate_space : str
+        Space of the *roi_name*/*roi_names* CSV centers -- ``"subject"``
+        (default) or ``"mni"``.  MNI centers are transformed to subject
+        space with ``simnibs.mni2subject_coords`` before the search runs.
+        Does not affect *roi_atlas*, which is always subject space.
     electrodes : BucketElectrodes or PoolElectrodes
         Electrode specification, either a single shared pool
         (:class:`PoolElectrodes`) or separate per-channel buckets
@@ -666,13 +677,34 @@ class ExConfig:
     ------
     ValueError
         If *current_step*, *total_current*, or *channel_limit* are
-        non-positive.
+        non-positive, or if *roi_coordinate_space* is not ``"subject"``
+        or ``"mni"``.
 
     See Also
     --------
     ExResult : Result container returned by :func:`~tit.opt.ex.ex.run_ex_search`.
     tit.opt.ex.ex.run_ex_search : Consumes this config.
     """
+
+    # ── Nested ROI types ─────────────────────────────────────────────────
+    @dataclass
+    class AtlasROI:
+        """Volumetric atlas or mask ROI, unioned with the spherical center(s).
+
+        Attributes
+        ----------
+        atlas_path : str
+            Path to a volumetric atlas or mask file -- NIfTI (``.nii``,
+            ``.nii.gz``) or FreeSurfer (``.mgz``), e.g. one discovered by
+            :class:`tit.atlas.voxel.VoxelAtlasManager`.
+        label : int or None
+            Integer label to select within the atlas (elements are
+            included where the voxel value equals *label*).  ``None``
+            treats the whole file as a binary mask (voxel value ``> 0``).
+        """
+
+        atlas_path: str
+        label: int | None = None
 
     # ── Nested electrode types ─────────────────────────────────────────
     @dataclass
@@ -722,6 +754,8 @@ class ExConfig:
     # ── ROI ────────────────────────────────────────────────────────────
     roi_radius: float = 3.0
     roi_names: list[str] | None = None
+    roi_atlas: list[AtlasROI] | None = None
+    roi_coordinate_space: Literal["subject", "mni"] = "subject"
 
     # ── Output naming (defaults to datetime stamp) ─────────────────────
     run_name: str | None = None
@@ -738,6 +772,17 @@ class ExConfig:
             self.roi_names = [
                 n if n.endswith(".csv") else f"{n}.csv" for n in self.roi_names
             ]
+        if self.roi_atlas is not None:
+            self.roi_atlas = [
+                a if isinstance(a, ExConfig.AtlasROI) else ExConfig.AtlasROI(**a)
+                for a in self.roi_atlas
+            ]
+        self.roi_coordinate_space = str(self.roi_coordinate_space).strip().lower()
+        if self.roi_coordinate_space not in ("subject", "mni"):
+            raise ValueError(
+                "roi_coordinate_space must be 'subject' or 'mni' (was "
+                f"{self.roi_coordinate_space!r})"
+            )
 
         # Validation
         if self.current_step <= 0:
@@ -820,6 +865,15 @@ class MExConfig:
         expressed.
     roi_radius : float
         Spherical ROI radius in mm for the target region.
+    roi_atlas : list of AtlasROI or None
+        Volumetric atlas or mask ROI(s) to union with the spherical center
+        from *roi_name*.  ``None`` (default) keeps the existing
+        spherical-only behavior.
+    roi_coordinate_space : str
+        Space of the *roi_name* CSV center -- ``"subject"`` (default) or
+        ``"mni"``.  An MNI center is transformed to subject space with
+        ``simnibs.mni2subject_coords`` before the search runs.  Does not
+        affect *roi_atlas*, which is always subject space.
     run_name : str or None
         Optional name for this run.  Defaults to a datetime stamp.
     symmetric_bucket : bool
@@ -838,8 +892,9 @@ class MExConfig:
     ------
     ValueError
         If *current_mA* is non-positive, if *symmetric_bucket* is set
-        with pool electrodes, or if *symmetry_pairing* is not one of
-        ``"within_pairs"``/``"cross_pairs"``.
+        with pool electrodes, if *symmetry_pairing* is not one of
+        ``"within_pairs"``/``"cross_pairs"``, or if *roi_coordinate_space*
+        is not ``"subject"`` or ``"mni"``.
 
     See Also
     --------
@@ -847,6 +902,26 @@ class MExConfig:
     tit.opt.mex.mex.run_m_ex_search : Consumes this config.
     tit.calc.get_mTI_vectors : Modulation-amplitude envelope; consumes *channels*.
     """
+
+    # ── Nested ROI types ─────────────────────────────────────────────────
+    @dataclass
+    class AtlasROI:
+        """Volumetric atlas or mask ROI, unioned with the spherical center.
+
+        Attributes
+        ----------
+        atlas_path : str
+            Path to a volumetric atlas or mask file -- NIfTI (``.nii``,
+            ``.nii.gz``) or FreeSurfer (``.mgz``), e.g. one discovered by
+            :class:`tit.atlas.voxel.VoxelAtlasManager`.
+        label : int or None
+            Integer label to select within the atlas (elements are
+            included where the voxel value equals *label*).  ``None``
+            treats the whole file as a binary mask (voxel value ``> 0``).
+        """
+
+        atlas_path: str
+        label: int | None = None
 
     # ── Nested electrode types ─────────────────────────────────────────
     @dataclass
@@ -892,6 +967,8 @@ class MExConfig:
 
     # ── ROI ────────────────────────────────────────────────────────────
     roi_radius: float = 3.0
+    roi_atlas: list[AtlasROI] | None = None
+    roi_coordinate_space: Literal["subject", "mni"] = "subject"
 
     # ── Output naming (defaults to datetime stamp) ─────────────────────
     run_name: str | None = None
@@ -909,6 +986,17 @@ class MExConfig:
                 self.electrodes = MExConfig.BucketElectrodes(**self.electrodes)
         if not self.roi_name.endswith(".csv"):
             self.roi_name += ".csv"
+        if self.roi_atlas is not None:
+            self.roi_atlas = [
+                a if isinstance(a, MExConfig.AtlasROI) else MExConfig.AtlasROI(**a)
+                for a in self.roi_atlas
+            ]
+        self.roi_coordinate_space = str(self.roi_coordinate_space).strip().lower()
+        if self.roi_coordinate_space not in ("subject", "mni"):
+            raise ValueError(
+                "roi_coordinate_space must be 'subject' or 'mni' (was "
+                f"{self.roi_coordinate_space!r})"
+            )
 
         if self.current_mA <= 0:
             raise ValueError("current_mA must be positive")

--- a/tit/opt/ex/engine.py
+++ b/tit/opt/ex/engine.py
@@ -31,7 +31,7 @@ class ExSearchEngine:
     def __init__(
         self,
         leadfield_hdf: str,
-        roi_file: str | list[str],
+        roi_file: str | tuple[str, int] | list[str | tuple[str, int]],
         roi_name: str,
         logger: logging.Logger,
     ):
@@ -53,7 +53,7 @@ class ExSearchEngine:
     # ── Initialization ────────────────────────────────────────────────────
 
     def initialize(self, roi_radius: float = 3.0) -> None:
-        """Load leadfield, parse ROI CSV, find ROI + GM elements."""
+        """Load leadfield, resolve the ROI (CSV/mask/atlas), find ROI + GM elements."""
         self._load_leadfield()
         self._load_roi_coordinates()
         self._find_roi_elements(roi_radius)
@@ -65,22 +65,48 @@ class ExSearchEngine:
         self.leadfield, self.mesh, self.idx_lf = TI.load_leadfield(self.leadfield_hdf)
         self.logger.info(f"Loaded in {time.time() - start:.1f}s")
 
-    def _load_roi_coordinates(self) -> None:
-        """Read ROI center(s) from one or more simple CSVs (one row: x,y,z).
+    def _roi_entries(self) -> list:
+        """Normalize ``roi_file`` to a list of entries.
 
-        A single ``roi_file`` (str) yields one center; a list yields one
-        center per file (combined/union mode).  ``roi_coords`` always
-        mirrors the first center for backward compatibility.
+        Each entry is a CSV path (spherical center), a NIfTI/MGZ path
+        (mask, ``value > 0``), or a ``(path, label)`` pair (one atlas
+        label, ``value == label``).
         """
-        files = self.roi_file if isinstance(self.roi_file, list) else [self.roi_file]
-        self.roi_centers = [self._read_center(f) for f in files]
-        self.roi_coords = self.roi_centers[0]
+        return self.roi_file if isinstance(self.roi_file, list) else [self.roi_file]
+
+    @staticmethod
+    def _is_nifti_roi(entry) -> bool:
+        """True if *entry* selects a volumetric mask rather than a CSV center.
+
+        A ``(path, label)`` pair always names a labelled atlas region. A
+        bare path names a mask when it has a NIfTI or FreeSurfer MGZ
+        extension (``.nii``, ``.nii.gz``, ``.mgz``) -- the extensions used
+        by every atlas :class:`tit.atlas.voxel.VoxelAtlasManager` discovers.
+        """
+        if isinstance(entry, (tuple, list)):
+            return True
+        name = str(entry).lower()
+        return name.endswith((".nii", ".nii.gz", ".mgz"))
+
+    def _load_roi_coordinates(self) -> None:
+        """Read spherical ROI center(s) from the CSV entries in ``roi_file``.
+
+        NIfTI/MGZ mask and atlas-label entries are skipped here and
+        resolved directly by :meth:`_find_roi_elements`.  ``roi_coords``
+        mirrors the first CSV center for backward compatibility, and is
+        ``None`` when every entry is a mask.
+        """
+        csv_files = [e for e in self._roi_entries() if not self._is_nifti_roi(e)]
+        self.roi_centers = [self._read_center(f) for f in csv_files]
+        self.roi_coords = self.roi_centers[0] if self.roi_centers else None
         if len(self.roi_centers) == 1:
             self.logger.info(f"ROI coords: {self.roi_coords}")
-        else:
+        elif self.roi_centers:
             self.logger.info(
                 f"ROI centers ({len(self.roi_centers)}): {self.roi_centers}"
             )
+        else:
+            self.logger.info("No spherical ROI centers (mask-only ROI)")
 
     def _read_center(self, path: str) -> list[float]:
         """Return the first valid ``[x, y, z]`` triple from an ROI CSV."""
@@ -93,19 +119,64 @@ class ExSearchEngine:
                     return coords[:3]
         raise ValueError(f"No valid coordinates in {path}")
 
-    def _find_roi_elements(self, roi_radius: float) -> None:
-        """Find mesh elements whose barycenters fall within any ROI sphere.
+    def _nifti_roi_mask(self, entry, baricenters: np.ndarray) -> np.ndarray:
+        """Boolean mask selecting elements inside one NIfTI/MGZ ROI source.
 
-        For a combined target the per-center spherical masks are OR-folded
-        into one region (single-center is the N=1 case).
+        *entry* is either a mask path (elements where ``value > 0``) or a
+        ``(atlas_path, label)`` pair selecting one atlas label
+        (``value == label``).
+        """
+        import nibabel as nib
+
+        path, label = entry if isinstance(entry, (tuple, list)) else (entry, None)
+        self.logger.info(
+            f"Finding ROI elements from {'atlas label ' + str(label) if label is not None else 'mask'}: {path}"
+        )
+
+        img = nib.load(path)
+        data = np.asanyarray(img.get_fdata())
+        if data.ndim == 4:
+            data = np.squeeze(data)
+        if data.ndim != 3:
+            raise ValueError(f"Expected a 3D ROI mask, got shape {data.shape}")
+        mask_data = data == label if label is not None else data > 0
+
+        homogeneous = np.hstack([baricenters, np.ones((len(baricenters), 1))])
+        vox = (homogeneous @ np.linalg.inv(img.affine).T)[:, :3]
+        vox = np.rint(vox).astype(int)
+
+        shape = np.asarray(mask_data.shape[:3])
+        in_bounds = np.all((vox >= 0) & (vox < shape), axis=1)
+        mask = np.zeros(len(baricenters), dtype=bool)
+        valid_vox = vox[in_bounds]
+        if len(valid_vox):
+            mask[in_bounds] = mask_data[
+                valid_vox[:, 0], valid_vox[:, 1], valid_vox[:, 2]
+            ]
+        return mask
+
+    def _find_roi_elements(self, roi_radius: float) -> None:
+        """Find mesh elements that fall within the target ROI.
+
+        Combines spherical centers (``value`` within *roi_radius* of a
+        center) and volumetric masks (whole NIfTI/MGZ masks, or
+        ``(path, label)`` atlas-label selections) -- every source in
+        ``roi_file`` is OR-folded into one region (a single spherical
+        center is the N=1 case).
         """
         self.logger.info(f"Finding ROI elements (radius={roi_radius}mm)...")
         baricenters = self.mesh.elements_baricenters().value
         roi_centers = self.roi_centers if self.roi_centers else [self.roi_coords]
         mask = np.zeros(baricenters.shape[0], dtype=bool)
         for c in roi_centers:
+            if c is None:
+                continue
             center = np.asarray(c, dtype=float)
             mask |= np.sum((baricenters - center) ** 2, axis=1) <= roi_radius**2
+
+        for entry in self._roi_entries():
+            if self._is_nifti_roi(entry):
+                mask |= self._nifti_roi_mask(entry, baricenters)
 
         volumes = self.mesh.elements_volumes_and_areas().value
         if volumes.ndim > 1:

--- a/tit/opt/ex/ex.py
+++ b/tit/opt/ex/ex.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 
+
 from tit.opt.config import ExConfig, ExResult
 from tit.paths import get_path_manager
 from tit.logger import add_file_handler
@@ -14,6 +15,7 @@ from tit.logger import add_file_handler
 from .engine import ExSearchEngine
 from .logic import generate_current_ratios
 from .results import process_and_save
+from .roi import atlas_roi_entries, mni_roi_files_to_subject_space
 
 
 def run_ex_search(config: ExConfig) -> ExResult:
@@ -46,10 +48,21 @@ def _run_ex_search_inner(config: ExConfig) -> ExResult:
     os.makedirs(output_dir, exist_ok=True)
     logger.info(f"Output: {output_dir}")
 
-    roi_names = config.roi_names or [config.roi_name]
-    roi_files = [os.path.join(pm.rois(config.subject_id), name) for name in roi_names]
+    roi_names = config.roi_names if config.roi_names is not None else [config.roi_name]
+    roi_dir = pm.rois(config.subject_id)
+    if roi_names and config.roi_coordinate_space == "mni":
+        roi_files = mni_roi_files_to_subject_space(
+            roi_names, roi_dir, pm.m2m(config.subject_id), output_dir, logger
+        )
+    else:
+        roi_files = [os.path.join(roi_dir, name) for name in roi_names]
     if len(roi_files) > 1:
         logger.info(f"Combining {len(roi_files)} ROIs into one target: {roi_names}")
+
+    atlas_entries = atlas_roi_entries(config)
+    if atlas_entries:
+        logger.info(f"Adding {len(atlas_entries)} atlas ROI target(s)")
+        roi_files = roi_files + atlas_entries
 
     if isinstance(config.electrodes, ExConfig.PoolElectrodes):
         pool = config.electrodes.electrodes

--- a/tit/opt/ex/roi.py
+++ b/tit/opt/ex/roi.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env simnibs_python
+"""ROI resolution shared by the 2-pair and 4-pair exhaustive searches.
+
+Both searches accept the same ROI inputs -- spherical centres from CSV, in
+subject or MNI space, and volumetric atlas regions -- so the translation from
+config fields to engine inputs lives here rather than in each search module.
+
+See Also
+--------
+tit.opt.ex.engine.ExSearchEngine : Consumes the entries built here.
+"""
+
+import csv
+import os
+from pathlib import Path
+
+import numpy as np
+
+
+def mni_roi_files_to_subject_space(
+    roi_names: list[str], roi_dir: str, m2m_path: str, output_dir: str, logger
+) -> list[str]:
+    """Reproject MNI-space ROI CSV centres to subject space.
+
+    Reads each ROI CSV's ``x, y, z`` row, transforms it with
+    ``simnibs.mni2subject_coords``, and writes a subject-space copy under
+    *output_dir*. The search engine only ever receives subject-space centres.
+
+    Parameters
+    ----------
+    roi_names : list of str
+        ROI CSV filenames, relative to *roi_dir*.
+    roi_dir : str
+        Directory holding the ROI CSVs.
+    m2m_path : str
+        Subject ``m2m_<id>`` directory, used for the transform.
+    output_dir : str
+        Where the subject-space copies are written.
+    logger : logging.Logger
+        Logger for progress output.
+
+    Returns
+    -------
+    list of str
+        Paths to the subject-space CSVs, in the order given.
+    """
+    from simnibs import mni2subject_coords
+
+    subject_files = []
+    for name in roi_names:
+        with open(os.path.join(roi_dir, name)) as f:
+            row = next(csv.reader(f))
+        coords = [float(v.strip()) for v in row if v.strip()][:3]
+        arr = np.atleast_2d(mni2subject_coords(np.array([coords]), str(m2m_path)))
+        dst = os.path.join(output_dir, f"{Path(name).stem}_subject_space.csv")
+        with open(dst, "w", newline="") as f:
+            csv.writer(f).writerow(list(arr[0]))
+        subject_files.append(dst)
+    logger.info("Transformed %d MNI ROI center(s) to subject space", len(subject_files))
+    return subject_files
+
+
+def atlas_roi_entries(config) -> list:
+    """Build engine ``roi_file`` entries from a config's ``roi_atlas`` targets.
+
+    Parameters
+    ----------
+    config : ExConfig or MExConfig
+        Any config exposing a ``roi_atlas`` sequence of targets with
+        ``atlas_path`` and ``label`` attributes.
+
+    Returns
+    -------
+    list
+        A bare path per whole-file mask target, or a ``(path, label)`` pair
+        per atlas-region target. Empty when no atlas targets are set.
+    """
+    if not getattr(config, "roi_atlas", None):
+        return []
+    return [
+        target.atlas_path if target.label is None else (target.atlas_path, target.label)
+        for target in config.roi_atlas
+    ]

--- a/tit/opt/mex/engine.py
+++ b/tit/opt/mex/engine.py
@@ -25,7 +25,7 @@ class MExSearchEngine(ExSearchEngine):
     def __init__(
         self,
         leadfield_hdf: str,
-        roi_file: str,
+        roi_file: str | tuple[str, int] | list[str | tuple[str, int]],
         roi_name: str,
         logger: logging.Logger,
         channels: list[tuple[list[int], list[int]]] | None = None,

--- a/tit/opt/mex/mex.py
+++ b/tit/opt/mex/mex.py
@@ -3,15 +3,18 @@
 Public API: ``run_m_ex_search(config) -> MExResult``
 """
 
+import csv
 import logging
 import os
 import time
 from pathlib import Path
 
+
 from tit.logger import add_file_handler
 from tit.opt.config import MExConfig, MExResult
 from tit.opt.ex.buckets import build_electrode_mirror_map, canonical_template_coord_path
 from tit.opt.ex.results import process_and_save
+from tit.opt.ex.roi import atlas_roi_entries, mni_roi_files_to_subject_space
 from tit.paths import get_path_manager
 
 from .engine import MExSearchEngine
@@ -44,7 +47,20 @@ def _run_m_ex_search_inner(config: MExConfig) -> MExResult:
     os.makedirs(output_dir, exist_ok=True)
     logger.info("Output: %s", output_dir)
 
-    roi_file = os.path.join(pm.rois(config.subject_id), config.roi_name)
+    roi_dir = pm.rois(config.subject_id)
+    if config.roi_coordinate_space == "mni":
+        [roi_file] = mni_roi_files_to_subject_space(
+            [config.roi_name], roi_dir, pm.m2m(config.subject_id), output_dir, logger
+        )
+    else:
+        roi_file = os.path.join(roi_dir, config.roi_name)
+
+    atlas_entries = atlas_roi_entries(config)
+    if atlas_entries:
+        logger.info("Adding %d atlas ROI target(s)", len(atlas_entries))
+        roi_target = [roi_file] + atlas_entries
+    else:
+        roi_target = roi_file
 
     if isinstance(config.electrodes, MExConfig.PoolElectrodes):
         buckets_or_pool = config.electrodes.electrodes
@@ -69,7 +85,7 @@ def _run_m_ex_search_inner(config: MExConfig) -> MExResult:
     )
 
     engine = MExSearchEngine(
-        leadfield_path, roi_file, config.roi_name, logger, channels=config.channels
+        leadfield_path, roi_target, config.roi_name, logger, channels=config.channels
     )
     engine.initialize(roi_radius=config.roi_radius)
     results = engine.run(


### PR DESCRIPTION
Exhaustive search accepted exactly one kind of target: a sphere of `roi_radius` around a centre from a CSV, subject space only. It now also accepts volumetric atlas regions and MNI-space centres, for both the 2-pair and 4-pair searches.

## Backend

Atlas ROIs reuse the NIfTI-mask element selection from `alba/ex-search-multipolar`, generalized twice over. Hers assumed a single `roi_file`; main takes `str | list[str]` for the multi-ROI union from #130, so masks are OR-folded the way spherical centres already were, and a **mixed** list of centres and masks unions transparently.

And a whole atlas file is not a target — a *label within it* is. A `(path, label)` entry masks on `data == label` rather than `data > 0`; otherwise picking "left hippocampus" from `labeling.nii.gz` would select the entire segmentation.

Atlas discovery is left to `tit.atlas.VoxelAtlasManager`, already canonical for the analyzer, flex-search and the NIfTI viewer, so ex-search offers exactly the same list: FreeSurfer atlases, `labeling.nii.gz` from CHARM, and the bundled MNI atlases.

MNI centres are transformed with `simnibs.mni2subject_coords` and written as subject-space CSVs before the engine sees them, so the engine still only ever receives subject-space coordinates. The default subject-space path never reaches the transform.

The two search modules had grown near-identical copies of both helpers — 32 lines differing only in a log-format style and a type annotation — so they now live in `tit/opt/ex/roi.py`, which mex already depends on. Dropped the imports that went dead with them.

## GUI

Subject/MNI radios matching the analyzer's wording and default, with a confirmation before a run when MNI is selected, mirroring flex-search's existing warning.

Atlas targets are added from a registry-populated combo, regions picked via the existing `AtlasRegionFinderDialog`, shown as removable chips; whole files can be added as binary masks. `list_regions` shells out to FreeSurfer's `mri_segstats`, so it is called only when a region is actually being picked — not at tab load or subject change — and failure surfaces as a message rather than an exception.

Explanations sit behind `HelpIcon` popups rather than as text in the window.

## Also fixed

The region-label parser had been a staticmethod on the tab, putting a pure string function behind a PyQt5 import so its tests skipped on any machine without a display. It moved to `tit/atlas/voxel.py` beside the `list_regions` whose format it parses, with five tests that actually run — region names containing their own parentheses, zero and negative labels, unparseable input.

`MExSearchEngine.roi_file` was annotated `str` while accepting masks and lists through the base class; corrected.

## Verification

Suite **2331 passed / 0 failed**. The 88 existing ex/mex tests pass unmodified as a regression guard — untouched controls leave the old behaviour exactly as it was (no chips means `roi_atlas` is `None`; the radio default means subject space).

**Rendering is unverified.** PyQt5 is absent on the host, so the taller ROI Selection box, the chips widget wrapping, and the dialog flows are unchecked.