### PR TITLE
sim: make the output fields selectable, TI_max only by default

### DIFF
--- a/tests/test_sim_config.py
+++ b/tests/test_sim_config.py
@@ -296,6 +296,35 @@ class TestSimulationConfig:
             )
             assert config.conductivity == cond
 
+    def test_default_output_fields(self):
+        config = SimulationConfig(subject_id="001", montages=[])
+        assert config.output_fields == ["TI_max"]
+
+    def test_output_fields_individually_selectable(self):
+        for name in ("TI_max", "TI_avg", "hf_peak", "hf_sar"):
+            config = SimulationConfig(
+                subject_id="001", montages=[], output_fields=[name]
+            )
+            assert config.output_fields == [name]
+
+    def test_output_fields_combination(self):
+        config = SimulationConfig(
+            subject_id="001",
+            montages=[],
+            output_fields=["TI_max", "hf_peak", "hf_sar"],
+        )
+        assert config.output_fields == ["TI_max", "hf_peak", "hf_sar"]
+
+    def test_output_fields_unknown_name_rejected(self):
+        with pytest.raises(ValueError, match="Invalid output field"):
+            SimulationConfig(
+                subject_id="001", montages=[], output_fields=["not_a_field"]
+            )
+
+    def test_output_fields_empty_rejected(self):
+        with pytest.raises(ValueError, match="output_fields must not be empty"):
+            SimulationConfig(subject_id="001", montages=[], output_fields=[])
+
     def test_with_montages(self):
         m = Montage(
             name="test",

--- a/tests/test_sim_pipeline.py
+++ b/tests/test_sim_pipeline.py
@@ -207,7 +207,16 @@ class TestTISimulation:
             }
 
             sim = _ti_mod.TISimulation(
-                _make_sim_config(), _make_ti_montage(), MagicMock()
+                _make_sim_config(
+                    output_fields=[
+                        const.FIELD_TI_MAX,
+                        const.FIELD_TI_AVG,
+                        const.FIELD_HF_PEAK,
+                        const.FIELD_HF_SAR,
+                    ]
+                ),
+                _make_ti_montage(),
+                MagicMock(),
             )
             sim.run("/fake/sim_dir")
 
@@ -341,7 +350,15 @@ class TestMTISimulation:
             mock_get_mti.return_value = np.zeros((e_field_value.shape[0], 3))
             mock_get_ti.return_value = np.zeros((10, 3))
 
-            config = _make_sim_config(intensities=[1.0, 1.0, 1.0, 1.0])
+            config = _make_sim_config(
+                intensities=[1.0, 1.0, 1.0, 1.0],
+                output_fields=[
+                    const.FIELD_TI_MAX,
+                    const.FIELD_TI_AVG,
+                    const.FIELD_HF_PEAK,
+                    const.FIELD_HF_SAR,
+                ],
+            )
             montage = _make_mti_montage()
             logger = MagicMock()
 
@@ -363,7 +380,7 @@ class TestMTISimulation:
             mock_get_mti.assert_called_once()
 
             # D2 regression guard: hf_peak/hf_sar safety metrics must be
-            # written onto the mTI output mesh unconditionally.
+            # written onto the mTI output mesh when selected.
             mout = mock_mesh_io.read_msh.return_value.crop_mesh.return_value
             written_field_names = [
                 call.args[1] for call in mout.add_element_field.call_args_list
@@ -372,7 +389,7 @@ class TestMTISimulation:
             assert const.FIELD_HF_SAR in written_field_names
 
             # TI_avg (tit.calc.get_TI_avg): orientation-averaged companion
-            # to TI_Max, must also be written unconditionally.
+            # to TI_Max, must also be written when selected.
             assert const.FIELD_TI_AVG in written_field_names
 
     def test_montage_channels_passed_to_get_mti_and_get_ti_avg(self):
@@ -428,7 +445,12 @@ class TestMTISimulation:
             mock_get_ti.return_value = np.zeros((10, 3))
 
             channels = [([0, 2], [1, 3])]
-            config = _make_sim_config(intensities=[1.0, 1.0, 1.0, 1.0])
+            # opt into TI_avg: this test asserts channel pass-through to
+            # get_TI_avg, which is no longer computed by default.
+            config = _make_sim_config(
+                intensities=[1.0, 1.0, 1.0, 1.0],
+                output_fields=[const.FIELD_TI_MAX, const.FIELD_TI_AVG],
+            )
             montage = _make_mti_montage(name="test_mti_ch", channels=channels)
             assert montage.channels == channels  # dataclass field round-trip
 
@@ -492,7 +514,12 @@ class TestMTISimulation:
             mock_get_avg.return_value = np.zeros(e_field_value.shape[0])
             mock_get_ti.return_value = np.zeros((10, 3))
 
-            config = _make_sim_config(intensities=[1.0, 1.0, 1.0, 1.0])
+            # opt into TI_avg: this test asserts channel pass-through to
+            # get_TI_avg, which is no longer computed by default.
+            config = _make_sim_config(
+                intensities=[1.0, 1.0, 1.0, 1.0],
+                output_fields=[const.FIELD_TI_MAX, const.FIELD_TI_AVG],
+            )
             montage = _make_mti_montage()
             assert montage.channels is None
 
@@ -682,3 +709,128 @@ class TestRunSimulation:
             assert len(results) == 1
             mock_ti_cls.assert_called_once()
             mock_mti_cls.assert_not_called()
+
+
+# ============================================================================
+# Output-field selection
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestOutputFieldSelection:
+    """Only the selected output fields are computed and written.
+
+    The point of gating is cost, not tidiness: TI_avg runs a direction sweep
+    (~0.5s per 200k elements), while hf_peak/hf_sar are nearly free. Skipping
+    the write but still computing would save nothing.
+    """
+
+    def _run_ti(self, output_fields):
+        with (
+            patch.object(_base_mod, "get_path_manager") as mock_pm,
+            patch.object(_base_mod, "setup_montage_directories") as mock_setup_dirs,
+            patch.object(_base_mod, "create_simulation_config_file"),
+            patch.object(_base_mod, "run_montage_visualization"),
+            patch.object(_base_mod, "run_simnibs"),
+            patch.object(_base_mod, "subprocess"),
+            patch.object(_ti_mod, "extract_fields"),
+            patch.object(_ti_mod, "transform_dirs_to_nifti"),
+            patch.object(_ti_mod, "start_t1_to_mni"),
+            patch.object(_ti_mod, "finish_t1_to_mni"),
+            patch.object(_ti_mod, "safe_move"),
+            patch.object(_ti_mod, "mesh_io") as mock_mesh_io,
+            patch.object(_ti_mod, "TI"),
+            patch.object(_ti_mod, "glob"),
+            patch.object(_ti_mod, "deepcopy") as mock_deepcopy,
+            patch.object(_ti_mod, "get_TI_avg") as mock_ti_avg,
+            patch.object(_ti_mod, "hf_peak") as mock_hf_peak,
+            patch.object(_ti_mod, "hf_sar") as mock_hf_sar,
+        ):
+            mock_pm.return_value.m2m.return_value = "/fake/m2m"
+            mock_pm.return_value.simulation.return_value = "/fake/sim/test_ti"
+            mock_pm.return_value.eeg_positions.return_value = "/fake/eeg"
+            _mock_mesh_efields(mock_mesh_io)
+            mock_deepcopy.side_effect = lambda obj: obj
+            mock_setup_dirs.return_value = {
+                k: f"/fake/{k}"
+                for k in (
+                    "montage_dir",
+                    "hf_dir",
+                    "hf_mesh",
+                    "hf_niftis",
+                    "hf_analysis",
+                    "ti_mesh",
+                    "ti_niftis",
+                    "ti_surfaces",
+                    "ti_surface_overlays",
+                    "ti_montage_imgs",
+                    "documentation",
+                )
+            }
+            sim = _ti_mod.TISimulation(
+                _make_sim_config(output_fields=output_fields),
+                _make_ti_montage(),
+                MagicMock(),
+            )
+            sim.run("/fake/simulation_dir")
+            mout = mock_mesh_io.read_msh.return_value.crop_mesh.return_value
+            written = [c.args[1] for c in mout.add_element_field.call_args_list]
+            return written, mock_ti_avg, mock_hf_peak, mock_hf_sar
+
+    def test_default_writes_only_ti_max(self):
+        written, ti_avg, hf_peak_m, hf_sar_m = self._run_ti([const.FIELD_TI_MAX])
+        assert written == [const.FIELD_TI_MAX]
+
+    def test_unselected_fields_are_not_computed(self):
+        _, ti_avg, hf_peak_m, hf_sar_m = self._run_ti([const.FIELD_TI_MAX])
+        ti_avg.assert_not_called()
+        hf_peak_m.assert_not_called()
+        hf_sar_m.assert_not_called()
+
+    def test_selecting_ti_avg_computes_it(self):
+        written, ti_avg, _, _ = self._run_ti([const.FIELD_TI_MAX, const.FIELD_TI_AVG])
+        ti_avg.assert_called_once()
+        assert const.FIELD_TI_AVG in written
+
+    def test_selecting_safety_fields_computes_them(self):
+        written, ti_avg, hf_peak_m, hf_sar_m = self._run_ti(
+            [const.FIELD_HF_PEAK, const.FIELD_HF_SAR]
+        )
+        hf_peak_m.assert_called_once()
+        hf_sar_m.assert_called_once()
+        ti_avg.assert_not_called()
+        assert const.FIELD_TI_MAX not in written
+
+
+@pytest.mark.unit
+class TestOutputFieldsSurviveDeserialization:
+    """``_build_sim_config`` reads an explicit key list, so a new field is
+    dropped unless added there -- the bug that silently lost Montage.channels
+    on the GUI -> JSON -> subprocess path."""
+
+    @staticmethod
+    def _rebuild(**overrides):
+        import json as _json
+        from tit.config_io import serialize_config
+        from tit.sim.__main__ import _build_sim_config
+
+        cfg = _make_sim_config(montages=[_make_ti_montage()], **overrides)
+        return _build_sim_config(_json.loads(_json.dumps(serialize_config(cfg))))
+
+    def test_selection_survives_round_trip(self):
+        back = self._rebuild(output_fields=[const.FIELD_TI_MAX, const.FIELD_HF_SAR])
+        assert back.output_fields == [const.FIELD_TI_MAX, const.FIELD_HF_SAR]
+
+    def test_absent_key_defaults_to_ti_max(self):
+        from tit.sim.__main__ import _build_sim_config
+
+        import json as _json
+        from tit.config_io import serialize_config
+
+        data = _json.loads(
+            _json.dumps(
+                serialize_config(_make_sim_config(montages=[_make_ti_montage()]))
+            )
+        )
+        data.pop("output_fields", None)
+        assert _build_sim_config(data).output_fields == [const.FIELD_TI_MAX]

--- a/tit/constants.py
+++ b/tit/constants.py
@@ -264,6 +264,15 @@ def get_fields_by_kind(kind: str) -> tuple[FieldSpec, ...]:
     return tuple(spec for spec in FIELD_REGISTRY if spec.kind == kind)
 
 
+def get_selectable_output_field_specs() -> tuple[FieldSpec, ...]:
+    """Return :class:`FieldSpec` entries for the four selectable output fields.
+
+    Order matches :data:`SELECTABLE_OUTPUT_FIELDS` (registry order). Used by
+    the GUI to build output-field checkboxes without hardcoding labels.
+    """
+    return tuple(get_field_spec(name) for name in SELECTABLE_OUTPUT_FIELDS)
+
+
 def get_field_spec(name: str) -> FieldSpec:
     """Look up a :class:`FieldSpec` by its exact field name.
 
@@ -276,6 +285,18 @@ def get_field_spec(name: str) -> FieldSpec:
         if spec.name == name:
             return spec
     raise KeyError(f"Unknown field name: {name!r}")
+
+
+#: The four volume-mesh output fields a simulation may selectively compute
+#: and write (``SimulationConfig.output_fields``). Excludes ``FIELD_MTI_MAX``
+#: (the mTI on-disk spelling of ``FIELD_TI_MAX``, not a distinct user choice)
+#: and ``FIELD_TI_NORMAL`` (a node field on a separate surface mesh, not a
+#: volume field produced by the same post-processing step).
+SELECTABLE_OUTPUT_FIELDS: tuple[str, ...] = tuple(
+    spec.name
+    for spec in FIELD_REGISTRY
+    if spec.name not in (FIELD_MTI_MAX, FIELD_TI_NORMAL)
+)
 
 
 #: Field names valid on the fsaverage surface: every registered field except

--- a/tit/gui/simulator_tab.py
+++ b/tit/gui/simulator_tab.py
@@ -37,11 +37,14 @@ from tit.gui.components.console import (
 from tit.gui.components.action_buttons import RunStopButtons
 from tit.gui.components.add_montage_dialog import AddMontageDialog
 from tit.gui.components.conductivity_dialog import ConductivityEditorDialog
+from tit.gui.components.help_icon import HelpIcon
 from tit.gui.utils import strip_ansi_codes, open_file, open_directory
 from tit.gui.components.base_thread import BaseProcessThread
 from tit.paths import get_path_manager
 from tit.config_io import serialize_config
 from tit.reporting import SimulationReportGenerator
+from tit import constants as const
+from tit.constants import get_selectable_output_field_specs
 
 from tit.sim import (
     Montage,
@@ -54,6 +57,15 @@ from tit.sim.utils import (
     save_montage_data,
     ensure_montage_file,
     upsert_montage,
+)
+
+OUTPUT_FIELDS_HELP = (
+    "Which volume fields to compute and write for each simulation.\n\n"
+    "TI_max and TI_avg are stimulation (functional) metrics. hf_peak and "
+    "hf_sar are carrier-exposure safety metrics (Cassarà 2025) and are "
+    "off by default -- enable them if you need safety reporting.\n\n"
+    "TI_avg costs extra compute time (a direction sweep); hf_peak/hf_sar "
+    "are effectively free."
 )
 
 
@@ -280,6 +292,20 @@ class SimulatorTab(QtWidgets.QWidget):
         row2b.addWidget(self.thickness_input)
         row2b.addStretch()
         global_layout.addLayout(row2b)
+
+        # Row 3: Output fields
+        row3 = QtWidgets.QHBoxLayout()
+        row3.addWidget(QtWidgets.QLabel("Output Fields:"))
+        self.output_field_checkboxes = {}
+        for spec in get_selectable_output_field_specs():
+            cb = QtWidgets.QCheckBox(spec.label)
+            cb.setChecked(spec.name == const.FIELD_TI_MAX)
+            cb.setToolTip(spec.description)
+            self.output_field_checkboxes[spec.name] = cb
+            row3.addWidget(cb)
+        row3.addWidget(HelpIcon(OUTPUT_FIELDS_HELP, title="Output Fields"))
+        row3.addStretch()
+        global_layout.addLayout(row3)
 
         # ── Assemble 2-column layout ───────────────────────────────────────
         # Right panel: Montage/Flex selection on top, Global Parameters below
@@ -1320,6 +1346,18 @@ class SimulatorTab(QtWidgets.QWidget):
             )
             dimensions = self.dimensions_input.text() or "8,8"
             thickness = self.thickness_input.text() or "4"
+            output_fields = [
+                name
+                for name, cb in self.output_field_checkboxes.items()
+                if cb.isChecked()
+            ]
+            if not output_fields:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Warning",
+                    "Select at least one output field.",
+                )
+                return
 
             # Validate numeric inputs
             try:
@@ -1418,13 +1456,10 @@ class SimulatorTab(QtWidgets.QWidget):
                             return
                 elif skip_existing:
                     skip_names = {
-                        (subject_id, mc.name)
-                        for subject_id, mc, _, _ in existing
+                        (subject_id, mc.name) for subject_id, mc, _, _ in existing
                     }
                     jobs = [
-                        job
-                        for job in jobs
-                        if (job[0], job[1].name) not in skip_names
+                        job for job in jobs if (job[0], job[1].name) not in skip_names
                     ]
                     for _, _, _, label in existing:
                         self.update_output(f"Skipping existing output: {label}")
@@ -1534,6 +1569,7 @@ class SimulatorTab(QtWidgets.QWidget):
                     electrode_shape,
                     electrode_dims,
                     float(thickness),
+                    output_fields,
                 )
                 config_data = serialize_config(sim_config)
                 fd, config_path = tempfile.mkstemp(prefix="sim_", suffix=".json")
@@ -1655,9 +1691,7 @@ class SimulatorTab(QtWidgets.QWidget):
                 currents_map = {name: cur for name, cur, _, _, _ in montage_list}
                 eeg_net_map = {name: net for name, _, net, _, _ in montage_list}
                 pairs_map = {name: pairs for name, _, _, pairs, _ in montage_list}
-                display_map = {
-                    name: display for name, _, _, _, display in montage_list
-                }
+                display_map = {name: display for name, _, _, _, display in montage_list}
 
                 # Generate individual report for each montage for this subject
                 for montage_name in montages_to_process:

--- a/tit/sim/TI.py
+++ b/tit/sim/TI.py
@@ -139,25 +139,38 @@ class TISimulation(BaseSimulation):
 
         ef1 = m1.field["E"]
         ef2 = m2.field["E"]
-        TImax = TI.get_maxTI(ef1.value, ef2.value)
+        selected = set(self.config.output_fields)
 
         mout = deepcopy(m1)
         mout.elmdata = []
-        mout.add_element_field(TImax, "TI_max")
-        # TI_avg: orientation-averaged companion to TI_max (tit.calc, not
-        # SimNIBS's TI.get_maxTI -- there is no direction-averaged form there).
-        TIavg = get_TI_avg([ef1.value, ef2.value])
-        mout.add_element_field(TIavg, const.FIELD_TI_AVG)
-        # Carrier-exposure safety maps (Cassarà 2025): peak carrier field and the
-        # heating driver. Written as volume fields so they flow to subject-/MNI-
-        # space NIfTIs alongside TI_max.
-        mout.add_element_field(hf_peak(ef1.value, ef2.value), const.FIELD_HF_PEAK)
-        mout.add_element_field(hf_sar(ef1.value, ef2.value), const.FIELD_HF_SAR)
+        if const.FIELD_TI_MAX in selected:
+            TImax = TI.get_maxTI(ef1.value, ef2.value)
+            mout.add_element_field(TImax, const.FIELD_TI_MAX)
+        if const.FIELD_TI_AVG in selected:
+            # TI_avg: orientation-averaged companion to TI_max (tit.calc, not
+            # SimNIBS's TI.get_maxTI -- there is no direction-averaged form there).
+            TIavg = get_TI_avg([ef1.value, ef2.value])
+            mout.add_element_field(TIavg, const.FIELD_TI_AVG)
+        if const.FIELD_HF_PEAK in selected:
+            # Carrier-exposure safety map (Cassarà 2025): peak carrier field.
+            # Written as a volume field so it flows to subject-/MNI-space
+            # NIfTIs alongside TI_max.
+            mout.add_element_field(hf_peak(ef1.value, ef2.value), const.FIELD_HF_PEAK)
+        if const.FIELD_HF_SAR in selected:
+            # Carrier-exposure safety map (Cassarà 2025): heating driver.
+            mout.add_element_field(hf_sar(ef1.value, ef2.value), const.FIELD_HF_SAR)
 
+        view_field = (
+            const.FIELD_TI_MAX
+            if const.FIELD_TI_MAX in selected
+            else next(iter(selected))
+        )
         ti_path = os.path.join(dirs["ti_mesh"], f"{name}_TI.msh")
         mesh_io.write_msh(mout, ti_path)
-        mout.view(visible_tags=[1002, 1006], visible_fields="TI_max").write_opt(ti_path)
-        self.logger.info(f"TI_max saved: {ti_path}")
+        mout.view(visible_tags=[1002, 1006], visible_fields=view_field).write_opt(
+            ti_path
+        )
+        self.logger.info(f"TI mesh saved: {ti_path}")
 
         self._calculate_ti_normal(dirs["hf_dir"], dirs["ti_mesh"], name)
 

--- a/tit/sim/__main__.py
+++ b/tit/sim/__main__.py
@@ -3,6 +3,7 @@
 import json
 import sys
 
+from tit import constants as const
 from tit.paths import get_path_manager
 from tit.sim.config import Montage, SimulationConfig
 from tit.sim.utils import run_simulation
@@ -43,10 +44,21 @@ def main() -> None:
 
     get_path_manager(data.pop("project_dir"))
 
-    montages_data = data.pop("montages")
-    montages = [_build_montage(m) for m in montages_data]
+    config = _build_sim_config(data)
 
-    config = SimulationConfig(
+    results = run_simulation(config)
+    failed = [r for r in results if r.get("status") == "failed"]
+    sys.exit(1 if failed else 0)
+
+
+def _build_sim_config(data: dict) -> SimulationConfig:
+    """Rebuild a :class:`SimulationConfig` from its serialized form.
+
+    Keys are read explicitly, so a field added to the dataclass is dropped
+    here unless it is added below as well.
+    """
+    montages = [_build_montage(m) for m in data["montages"]]
+    return SimulationConfig(
         subject_id=data["subject_id"],
         montages=montages,
         conductivity=data.get("conductivity", "scalar"),
@@ -63,11 +75,8 @@ def main() -> None:
         tissues_in_niftis=data.get("tissues_in_niftis", "all"),
         aniso_maxratio=data.get("aniso_maxratio", 10.0),
         aniso_maxcond=data.get("aniso_maxcond", 2.0),
+        output_fields=data.get("output_fields", [const.FIELD_TI_MAX]),
     )
-
-    results = run_simulation(config)
-    failed = [r for r in results if r.get("status") == "failed"]
-    sys.exit(1 if failed else 0)
 
 
 if __name__ == "__main__":

--- a/tit/sim/config.py
+++ b/tit/sim/config.py
@@ -22,6 +22,8 @@ tit.sim.base.BaseSimulation : Uses ``SimulationConfig`` and ``Montage``
 from dataclasses import dataclass, field
 from enum import Enum
 
+from tit import constants as const
+
 
 class SimulationMode(Enum):
     """Simulation type: standard two-pair TI or multi-channel mTI.
@@ -228,11 +230,20 @@ class SimulationConfig:
     aniso_maxcond : float
         Maximum absolute conductivity clamp (S/m) for anisotropic
         tensors.
+    output_fields : list[str]
+        Which volume-mesh fields to compute and write. Logical names from
+        :data:`tit.constants.SELECTABLE_OUTPUT_FIELDS`: ``"TI_max"``,
+        ``"TI_avg"``, ``"hf_peak"``, ``"hf_sar"``. ``"TI_max"`` maps to
+        ``TI_Max`` (capital M) on disk for mTI meshes. Defaults to
+        ``["TI_max"]`` only -- ``TI_avg`` and the safety fields
+        (``hf_peak``, ``hf_sar``) must be opted into.
 
     Raises
     ------
     ValueError
-        If *conductivity* is not one of the valid model names.
+        If *conductivity* is not one of the valid model names, if
+        *output_fields* contains an unknown name, or if *output_fields*
+        is empty.
 
     See Also
     --------
@@ -260,12 +271,24 @@ class SimulationConfig:
     tissues_in_niftis: str = "all"
     aniso_maxratio: float = 10.0
     aniso_maxcond: float = 2.0
+    output_fields: list[str] = field(default_factory=lambda: [const.FIELD_TI_MAX])
 
     def __post_init__(self):
         if self.conductivity not in _VALID_CONDUCTIVITIES:
             raise ValueError(
                 f"Invalid conductivity {self.conductivity!r}, "
                 f"must be one of {_VALID_CONDUCTIVITIES}"
+            )
+        invalid = sorted(set(self.output_fields) - set(const.SELECTABLE_OUTPUT_FIELDS))
+        if invalid:
+            raise ValueError(
+                f"Invalid output field(s) {invalid}, must be a subset of "
+                f"{list(const.SELECTABLE_OUTPUT_FIELDS)}"
+            )
+        if not self.output_fields:
+            raise ValueError(
+                "output_fields must not be empty; at least one output field "
+                "must be selected"
             )
 
 

--- a/tit/sim/mTI.py
+++ b/tit/sim/mTI.py
@@ -183,29 +183,39 @@ class mTISimulation(BaseSimulation):
         # see tit.calc.get_nTI_vectors). montage.channels controls which
         # fields share a carrier (None = one carrier per pair, today's
         # default).
-        mti_vectors = get_mTI_vectors(e_fields, channels=self.montage.channels)
-        mti_field = np.linalg.norm(mti_vectors, axis=1)
+        selected = set(self.config.output_fields)
+
         mout = deepcopy(meshes[0])
         mout.elmdata = []
-        mout.add_element_field(mti_field, "TI_Max")
-        # TI_avg: orientation-averaged companion to TI_Max, over all N
-        # per-pair carrier fields jointly (tit.calc.get_TI_avg), grouped by
-        # the same montage.channels.
-        mti_avg = get_TI_avg(e_fields, channels=self.montage.channels)
-        mout.add_element_field(mti_avg, const.FIELD_TI_AVG)
-        # Carrier-exposure safety maps (Cassarà 2025): peak carrier field and the
-        # heating driver, over all N per-pair carrier fields. Written unconditionally
-        # as volume fields so they flow to subject-/MNI-space NIfTIs alongside
-        # TI_Max, mirroring tit.sim.TI.TISimulation._post_process.
-        mout.add_element_field(hf_peak(*e_fields), const.FIELD_HF_PEAK)
-        mout.add_element_field(hf_sar(*e_fields), const.FIELD_HF_SAR)
+        if const.FIELD_TI_MAX in selected:
+            mti_vectors = get_mTI_vectors(e_fields, channels=self.montage.channels)
+            mti_field = np.linalg.norm(mti_vectors, axis=1)
+            mout.add_element_field(mti_field, const.FIELD_MTI_MAX)
+        if const.FIELD_TI_AVG in selected:
+            # TI_avg: orientation-averaged companion to TI_Max, over all N
+            # per-pair carrier fields jointly (tit.calc.get_TI_avg), grouped by
+            # the same montage.channels.
+            mti_avg = get_TI_avg(e_fields, channels=self.montage.channels)
+            mout.add_element_field(mti_avg, const.FIELD_TI_AVG)
+        if const.FIELD_HF_PEAK in selected:
+            # Carrier-exposure safety map (Cassarà 2025): peak carrier field,
+            # over all N per-pair carrier fields.
+            mout.add_element_field(hf_peak(*e_fields), const.FIELD_HF_PEAK)
+        if const.FIELD_HF_SAR in selected:
+            # Carrier-exposure safety map (Cassarà 2025): heating driver.
+            mout.add_element_field(hf_sar(*e_fields), const.FIELD_HF_SAR)
 
+        view_field = (
+            const.FIELD_MTI_MAX
+            if const.FIELD_TI_MAX in selected
+            else next(iter(selected))
+        )
         mti_path = os.path.join(dirs["mti_mesh"], f"{name}_mTI.msh")
         mesh_io.write_msh(mout, mti_path)
-        mout.view(visible_tags=[1002, 1006], visible_fields="TI_Max").write_opt(
+        mout.view(visible_tags=[1002, 1006], visible_fields=view_field).write_opt(
             mti_path
         )
-        self.logger.info(f"mTI_max saved: {mti_path}")
+        self.logger.info(f"mTI mesh saved: {mti_path}")
 
         # TI_normal is not computed for mTI. TISimulation._calculate_ti_normal
         # uses SimNIBS's 2-field TI.get_dirTI; the N-pair analogue needs the

--- a/tit/sim/utils.py
+++ b/tit/sim/utils.py
@@ -854,8 +854,12 @@ def build_simulation_config_for_job(
     electrode_shape: str,
     electrode_dimensions: list[float],
     gel_thickness: float,
+    output_fields: list[str] | None = None,
 ) -> SimulationConfig:
     """Build the backend config for one subject/montage job."""
+    kwargs = {}
+    if output_fields is not None:
+        kwargs["output_fields"] = output_fields
     return SimulationConfig(
         subject_id=subject_id,
         montages=[montage],
@@ -864,6 +868,7 @@ def build_simulation_config_for_job(
         electrode_shape=electrode_shape,
         electrode_dimensions=electrode_dimensions,
         gel_thickness=gel_thickness,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
Every simulation computed and wrote `TI_max`, `TI_avg`, `hf_peak` and `hf_sar` unconditionally. They are now selectable, defaulting to `TI_max` alone, via `SimulationConfig.output_fields` and four checkboxes in the simulator tab.

**This is a behaviour change.** A caller passing nothing previously got all four and now gets one. It also means the carrier-exposure maps are off unless asked for, so a run is no longer self-documenting for safety — an accepted tradeoff, noted here so it is not mistaken for an oversight.

## The gating skips computation, not just the write

That is the point of the feature. `TI_avg` runs a direction sweep costing roughly half a second per 200k elements, while `hf_peak` and `hf_sar` are nearly free — so unchecking `TI_avg` genuinely saves time rather than just tidying output. A test asserts `get_TI_avg` is never called when unselected.

## Details

Valid names come from `FIELD_REGISTRY` rather than a second hardcoded list, and the checkboxes are built from it too, filtered to the four selectable fields so the mTI casing variant does not surface as a separate choice. The logical name `TI_max` still maps to `TI_max` for 2-pair and `TI_Max` for mTI.

An empty selection is rejected — the output mesh would carry nothing and the analyzer, reporting and fsaverage paths would all have nothing to read.

`SimulationConfig` is rebuilt from an explicit key list, so the new field would have been dropped between the GUI and the subprocess — exactly how `Montage.channels` was silently lost earlier. That construction is now factored into `_build_sim_config` so the round trip is testable, with two tests covering it.

`TI_normal` is unaffected; it is a node field on a separate surface mesh.

## Verification

Suite **2342 passed / 0 failed**. Two pre-existing tests that asserted `get_TI_avg` was called now opt into `TI_avg` explicitly — they exercise channel threading, not field selection, so they were updated rather than weakened.

**Rendering is unverified** — PyQt5 is absent on the host, so the new checkbox row is unchecked visually.

## One thing worth deciding

`TI_max` is itself uncheckable. The analyzer defaults to it and `field_selector` resolves to it, so a run without `TI_max` produces a mesh the analyzer cannot read by default. The empty-selection guard does not catch that case.