### PR TITLE
gui: reuse the shared ROI picker in ex-search; stabilise and extend the analyzer

### DIFF
--- a/tests/test_analyzer_spheres.py
+++ b/tests/test_analyzer_spheres.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env simnibs_python
+"""Unit tests for tit.analyzer.spheres -- 'x,y,z,r' sphere parsing.
+
+These live outside the GUI tests deliberately: the parsers are pure, and the
+analyzer tab imports PyQt5, which is absent from this environment. Kept here
+they run everywhere.
+"""
+
+import pytest
+
+from tit.analyzer.spheres import parse_sphere_row, parse_sphere_rows
+
+
+@pytest.mark.unit
+class TestParseSphereRow:
+    def test_parses_a_row(self):
+        assert parse_sphere_row("10,-20,30,5") == (10.0, -20.0, 30.0, 5.0)
+
+    def test_tolerates_whitespace_and_floats(self):
+        assert parse_sphere_row("  1.5 , -2.25 ,3 , 4.5 ") == (1.5, -2.25, 3.0, 4.5)
+
+    def test_rejects_empty(self):
+        for bad in ("", "   ", None):
+            with pytest.raises(ValueError, match="Please enter coordinates"):
+                parse_sphere_row(bad)
+
+    def test_rejects_wrong_field_count(self):
+        for bad in ("1,2,3", "1,2,3,4,5", "1,2,3,"):
+            with pytest.raises(ValueError, match="exactly 4 values"):
+                parse_sphere_row(bad)
+
+    def test_rejects_non_numeric(self):
+        with pytest.raises(ValueError, match="must be numeric"):
+            parse_sphere_row("1,2,three,4")
+
+    def test_rejects_non_positive_radius(self):
+        for bad in ("1,2,3,0", "1,2,3,-5"):
+            with pytest.raises(ValueError, match="Radius must be positive"):
+                parse_sphere_row(bad)
+
+
+@pytest.mark.unit
+class TestParseSphereRows:
+    def test_single_row_matches_single_sphere_behaviour(self):
+        assert parse_sphere_rows(["10,-20,30,5"]) == [(10.0, -20.0, 30.0, 5.0)]
+
+    def test_preserves_order(self):
+        rows = ["1,1,1,1", "2,2,2,2", "3,3,3,3"]
+        assert parse_sphere_rows(rows) == [
+            (1.0, 1.0, 1.0, 1.0),
+            (2.0, 2.0, 2.0, 2.0),
+            (3.0, 3.0, 3.0, 3.0),
+        ]
+
+    def test_empty_sequence_rejected(self):
+        with pytest.raises(ValueError, match="Please enter coordinates"):
+            parse_sphere_rows([])
+
+    def test_single_bad_row_keeps_the_plain_message(self):
+        """N=1 must read exactly as it always did -- no row prefix."""
+        with pytest.raises(ValueError, match="^Radius must be positive"):
+            parse_sphere_rows(["1,2,3,-1"])
+
+    def test_bad_row_among_several_is_numbered(self):
+        with pytest.raises(ValueError, match="^Row 2: "):
+            parse_sphere_rows(["1,2,3,4", "1,2,3,-1", "5,5,5,5"])

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -146,36 +146,25 @@ class TestGuiImports:
         assert ExSearchTab.coordinate_space_value(True) == "mni"
 
     @pytest.mark.unit
-    def test_ex_search_atlas_roi_chip_key_roundtrip(self):
-        """Chip keys round-trip through atlas_roi_chip_key / atlas_roi_from_chip_key."""
+    def test_ex_search_build_roi_atlas_entries_single_region(self):
+        """N=1 case: one selected subcortical region -> one AtlasROI dict."""
         pytest.importorskip("PyQt5")
         from tit.gui.ex_search_tab import ExSearchTab
 
-        key = ExSearchTab.atlas_roi_chip_key("/atlas/aseg.mgz", 17)
-        assert ExSearchTab.atlas_roi_from_chip_key(key) == ("/atlas/aseg.mgz", 17)
-
-        # label=None -> whole file as a binary mask
-        key_whole = ExSearchTab.atlas_roi_chip_key("/atlas/mask.nii.gz", None)
-        assert ExSearchTab.atlas_roi_from_chip_key(key_whole) == (
-            "/atlas/mask.nii.gz",
-            None,
-        )
+        entries = ExSearchTab.build_roi_atlas_entries("/atlas/aseg.mgz", ["17"])
+        assert entries == [{"atlas_path": "/atlas/aseg.mgz", "label": 17}]
 
     @pytest.mark.unit
-    def test_ex_search_build_roi_atlas_entries(self):
-        """Selected atlas-ROI chips become ExConfig.AtlasROI-shaped dicts."""
+    def test_ex_search_build_roi_atlas_entries_multi_region(self):
+        """Multiple selected labels from the same atlas union into one list."""
         pytest.importorskip("PyQt5")
         from tit.gui.ex_search_tab import ExSearchTab
         from tit.opt.config import ExConfig
 
-        keys = [
-            ExSearchTab.atlas_roi_chip_key("/atlas/aseg.mgz", 17),
-            ExSearchTab.atlas_roi_chip_key("/atlas/mask.nii.gz", None),
-        ]
-        entries = ExSearchTab.build_roi_atlas_entries(keys)
+        entries = ExSearchTab.build_roi_atlas_entries("/atlas/aseg.mgz", ["17", "53"])
         assert entries == [
             {"atlas_path": "/atlas/aseg.mgz", "label": 17},
-            {"atlas_path": "/atlas/mask.nii.gz", "label": None},
+            {"atlas_path": "/atlas/aseg.mgz", "label": 53},
         ]
 
         # Feeds straight into ExConfig.roi_atlas without further conversion.
@@ -193,8 +182,26 @@ class TestGuiImports:
         )
         assert config.roi_atlas == [
             ExConfig.AtlasROI(atlas_path="/atlas/aseg.mgz", label=17),
-            ExConfig.AtlasROI(atlas_path="/atlas/mask.nii.gz", label=None),
+            ExConfig.AtlasROI(atlas_path="/atlas/aseg.mgz", label=53),
         ]
+
+    @pytest.mark.unit
+    def test_ex_search_build_roi_atlas_entries_empty_is_optional(self):
+        """No atlas or no region selected -> None (Atlas ROI stays optional)."""
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab
+
+        assert ExSearchTab.build_roi_atlas_entries(None, []) is None
+        assert ExSearchTab.build_roi_atlas_entries("/atlas/aseg.mgz", []) is None
+        assert ExSearchTab.build_roi_atlas_entries("", ["17"]) is None
+
+    @pytest.mark.unit
+    def test_ex_search_no_add_whole_file_reference(self):
+        """The removed 'Add Whole File' handler/button leaves no trace."""
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        assert "Add Whole File" not in source
+        assert "_on_add_atlas_whole_file" not in source
+        assert "atlas_roi_chip_key" not in source
 
     @pytest.mark.unit
     def test_ex_search_tab_compiles(self):
@@ -208,3 +215,44 @@ class TestGuiImports:
         import py_compile
 
         py_compile.compile(str(GUI_ROOT / "ex_search_tab.py"), doraise=True)
+
+    @pytest.mark.unit
+    def test_analyzer_tab_compiles(self):
+        """tit/gui/analyzer_tab.py is syntactically valid Python.
+
+        No PyQt5 needed (py_compile only compiles to bytecode, never runs
+        module-level code), so this actually runs -- not skips -- on hosts
+        without PyQt5 installed.
+        """
+        import py_compile
+
+        py_compile.compile(str(GUI_ROOT / "analyzer_tab.py"), doraise=True)
+
+    @pytest.mark.unit
+    def test_analyzer_target_groups_use_stacked_widget(self):
+        """cortical_group/spherical_group live in target_stack, not toggled visibility.
+
+        Toggling target type used to call setVisible() on both group boxes
+        directly, which reflows/resizes the right-hand column because the
+        two boxes have different natural widths. A QStackedWidget reserves
+        the size of its largest page, so the fix is checked at the source
+        level (no PyQt5 needed): update_atlas_visibility must no longer call
+        setVisible on cortical_group/spherical_group, and must instead use
+        target_stack.setCurrentWidget.
+        """
+        source = (GUI_ROOT / "analyzer_tab.py").read_text(encoding="utf-8")
+
+        assert "self.target_stack = QtWidgets.QStackedWidget()" in source
+        assert "self.target_stack.addWidget(self.cortical_group)" in source
+        assert "self.target_stack.addWidget(self.spherical_group)" in source
+
+        # Locate update_atlas_visibility and ensure it uses the stack, not
+        # setVisible(), to switch between the two target groups.
+        start = source.index("def update_atlas_visibility")
+        end = source.index("\n    def ", start + 1)
+        body = source[start:end]
+
+        assert "self.target_stack.setCurrentWidget(self.cortical_group)" in body
+        assert "self.target_stack.setCurrentWidget(self.spherical_group)" in body
+        assert "self.cortical_group.setVisible" not in body
+        assert "self.spherical_group.setVisible" not in body

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -196,6 +196,117 @@ class TestGuiImports:
         assert ExSearchTab.build_roi_atlas_entries("", ["17"]) is None
 
     @pytest.mark.unit
+    def test_ex_search_roi_names_for_mode(self):
+        """ROI Type toggle maps to ExConfig.roi_names: sphere passes through, atlas empties it.
+
+        Atlas mode must produce an *explicit* empty list (ExConfig treats
+        that as "no spherical centers at all"), not None (which falls back
+        to a single roi_name).
+        """
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab, ROI_MODE_SPHERE, ROI_MODE_ATLAS
+
+        assert ExSearchTab.roi_names_for_mode(ROI_MODE_SPHERE, ["a.csv", "b.csv"]) == [
+            "a.csv",
+            "b.csv",
+        ]
+        assert ExSearchTab.roi_names_for_mode(ROI_MODE_SPHERE, None) is None
+        assert ExSearchTab.roi_names_for_mode(ROI_MODE_ATLAS, ["a.csv"]) == []
+        assert ExSearchTab.roi_names_for_mode(ROI_MODE_ATLAS, None) == []
+
+    @pytest.mark.unit
+    def test_ex_search_roi_atlas_for_mode(self):
+        """ROI Type toggle maps to roi_atlas: sphere disables it, atlas passes it through.
+
+        Applies to both ExConfig and MExConfig (mex has no roi_names union
+        equivalent, so this is the only mode-gated field it has).
+        """
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab, ROI_MODE_SPHERE, ROI_MODE_ATLAS
+
+        entries = [{"atlas_path": "/atlas/aseg.mgz", "label": 17}]
+        assert ExSearchTab.roi_atlas_for_mode(ROI_MODE_SPHERE, entries) is None
+        assert ExSearchTab.roi_atlas_for_mode(ROI_MODE_SPHERE, None) is None
+        assert ExSearchTab.roi_atlas_for_mode(ROI_MODE_ATLAS, entries) == entries
+        assert ExSearchTab.roi_atlas_for_mode(ROI_MODE_ATLAS, None) is None
+
+    @pytest.mark.unit
+    def test_ex_search_roi_mode_kwargs_build_ti_and_mti_configs(self):
+        """Sphere vs Atlas mode produce the documented ExConfig/MExConfig shapes.
+
+        Sphere: roi_names populated, roi_atlas=None.
+        Atlas: roi_names=[] (ExConfig only), roi_atlas populated.
+        """
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab, ROI_MODE_SPHERE, ROI_MODE_ATLAS
+        from tit.opt.config import ExConfig, MExConfig
+
+        entries = [{"atlas_path": "/atlas/aseg.mgz", "label": 17}]
+        electrodes = ExConfig.BucketElectrodes(
+            e1_plus=["E1"], e1_minus=["E2"], e2_plus=["E3"], e2_minus=["E4"]
+        )
+
+        sphere_config = ExConfig(
+            subject_id="ernie",
+            leadfield_hdf="/leadfields/ernie.hdf5",
+            roi_name="target.csv",
+            roi_names=ExSearchTab.roi_names_for_mode(ROI_MODE_SPHERE, ["target.csv"]),
+            roi_atlas=ExSearchTab.roi_atlas_for_mode(ROI_MODE_SPHERE, entries),
+            electrodes=electrodes,
+        )
+        assert sphere_config.roi_names == ["target.csv"]
+        assert sphere_config.roi_atlas is None
+
+        atlas_config = ExConfig(
+            subject_id="ernie",
+            leadfield_hdf="/leadfields/ernie.hdf5",
+            roi_name="atlas_17",
+            roi_names=ExSearchTab.roi_names_for_mode(ROI_MODE_ATLAS, ["target.csv"]),
+            roi_atlas=ExSearchTab.roi_atlas_for_mode(ROI_MODE_ATLAS, entries),
+            electrodes=electrodes,
+        )
+        assert atlas_config.roi_names == []
+        assert atlas_config.roi_atlas == [ExConfig.AtlasROI(**entries[0])]
+
+        mex_electrodes = MExConfig.BucketElectrodes(
+            e1_plus=["E1"],
+            e1_minus=["E2"],
+            e2_plus=["E3"],
+            e2_minus=["E4"],
+            e3_plus=["E5"],
+            e3_minus=["E6"],
+            e4_plus=["E7"],
+            e4_minus=["E8"],
+        )
+        mex_sphere = MExConfig(
+            subject_id="ernie",
+            leadfield_hdf="/leadfields/ernie.hdf5",
+            roi_name="target.csv",
+            roi_atlas=ExSearchTab.roi_atlas_for_mode(ROI_MODE_SPHERE, entries),
+            electrodes=mex_electrodes,
+        )
+        assert mex_sphere.roi_atlas is None
+
+        mex_atlas = MExConfig(
+            subject_id="ernie",
+            leadfield_hdf="/leadfields/ernie.hdf5",
+            roi_name="target.csv",
+            roi_atlas=ExSearchTab.roi_atlas_for_mode(ROI_MODE_ATLAS, entries),
+            electrodes=mex_electrodes,
+        )
+        assert mex_atlas.roi_atlas == [MExConfig.AtlasROI(**entries[0])]
+
+    @pytest.mark.unit
+    def test_ex_search_atlas_only_roi_label(self):
+        """Synthetic ExConfig.roi_name label built from selected atlas region keys."""
+        pytest.importorskip("PyQt5")
+        from tit.gui.ex_search_tab import ExSearchTab
+
+        assert ExSearchTab.atlas_only_roi_label([]) == "atlas_roi"
+        assert ExSearchTab.atlas_only_roi_label(["17"]) == "atlas_17"
+        assert ExSearchTab.atlas_only_roi_label(["17", "53"]) == "atlas_17_53"
+
+    @pytest.mark.unit
     def test_ex_search_no_add_whole_file_reference(self):
         """The removed 'Add Whole File' handler/button leaves no trace."""
         source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
@@ -227,6 +338,71 @@ class TestGuiImports:
         import py_compile
 
         py_compile.compile(str(GUI_ROOT / "analyzer_tab.py"), doraise=True)
+
+    @pytest.mark.unit
+    def test_ex_search_atlas_roi_mode_is_ti_only(self):
+        """Atlas-only ROI targeting must be disabled in mTI mode.
+
+        tit/opt/ex/ex.py honours ``roi_names=[]`` and reads no sphere file, so
+        a TI run can target an atlas alone. tit/opt/mex/mex.py builds
+        ``roi_file`` from ``config.roi_name`` unconditionally, so a multipolar
+        run always needs a spherical ROI. Leaving the Atlas choice selectable
+        under mTI would accept the selection and then fail validation asking
+        for a sphere, so the mode handler disables it and falls back to Sphere.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        body = source.split("def _on_search_mode_changed(self):", 1)[1]
+        body = body.split("\n    def ", 1)[0]
+        assert "self.roi_mode_atlas_radio.setEnabled(not is_mti)" in body
+        # and it must not leave the stack showing a page the user cannot reach
+        assert "self.roi_mode_sphere_radio.setChecked(True)" in body
+
+    def test_ex_search_containers_hug_content_not_fixed_height(self):
+        """ROI/Subject/Electrode/Current/Leadfield containers no longer reserve dead space.
+
+        Every top-level group box in ex_search_tab.py used to call
+        setFixedHeight with a hand-picked number, reserving that height
+        whether the content needed it or not (with zero setSizePolicy calls
+        anywhere in the file). The fix: each container gets a vertical
+        QSizePolicy.Maximum so it hugs its content instead, and a single
+        trailing stretch in scroll_layout absorbs the freed space.
+
+        Inner-widget fixed heights (list boxes, buttons, spinbox rows) are
+        deliberate and must remain untouched.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+
+        # The five container-level setFixedHeight calls are gone.
+        for removed in (
+            "subject_container.setFixedHeight",
+            "electrode_container.setFixedHeight",
+            "roi_container.setFixedHeight",
+            "self.current_container.setFixedHeight",
+            "leadfield_container.setFixedHeight",
+        ):
+            assert removed not in source, f"expected {removed} to be removed"
+
+        # Each container instead hugs its content vertically.
+        for container in (
+            "subject_container",
+            "electrode_container",
+            "roi_container",
+            "self.current_container",
+            "leadfield_container",
+        ):
+            assert (
+                f"{container}.setSizePolicy(\n"
+                f"            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum\n"
+                f"        )" in source
+            ), f"expected {container} to get a Maximum vertical size policy"
+
+        # A single trailing stretch absorbs the freed vertical space.
+        assert "scroll_layout.addStretch(1)" in source
+
+        # Deliberate inner-widget fixed heights must remain untouched.
+        assert "self.roi_list.setFixedHeight(80)" in source
+        assert "self.leadfield_list.setFixedHeight(140)" in source
+        assert "self.add_roi_btn.setFixedHeight(25)" in source
 
     @pytest.mark.unit
     def test_analyzer_target_groups_use_stacked_widget(self):

--- a/tit/analyzer/spheres.py
+++ b/tit/analyzer/spheres.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env simnibs_python
+"""Parsing of spherical ROI specifications.
+
+The GUI collects spheres as ``"x,y,z,r"`` rows. Parsing lives here rather than
+in the tab so it is exercised without PyQt5, which is absent from the test
+environment.
+
+See Also
+--------
+tit.analyzer.analyzer.Analyzer.analyze_sphere : Consumes one parsed sphere.
+"""
+
+
+def parse_sphere_row(text: str) -> tuple[float, float, float, float]:
+    """Parse a single ``"x,y,z,r"`` row.
+
+    Parameters
+    ----------
+    text : str
+        Comma-separated centre and radius.
+
+    Returns
+    -------
+    tuple of float
+        ``(x, y, z, r)``.
+
+    Raises
+    ------
+    ValueError
+        If *text* is empty, does not hold exactly four values, holds a
+        non-numeric value, or gives a non-positive radius.
+    """
+    text = (text or "").strip()
+    if not text:
+        raise ValueError("Please enter coordinates and radius as x,y,z,r.")
+    parts = [p.strip() for p in text.split(",")]
+    if len(parts) != 4 or any(p == "" for p in parts):
+        raise ValueError("Enter exactly 4 values: x,y,z,r.")
+    try:
+        x, y, z, r = (float(p) for p in parts)
+    except ValueError:
+        raise ValueError("All values must be numeric: x,y,z,r.")
+    if r <= 0:
+        raise ValueError("Radius must be positive.")
+    return (x, y, z, r)
+
+
+def parse_sphere_rows(texts) -> list[tuple[float, float, float, float]]:
+    """Parse several ``"x,y,z,r"`` rows.
+
+    A one-element sequence reproduces single-sphere behaviour exactly, including
+    its error messages -- the row number is only prefixed when there is more
+    than one row, so a single malformed sphere reads the way it always did.
+
+    Parameters
+    ----------
+    texts : sequence of str
+        One ``"x,y,z,r"`` string per sphere.
+
+    Returns
+    -------
+    list of tuple of float
+        One ``(x, y, z, r)`` per input row, in order.
+
+    Raises
+    ------
+    ValueError
+        If *texts* is empty or any row is malformed.
+    """
+    if not texts:
+        raise ValueError("Please enter coordinates and radius as x,y,z,r.")
+    spheres = []
+    for i, text in enumerate(texts):
+        try:
+            spheres.append(parse_sphere_row(text))
+        except ValueError as exc:
+            if len(texts) == 1:
+                raise
+            raise ValueError(f"Row {i + 1}: {exc}")
+    return spheres

--- a/tit/gui/analyzer_tab.py
+++ b/tit/gui/analyzer_tab.py
@@ -25,6 +25,7 @@ import subprocess
 from PyQt5 import QtWidgets, QtCore, QtGui
 
 from tit.gui.confirmation_dialog import ConfirmationDialog
+from tit.analyzer.spheres import parse_sphere_row, parse_sphere_rows
 from tit.gui.utils import confirm_overwrite
 from tit.gui.components.console import (
     ConsoleWidget,
@@ -291,7 +292,8 @@ class AnalyzerTab(QtWidgets.QWidget):
 
     def _update_coordinate_space_labels(self):
         """Update coordinate space labels and tooltips based on space selection."""
-        if hasattr(self, "coordinates_label") and hasattr(self, "coords_radius_input"):
+        if hasattr(self, "coordinates_label") and hasattr(self, "spheres_table"):
+            row_tooltip = None
             if self.coord_space_mni.isChecked():
                 self.coordinates_label.setText("MNI RAS (x,y,z,r):")
                 self.coordinates_label.setToolTip(
@@ -300,7 +302,7 @@ class AnalyzerTab(QtWidgets.QWidget):
                 self.coordinates_label.setStyleSheet(
                     "color: #007ACC; font-weight: bold;"
                 )
-                self.coords_radius_input.setToolTip("x,y,z,radius in MNI space")
+                row_tooltip = "x,y,z,radius in MNI space"
 
                 if hasattr(self, "view_in_freeview_btn"):
                     self.view_in_freeview_btn.setText("View MNI Template")
@@ -311,13 +313,18 @@ class AnalyzerTab(QtWidgets.QWidget):
                 self.coordinates_label.setText("Subject RAS (x,y,z,r):")
                 self.coordinates_label.setToolTip("Subject-specific RAS coordinates")
                 self.coordinates_label.setStyleSheet("")
-                self.coords_radius_input.setToolTip("x,y,z,radius in subject RAS space")
+                row_tooltip = "x,y,z,radius in subject RAS space"
 
                 if hasattr(self, "view_in_freeview_btn"):
                     self.view_in_freeview_btn.setText("View in Freeview")
                     self.view_in_freeview_btn.setToolTip(
                         "View T1 in Freeview to help find coordinates"
                     )
+
+            for row in range(self.spheres_table.rowCount()):
+                edit = self.spheres_table.cellWidget(row, 0)
+                if edit is not None:
+                    edit.setToolTip(row_tooltip)
 
     def get_selected_subjects(self):
         """Get selected subjects from pairs table."""
@@ -789,8 +796,6 @@ class AnalyzerTab(QtWidgets.QWidget):
         # Now that region_chips exists, wire the "Clear" button created above.
         self.clear_regions_btn.clicked.connect(self.region_chips.clear)
 
-        analysis_params_layout.addWidget(self.cortical_group)
-
         # ===================== Spherical target group =====================
         self.spherical_group = QtWidgets.QGroupBox("Spherical target")
         spherical_layout = QtWidgets.QVBoxLayout(self.spherical_group)
@@ -809,21 +814,53 @@ class AnalyzerTab(QtWidgets.QWidget):
         coord_space_row.addStretch()
         spherical_layout.addLayout(coord_space_row)
 
-        # Coordinates & Radius (single input: x,y,z,r)
-        coords_row = QtWidgets.QHBoxLayout()
-        coords_row.setSpacing(10)
+        # Coordinates & Radius — one or more spheres, each a row of "x,y,z,r".
+        # A single row reproduces the classic single-sphere behavior exactly
+        # (see parse_sphere_rows / _parse_all_spheres); extra rows each run
+        # their own separate analysis (N spheres -> N analyses), following the
+        # multi-sphere table already used by the flex-search ROI picker
+        # (tit/gui/components/roi_picker.py) — recycled here as a lightweight
+        # local table (rather than embedding that widget wholesale) since the
+        # analyzer's cortical/space/tissue handling is not shared with it.
         self.coordinates_label = QtWidgets.QLabel("Coordinates (x,y,z,r):")
         self.coordinates_label.setSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
-        self.coords_radius_input = QtWidgets.QLineEdit()
-        self.coords_radius_input.setPlaceholderText("x,y,z,r")
-        self.coords_radius_input.setMinimumWidth(180)
-        self.coords_radius_input.setSizePolicy(
-            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed
+        spherical_layout.addWidget(self.coordinates_label)
+
+        self.spheres_table = QtWidgets.QTableWidget(0, 2)
+        self.spheres_table.setHorizontalHeaderLabels(["x,y,z,r", ""])
+        sph_header = self.spheres_table.horizontalHeader()
+        sph_header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        sph_header.setSectionResizeMode(1, QtWidgets.QHeaderView.Fixed)
+        self.spheres_table.setColumnWidth(1, 32)
+        self.spheres_table.verticalHeader().setVisible(False)
+        self.spheres_table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.spheres_table.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.spheres_table.setMinimumHeight(90)
+        self.spheres_table.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
         )
-        coords_row.addWidget(self.coordinates_label)
-        coords_row.addWidget(self.coords_radius_input)
+        self.spheres_table.setToolTip(
+            "Each row is a sphere ('x,y,z,r'). A single row behaves exactly "
+            "like the classic single-sphere analysis. Additional rows each "
+            "run as a separate analysis (one result per sphere)."
+        )
+        spherical_layout.addWidget(self.spheres_table)
+
+        sphere_btn_row = QtWidgets.QHBoxLayout()
+        sphere_btn_row.setSpacing(10)
+        self.add_sphere_btn = QtWidgets.QPushButton("Add Sphere")
+        self.add_sphere_btn.setToolTip(
+            "Add another sphere row. Each sphere runs as its own analysis."
+        )
+        self.add_sphere_btn.clicked.connect(lambda: self._add_sphere_row())
+        self.remove_sphere_btn = QtWidgets.QPushButton("Remove Selected")
+        self.remove_sphere_btn.setToolTip("Remove the selected sphere row(s).")
+        self.remove_sphere_btn.clicked.connect(self._remove_selected_sphere_rows)
+        sphere_btn_row.addWidget(self.add_sphere_btn)
+        sphere_btn_row.addWidget(self.remove_sphere_btn)
+        sphere_btn_row.addStretch()
 
         self.view_in_freeview_btn = QtWidgets.QPushButton("View in Freeview")
         self.view_in_freeview_btn.setToolTip(
@@ -833,15 +870,24 @@ class AnalyzerTab(QtWidgets.QWidget):
         self.view_in_freeview_btn.setSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
-        coords_row.addSpacing(10)
-        coords_row.addWidget(self.view_in_freeview_btn)
-        coords_row.addStretch()
-        spherical_layout.addLayout(coords_row)
+        sphere_btn_row.addWidget(self.view_in_freeview_btn)
+        spherical_layout.addLayout(sphere_btn_row)
 
-        analysis_params_layout.addWidget(self.spherical_group)
+        # Seed one default row so the table is never empty — this is the
+        # exact single-sphere path exercised by all real-world usage today.
+        self._add_sphere_row()
 
-        # Remove the stacked widget approach - coordinates/radius are always visible
-        # Instead, we'll enable/disable them based on mode
+        # Cortical and spherical target groups are placed in a QStackedWidget
+        # rather than toggled via setVisible(). A QStackedWidget reserves the
+        # size of its largest page, so switching target type no longer
+        # reflows/resizes the right-hand column (the two group boxes have
+        # different natural widths). See update_atlas_visibility().
+        self.target_stack = QtWidgets.QStackedWidget()
+        self.target_stack.addWidget(self.cortical_group)
+        self.target_stack.addWidget(self.spherical_group)
+        analysis_params_layout.addWidget(self.target_stack)
+
+        # Coordinates/radius enable-state (not visibility) still tracks mode.
 
         # Original connections from setup_ui for space/type changes.
         # update_atlas_visibility() also drives the adaptive cortical/spherical
@@ -1177,13 +1223,17 @@ class AnalyzerTab(QtWidgets.QWidget):
         is_cortical = self.type_cortical.isChecked()
         is_spherical = self.type_spherical.isChecked()
 
-        # Adaptive target-group visibility: show only the group matching the
-        # selected analysis type. Guarded for early calls before the groups
-        # are created.
-        if hasattr(self, "cortical_group"):
-            self.cortical_group.setVisible(is_cortical)
-        if hasattr(self, "spherical_group"):
-            self.spherical_group.setVisible(is_spherical)
+        # Adaptive target-group display: switch the stacked page matching the
+        # selected analysis type. Using a QStackedWidget (rather than
+        # setVisible() on each group) keeps the right-hand column's width
+        # fixed to the widest page — toggling visibility instead let the
+        # column reflow whenever the two group boxes' natural widths
+        # differed. Guarded for early calls before the stack/groups exist.
+        if hasattr(self, "target_stack"):
+            if is_cortical:
+                self.target_stack.setCurrentWidget(self.cortical_group)
+            elif is_spherical:
+                self.target_stack.setCurrentWidget(self.spherical_group)
 
         # Tissue selection only applies to voxel space
         self.tissue_combo.setEnabled(not is_mesh)
@@ -1229,8 +1279,12 @@ class AnalyzerTab(QtWidgets.QWidget):
         coordinates_enabled = is_spherical
         if hasattr(self, "coordinates_label"):
             self.coordinates_label.setEnabled(coordinates_enabled)
-        if hasattr(self, "coords_radius_input"):
-            self.coords_radius_input.setEnabled(coordinates_enabled)
+        if hasattr(self, "spheres_table"):
+            self.spheres_table.setEnabled(coordinates_enabled)
+        if hasattr(self, "add_sphere_btn"):
+            self.add_sphere_btn.setEnabled(coordinates_enabled)
+        if hasattr(self, "remove_sphere_btn"):
+            self.remove_sphere_btn.setEnabled(coordinates_enabled)
         if hasattr(self, "view_in_freeview_btn"):
             self.view_in_freeview_btn.setEnabled(coordinates_enabled)
 
@@ -1552,47 +1606,97 @@ class AnalyzerTab(QtWidgets.QWidget):
 
         return self.validate_analysis_parameters()
 
-    def _parse_coords_radius(self, show_warning=True):
-        """Parse 'x,y,z,r' from the single input field. Returns (x,y,z,r) or None."""
-        text = self.coords_radius_input.text().strip()
-        if not text:
-            if show_warning:
-                QtWidgets.QMessageBox.warning(
-                    self, "Warning", "Please enter coordinates and radius as x,y,z,r."
-                )
-            return None
-        parts = [p.strip() for p in text.split(",")]
-        if len(parts) != 4:
-            if show_warning:
-                QtWidgets.QMessageBox.warning(
-                    self, "Warning", "Enter exactly 4 values: x,y,z,r."
-                )
-            return None
+    def _add_sphere_row(self, text=""):
+        """Append a new sphere row ('x,y,z,r' line edit + delete button)."""
+        table = self.spheres_table
+        row = table.rowCount()
+        table.insertRow(row)
+
+        edit = QtWidgets.QLineEdit()
+        edit.setPlaceholderText("x,y,z,r")
+        if text:
+            edit.setText(text)
+        table.setCellWidget(row, 0, edit)
+
+        del_btn = QtWidgets.QPushButton("x")
+        del_btn.setToolTip("Remove this sphere.")
+        del_btn.setFixedWidth(28)
+        del_btn.clicked.connect(lambda: self._remove_sphere_row_widget(del_btn))
+        table.setCellWidget(row, 1, del_btn)
+        return edit
+
+    def _remove_sphere_row_widget(self, button):
+        """Remove the row containing ``button``, always keeping >= 1 row."""
+        table = self.spheres_table
+        for row in range(table.rowCount()):
+            if table.cellWidget(row, 1) is button:
+                self._remove_sphere_at(row)
+                return
+
+    def _remove_sphere_at(self, row):
+        """Remove the sphere at ``row``, always keeping at least one row."""
+        table = self.spheres_table
+        if table.rowCount() <= 1:
+            return
+        table.removeRow(row)
+
+    def _remove_selected_sphere_rows(self):
+        """Remove all currently-selected sphere rows (keeping >= 1 row)."""
+        table = self.spheres_table
+        rows = sorted({idx.row() for idx in table.selectedIndexes()}, reverse=True)
+        for row in rows:
+            self._remove_sphere_at(row)
+        if table.rowCount() == 0:
+            self._add_sphere_row()
+
+    def _get_sphere_row_texts(self):
+        """Return the raw 'x,y,z,r' text of every sphere row, in order."""
+        table = self.spheres_table
+        texts = []
+        for row in range(table.rowCount()):
+            edit = table.cellWidget(row, 0)
+            texts.append(edit.text() if edit is not None else "")
+        return texts
+
+    def _parse_all_spheres(self, show_warning=True):
+        """Parse every sphere row into ``[(x, y, z, r), ...]``.
+
+        Returns ``None`` (optionally showing a warning dialog) if any row is
+        empty or malformed. This is the multi-sphere counterpart of
+        ``_parse_coords_radius``; N rows here become N separate analyses.
+        """
         try:
-            x, y, z, r = (
-                float(parts[0]),
-                float(parts[1]),
-                float(parts[2]),
-                float(parts[3]),
-            )
-        except ValueError:
+            return parse_sphere_rows(self._get_sphere_row_texts())
+        except ValueError as exc:
             if show_warning:
-                QtWidgets.QMessageBox.warning(
-                    self, "Warning", "All values must be numeric: x,y,z,r."
-                )
+                QtWidgets.QMessageBox.warning(self, "Warning", str(exc))
             return None
-        if r <= 0:
-            if show_warning:
-                QtWidgets.QMessageBox.warning(
-                    self, "Warning", "Radius must be positive."
-                )
+
+    def _parse_coords_radius(self, show_warning=True):
+        """Parse the first sphere row as ``(x, y, z, r)``.
+
+        Used where a single representative sphere suffices (group-mode
+        summary text, start-of-run preview). Single-subject spherical runs
+        use ``_parse_all_spheres`` to run one analysis per sphere row.
+        """
+        spheres = self._parse_all_spheres(show_warning=show_warning)
+        if not spheres:
             return None
-        return (x, y, z, r)
+        return spheres[0]
 
     def validate_analysis_parameters(self):  # Shared parameters
         if self.type_spherical.isChecked():
-            parsed = self._parse_coords_radius()
-            if parsed is None:
+            spheres = self._parse_all_spheres()
+            if spheres is None:
+                return False
+            if self.is_group_mode and len(spheres) > 1:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Warning",
+                    "Group analysis currently supports only one sphere. "
+                    "Remove the extra sphere rows, or run single-subject "
+                    "analyses for the additional spheres.",
+                )
                 return False
         elif self.type_cortical.isChecked():
             # Atlas selection for cortical is handled by validate_single/group_inputs
@@ -1678,22 +1782,14 @@ class AnalyzerTab(QtWidgets.QWidget):
                 self.analysis_finished(success=False)
                 return
 
-            cmd = self.build_single_analysis_command(subject_id, simulation_name)
-            if not cmd:  # build_analysis_command returns None on error
+            cmds = self.build_single_analysis_commands(subject_id, simulation_name)
+            if not cmds:  # build_single_analysis_commands returns None on error
                 self.analysis_finished(success=False)
                 return
-
-            env = os.environ.copy()
-            env["PROJECT_DIR"] = self.pm.project_dir
-            env["SUBJECT_ID"] = subject_id  # Passed to script via env
-
-            # Ensure the analyzer runs against the repo sources even when launched from the GUI.
-            # When executing `-m tit...`, Python needs the repo root on sys.path.
-            gui_app_root = os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )  # .../tit
-            repo_root = os.path.dirname(gui_app_root)  # .../ (ti-toolbox)
-            env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+            if len(cmds) > 1:
+                self.update_output(
+                    f"Running {len(cmds)} separate analyses (one per sphere)."
+                )
 
             # Mark thread start as early as possible to avoid race double-starts
             self._thread_started = True
@@ -1704,32 +1800,81 @@ class AnalyzerTab(QtWidgets.QWidget):
             else:
                 self._summary_printed = set()
 
-            # Record output dir for later summary line (guard against duplicates)
-            if not getattr(self, "_summary_started", False):
-                self._last_output_dir = self._extract_output_dir_from_cmd(cmd)
-                # Mark started to avoid duplicated blocks
-                # Note: The analyzer process will print all the step messages via its logging functions
-                self._summary_started = True
-
-            self.optimization_process = AnalysisThread(cmd, env, cwd=repo_root)
-            self.optimization_process.output_signal.connect(
-                self.update_output, QtCore.Qt.QueuedConnection
-            )
-            self.optimization_process.error_signal.connect(
-                lambda msg: self.update_output(msg, "error"),
-                QtCore.Qt.QueuedConnection,
-            )
-            self.optimization_process.process_finished.connect(
-                lambda ok, rc, sid=subject_id, sim_name=simulation_name: self.analysis_finished(
-                    subject_id=sid, simulation_name=sim_name, success=ok
-                ),
-                QtCore.Qt.QueuedConnection,
-            )
-            self._thread_started = True
-            self.optimization_process.start()
+            # Queue every remaining sphere's command; the first is started
+            # below and each subsequent one is started from
+            # _run_next_single_analysis_cmd() once the previous finishes.
+            self._single_analysis_queue = list(cmds[1:])
+            self._single_analysis_subject_id = subject_id
+            self._single_analysis_simulation_name = simulation_name
+            self._single_analysis_all_ok = True
+            self._start_single_analysis_cmd(cmds[0])
         except (OSError, ValueError, KeyError, RuntimeError) as e:
             self.update_output(f"Error preparing single analysis: {str(e)}")
             self.analysis_finished(success=False)
+
+    def _start_single_analysis_cmd(self, cmd):
+        """Start ``cmd`` (one analysis run) via ``AnalysisThread``.
+
+        Used both for the first sphere and, via ``process_finished``, for
+        each subsequent queued sphere so that N sphere rows run as N
+        sequential analyses.
+        """
+        subject_id = self._single_analysis_subject_id
+        simulation_name = self._single_analysis_simulation_name
+
+        env = os.environ.copy()
+        env["PROJECT_DIR"] = self.pm.project_dir
+        env["SUBJECT_ID"] = subject_id  # Passed to script via env
+
+        # Ensure the analyzer runs against the repo sources even when launched from the GUI.
+        # When executing `-m tit...`, Python needs the repo root on sys.path.
+        gui_app_root = os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))
+        )  # .../tit
+        repo_root = os.path.dirname(gui_app_root)  # .../ (ti-toolbox)
+        env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+
+        # Record output dir for later summary line (guard against duplicates)
+        if not getattr(self, "_summary_started", False):
+            self._last_output_dir = self._extract_output_dir_from_cmd(cmd)
+            # Mark started to avoid duplicated blocks
+            # Note: The analyzer process will print all the step messages via its logging functions
+            self._summary_started = True
+
+        self.optimization_process = AnalysisThread(cmd, env, cwd=repo_root)
+        self.optimization_process.output_signal.connect(
+            self.update_output, QtCore.Qt.QueuedConnection
+        )
+        self.optimization_process.error_signal.connect(
+            lambda msg: self.update_output(msg, "error"),
+            QtCore.Qt.QueuedConnection,
+        )
+        self.optimization_process.process_finished.connect(
+            self._on_single_analysis_cmd_finished,
+            QtCore.Qt.QueuedConnection,
+        )
+        self._thread_started = True
+        self.optimization_process.start()
+
+    def _on_single_analysis_cmd_finished(self, ok, rc):
+        """Handle one queued sphere's analysis finishing.
+
+        Starts the next queued sphere if any remain; otherwise reports the
+        combined result of all spheres via ``analysis_finished`` -- exactly
+        as before for the N=1 case (nothing queued, this fires once).
+        """
+        self._single_analysis_all_ok = self._single_analysis_all_ok and ok
+        self._thread_started = False
+        if self._single_analysis_queue:
+            next_cmd = self._single_analysis_queue.pop(0)
+            self._start_single_analysis_cmd(next_cmd)
+            return
+
+        self.analysis_finished(
+            subject_id=self._single_analysis_subject_id,
+            simulation_name=self._single_analysis_simulation_name,
+            success=self._single_analysis_all_ok,
+        )
 
     def run_group_analysis(self):
         """Run group analysis using the Analyzer API."""
@@ -1963,12 +2108,17 @@ class AnalyzerTab(QtWidgets.QWidget):
             details += f"- Field File: {mont}.msh (auto-selected)\n"
         if self.type_spherical.isChecked():
             coord_space = "MNI" if self.coord_space_mni.isChecked() else "RAS"
-            parsed = self._parse_coords_radius()
-            if parsed:
-                x, y, z, r = parsed
-                details += f"- Coordinates ({coord_space}): ({x}, {y}, {z})\n- Radius: {r} mm\n"
+            spheres = self._parse_all_spheres(show_warning=False)
+            if spheres:
+                if len(spheres) == 1:
+                    x, y, z, r = spheres[0]
+                    details += f"- Coordinates ({coord_space}): ({x}, {y}, {z})\n- Radius: {r} mm\n"
+                else:
+                    details += f"- Spheres ({coord_space}, {len(spheres)} separate analyses):\n"
+                    for x, y, z, r in spheres:
+                        details += f"  - ({x}, {y}, {z}), radius {r} mm\n"
             else:
-                details += f"- Coordinates: {self.coords_radius_input.text()}\n"
+                details += f"- Coordinates: {', '.join(self._get_sphere_row_texts())}\n"
             if self.coord_space_mni.isChecked():
                 details += (
                     f"- Coordinate Transformation: MNI → Subject space (automatic)\n"
@@ -2012,7 +2162,7 @@ class AnalyzerTab(QtWidgets.QWidget):
                 x, y, z, r = parsed
                 details += f"- Coordinates ({coord_space}): ({x}, {y}, {z})\n- Radius: {r} mm\n"
             else:
-                details += f"- Coordinates: {self.coords_radius_input.text()}\n"
+                details += f"- Coordinates: {', '.join(self._get_sphere_row_texts())}\n"
             if self.coord_space_mni.isChecked():
                 details += f"- Coordinate Transformation: MNI → Subject space (automatic for each)\n"
         else:  # cortical
@@ -2170,11 +2320,13 @@ class AnalyzerTab(QtWidgets.QWidget):
             region_str = "+".join(regions) or "region"
             return f"Cortical: {atlas}.{region_str}"
         else:
-            parsed = self._parse_coords_radius()
-            if parsed:
-                x, y, z, r = parsed
-                return f"Spherical: ({x},{y},{z}) r{r}mm"
-            return f"Spherical: {self.coords_radius_input.text()}"
+            spheres = self._parse_all_spheres(show_warning=False)
+            if spheres:
+                if len(spheres) == 1:
+                    x, y, z, r = spheres[0]
+                    return f"Spherical: ({x},{y},{z}) r{r}mm"
+                return f"Spherical: {len(spheres)} spheres"
+            return f"Spherical: {', '.join(self._get_sphere_row_texts())}"
 
     def _extract_output_dir_from_cmd(self, cmd):
         try:
@@ -2207,7 +2359,9 @@ class AnalyzerTab(QtWidgets.QWidget):
             self.space_voxel,
             self.type_spherical,
             self.type_cortical,
-            self.coords_radius_input,
+            self.spheres_table,
+            self.add_sphere_btn,
+            self.remove_sphere_btn,
             self.view_in_freeview_btn,
             self.atlas_name_combo,
             self.atlas_combo,
@@ -2233,7 +2387,9 @@ class AnalyzerTab(QtWidgets.QWidget):
             self.space_voxel,
             self.type_spherical,
             self.type_cortical,
-            self.coords_radius_input,
+            self.spheres_table,
+            self.add_sphere_btn,
+            self.remove_sphere_btn,
             self.view_in_freeview_btn,
             # atlas_name_combo, atlas_combo, show_regions_btn, region_chips handled by update_atlas_visibility
         ]
@@ -2620,8 +2776,42 @@ class AnalyzerTab(QtWidgets.QWidget):
         subprocess.Popen(["gmsh", msh_file])
         self.update_output(f"Launched Gmsh with mesh file: {msh_file}")
 
-    def build_single_analysis_command(self, subject_id, simulation_name):
-        """Build command to run single-subject analysis using the new Analyzer API via subprocess."""
+    def build_single_analysis_commands(self, subject_id, simulation_name):
+        """Build the list of commands for a single-subject run.
+
+        Cortical analysis is unchanged: one command. Spherical analysis
+        builds one command per sphere row -- N spheres become N separate
+        analyses (N separate output dirs), each run in turn. A single sphere
+        row produces exactly the same one-command list as before.
+
+        Returns ``None`` on any error (mirrors ``build_single_analysis_command``).
+        """
+        if not self.type_spherical.isChecked():
+            cmd = self.build_single_analysis_command(subject_id, simulation_name)
+            return [cmd] if cmd else None
+
+        spheres = self._parse_all_spheres()
+        if not spheres:
+            return None
+
+        cmds = []
+        for x, y, z, r in spheres:
+            cmd = self.build_single_analysis_command(
+                subject_id, simulation_name, sphere=(x, y, z, r)
+            )
+            if not cmd:
+                return None
+            cmds.append(cmd)
+        return cmds
+
+    def build_single_analysis_command(self, subject_id, simulation_name, sphere=None):
+        """Build command to run single-subject analysis using the new Analyzer API via subprocess.
+
+        Args:
+            sphere: Optional ``(x, y, z, r)`` to use instead of parsing the
+                first sphere row -- used by ``build_single_analysis_commands``
+                to build one command per sphere for multi-sphere runs.
+        """
         try:
             project_dir = self.pm.project_dir
             if not project_dir:
@@ -2647,7 +2837,13 @@ class AnalyzerTab(QtWidgets.QWidget):
 
             # Build output directory using PathManager for overwrite confirmation
             if analysis_type == "spherical":
-                x, y, z, radius_val = self._parse_coords_radius()
+                if sphere is not None:
+                    x, y, z, radius_val = sphere
+                else:
+                    parsed = self._parse_coords_radius()
+                    if parsed is None:
+                        return None
+                    x, y, z, radius_val = parsed
                 coords = [x, y, z]
                 coord_space = "MNI" if self.coord_space_mni.isChecked() else "subject"
             else:
@@ -2779,11 +2975,9 @@ class AnalyzerTab(QtWidgets.QWidget):
         # via height-for-width, so it needs no maximum-width clamp; leaving one
         # would stop the chips from reflowing to fill the available row.
 
-        # Coordinates+radius input uses Preferred policy
-        if hasattr(self, "coords_radius_input"):
-            coords_max = max(200, min(300, int(container_width * 0.30)))
-            if self.coords_radius_input.maximumWidth() != coords_max:
-                self.coords_radius_input.setMaximumWidth(coords_max)
+        # The spheres table uses Expanding policy, so it fills the available
+        # width on its own — no dynamic max-width clamp needed (unlike the
+        # single-line input it replaced).
 
         # Buttons use Fixed policy - no dynamic adjustment needed
         # Atlas and Gmsh combo boxes use Expanding policy - they automatically fill space

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -127,12 +127,31 @@ COORD_SPACE_HELP = (
 )
 
 ATLAS_ROI_HELP = (
-    "Adds a volumetric (subcortical) atlas region as an additional search "
-    "target, unioned together with the spherical ROI(s) selected above -- "
-    "the field is evaluated over their combined coverage. Optional; leave "
-    "empty to use only the spherical ROI(s) above.\n\n"
+    "Volumetric (subcortical) atlas region(s) used as the search target "
+    "when ROI Type is set to Atlas.\n\n"
     "Atlas targets are always read in the subject's own space, regardless "
-    "of the Coordinate Space setting above."
+    "of the Coordinate Space setting on the Sphere page."
+)
+
+#: ROI-mechanism modes for the ROI Selection box: sphere (ROI CSVs, radius,
+#: coordinate space) or atlas (volumetric ROIPickerWidget). These are
+#: alternatives, not companions -- see ExConfig.roi_names ("an explicit
+#: empty list means 'no spherical centers at all' -- useful for a purely
+#: atlas-driven ROI") and ExConfig.roi_atlas in tit/opt/config.py.
+ROI_MODE_SPHERE = "sphere"
+ROI_MODE_ATLAS = "atlas"
+
+ROI_MODE_HELP = (
+    "Choose how the search target is defined -- the two mechanisms are "
+    "alternatives, not companions:\n\n"
+    "Sphere: one or more spherical ROIs (from ROI CSVs), sized by ROI "
+    "Radius, in either Subject or MNI coordinate space. This is the "
+    "default and the only path in common use.\n\n"
+    "Atlas: a volumetric (subcortical) atlas region instead of any "
+    "spherical ROI. Always read in the subject's own space.\n\n"
+    "mTI (4-pair) search always requires a Sphere ROI regardless of this "
+    "toggle -- the multipolar backend has no atlas-only equivalent to "
+    "ExConfig's roi_names=[] escape hatch."
 )
 
 
@@ -421,6 +440,51 @@ class ExSearchTab(QtWidgets.QWidget):
         atlas_path = picker.volume_atlas_combo.currentData()
         region_keys = list(picker.subcortical_chips.keys())
         return self.build_roi_atlas_entries(atlas_path, region_keys)
+
+    @staticmethod
+    def roi_names_for_mode(mode: str, roi_names: list[str] | None) -> list[str] | None:
+        """Map the ROI mode toggle to ``ExConfig.roi_names``.
+
+        Atlas mode means the target is atlas-only: an *explicit* empty
+        list, which ``ExConfig`` treats as "no spherical centers at all"
+        (see its docstring) rather than ``None`` (which falls back to the
+        single ``roi_name``). Sphere mode passes the caller's ROI names
+        through unchanged -- today's only real path.
+        """
+        return [] if mode == ROI_MODE_ATLAS else roi_names
+
+    @staticmethod
+    def roi_atlas_for_mode(
+        mode: str, roi_atlas_entries: list[dict] | None
+    ) -> list[dict] | None:
+        """Map the ROI mode toggle to ``roi_atlas`` for ExConfig/MExConfig.
+
+        Sphere mode disables the atlas path entirely (``None``) so the two
+        ROI mechanisms behave as alternatives rather than silently
+        combining. Atlas mode passes the picker's current entries through
+        unchanged.
+        """
+        return roi_atlas_entries if mode == ROI_MODE_ATLAS else None
+
+    @staticmethod
+    def atlas_only_roi_label(region_keys: list[str]) -> str:
+        """Synthetic ``ExConfig.roi_name`` label for atlas-only mode.
+
+        ``roi_name`` is always required -- it is the metric-key prefix and
+        (with the net name) the output-directory label -- even when there
+        are no spherical centers at all (``roi_names=[]``). Atlas mode has
+        no ROI CSV to name itself after, so build a stable label from the
+        selected atlas region keys instead.
+        """
+        if not region_keys:
+            return "atlas_roi"
+        return "atlas_" + "_".join(str(key) for key in region_keys)
+
+    def _current_roi_mode(self) -> str:
+        """Return the active ROI mechanism: ``ROI_MODE_SPHERE`` or ``ROI_MODE_ATLAS``."""
+        return (
+            ROI_MODE_ATLAS if self.roi_mode_atlas_radio.isChecked() else ROI_MODE_SPHERE
+        )
 
     def __init__(self, parent=None):
         super(ExSearchTab, self).__init__(parent)
@@ -937,7 +1001,9 @@ class ExSearchTab(QtWidgets.QWidget):
         # ROW 0, COLUMN 0: Subject Selection
         # ============================================================
         subject_container = QtWidgets.QGroupBox("Subject Selection")
-        subject_container.setFixedHeight(180)  # Match electrode selection height
+        subject_container.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         subject_layout = QtWidgets.QVBoxLayout(subject_container)
         subject_layout.setContentsMargins(10, 10, 10, 10)
         subject_layout.setSpacing(8)
@@ -970,9 +1036,9 @@ class ExSearchTab(QtWidgets.QWidget):
         # ROW 0, COLUMN 1: Electrode Selection
         # ============================================================
         electrode_container = QtWidgets.QGroupBox("Electrode Selection")
-        electrode_container.setFixedHeight(
-            220
-        )  # Fixed height for balance (+search-mode row)
+        electrode_container.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         electrode_main_layout = QtWidgets.QVBoxLayout(electrode_container)
         electrode_main_layout.setContentsMargins(10, 10, 10, 10)
         electrode_main_layout.setSpacing(8)
@@ -1041,23 +1107,47 @@ class ExSearchTab(QtWidgets.QWidget):
         # ============================================================
         # ROW 1, COLUMN 0: ROI Selection
         # ============================================================
+        # Sphere ROI(s) and Atlas ROI are alternatives, not companions --
+        # a ROI Type toggle drives a QStackedWidget with one page per
+        # mechanism (same idiom as electrode_stack above). The group hugs
+        # whichever page is showing (Maximum) instead of reserving room for
+        # both; see _resize_roi_mode_stack.
         roi_container = QtWidgets.QGroupBox("ROI Selection")
-        roi_container.setFixedHeight(
-            220 + 68 + 90
-        )  # Fixed height for balance (includes radius + combine + atlas controls).
-        # The +90 accounts for the subcortical ROIPickerWidget page (atlas-space
-        # toggle + tissue combo + atlas combo/buttons + chips), taller than the
-        # single combo+chips row it replaced. Not verified visually -- no
-        # display available in this environment; re-check in a running GUI.
+        roi_container.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         roi_layout = QtWidgets.QVBoxLayout(roi_container)
         roi_layout.setContentsMargins(10, 10, 10, 10)
         roi_layout.setSpacing(8)
+
+        roi_mode_layout = QtWidgets.QHBoxLayout()
+        roi_mode_layout.addWidget(QtWidgets.QLabel("ROI Type:"))
+        self.roi_mode_sphere_radio = QtWidgets.QRadioButton("Sphere")
+        self.roi_mode_atlas_radio = QtWidgets.QRadioButton("Atlas")
+        self.roi_mode_sphere_radio.setChecked(True)  # Default: today's only real path
+        roi_mode_group = QtWidgets.QButtonGroup(self)
+        roi_mode_group.addButton(self.roi_mode_sphere_radio)
+        roi_mode_group.addButton(self.roi_mode_atlas_radio)
+        roi_mode_layout.addWidget(self.roi_mode_sphere_radio)
+        roi_mode_layout.addWidget(self.roi_mode_atlas_radio)
+        roi_mode_layout.addWidget(HelpIcon(ROI_MODE_HELP, title="ROI Type"))
+        roi_mode_layout.addStretch()
+        roi_layout.addLayout(roi_mode_layout)
+
+        self.roi_mode_stack = QtWidgets.QStackedWidget()
+        roi_layout.addWidget(self.roi_mode_stack)
+
+        # ---- Sphere page (index 0) ----
+        sphere_page = QtWidgets.QWidget()
+        sphere_layout = QtWidgets.QVBoxLayout(sphere_page)
+        sphere_layout.setContentsMargins(0, 0, 0, 0)
+        sphere_layout.setSpacing(8)
 
         # List widget for ROI selection
         self.roi_list = QtWidgets.QListWidget()
         self.roi_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.roi_list.setFixedHeight(80)  # Adjusted to fit within ROI container
-        roi_layout.addWidget(self.roi_list)
+        sphere_layout.addWidget(self.roi_list)
 
         # ROI control buttons
         roi_button_layout = QtWidgets.QHBoxLayout()
@@ -1074,7 +1164,7 @@ class ExSearchTab(QtWidgets.QWidget):
         roi_button_layout.addWidget(self.add_roi_btn)
         roi_button_layout.addWidget(self.remove_roi_btn)
         roi_button_layout.addWidget(self.list_rois_btn)
-        roi_layout.addLayout(roi_button_layout)
+        sphere_layout.addLayout(roi_button_layout)
 
         # ROI radius parameter
         radius_layout = QtWidgets.QHBoxLayout()
@@ -1091,7 +1181,7 @@ class ExSearchTab(QtWidgets.QWidget):
         radius_layout.addWidget(radius_label)
         radius_layout.addWidget(self.roi_radius_spinbox)
         radius_layout.addStretch()
-        roi_layout.addLayout(radius_layout)
+        sphere_layout.addLayout(radius_layout)
 
         # Combine selected ROIs into a single (unioned) target
         combine_tooltip = (
@@ -1107,7 +1197,7 @@ class ExSearchTab(QtWidgets.QWidget):
         combine_layout.addWidget(self.combine_rois_cb)
         combine_layout.addWidget(HelpIcon(combine_tooltip, title="Combine ROIs"))
         combine_layout.addStretch()
-        roi_layout.addLayout(combine_layout)
+        sphere_layout.addLayout(combine_layout)
 
         # Coordinate space toggle (governs the spherical ROI centers only).
         space_layout = QtWidgets.QHBoxLayout()
@@ -1122,19 +1212,26 @@ class ExSearchTab(QtWidgets.QWidget):
         space_layout.addWidget(self.coord_space_mni)
         space_layout.addWidget(HelpIcon(COORD_SPACE_HELP, title="Coordinate Space"))
         space_layout.addStretch()
-        roi_layout.addLayout(space_layout)
+        sphere_layout.addLayout(space_layout)
 
-        # Atlas ROI: optional subcortical (volumetric atlas) target(s), unioned
-        # with the spherical ROI(s) selected above. Shares the same
-        # ROIPickerWidget component flex-search uses, minus the cortical mode
-        # (ex-search has no surface-annotation ROI concept) -- this also gives
-        # it the same region-listing behavior (no synchronous FreeSurfer
-        # mri_segstats call on the UI thread; see ROIPickerWidget/VoxelAtlasManager).
+        self.roi_mode_stack.addWidget(sphere_page)
+
+        # ---- Atlas page (index 1) ----
+        # Shares the same ROIPickerWidget component flex-search uses, minus
+        # the cortical mode (ex-search has no surface-annotation ROI
+        # concept) -- this also gives it the same region-listing behavior
+        # (no synchronous FreeSurfer mri_segstats call on the UI thread; see
+        # ROIPickerWidget/VoxelAtlasManager).
+        atlas_page = QtWidgets.QWidget()
+        atlas_layout = QtWidgets.QVBoxLayout(atlas_page)
+        atlas_layout.setContentsMargins(0, 0, 0, 0)
+        atlas_layout.setSpacing(8)
+
         atlas_header_layout = QtWidgets.QHBoxLayout()
-        atlas_header_layout.addWidget(QtWidgets.QLabel("Atlas ROI (optional):"))
+        atlas_header_layout.addWidget(QtWidgets.QLabel("Atlas ROI:"))
         atlas_header_layout.addWidget(HelpIcon(ATLAS_ROI_HELP, title="Atlas ROI"))
         atlas_header_layout.addStretch()
-        roi_layout.addLayout(atlas_header_layout)
+        atlas_layout.addLayout(atlas_header_layout)
 
         self.atlas_roi_picker = ROIPickerWidget(
             enable_spherical=False,
@@ -1157,7 +1254,14 @@ class ExSearchTab(QtWidgets.QWidget):
         self.atlas_roi_picker.volume_subject_radio.setChecked(True)
         self.atlas_roi_picker.volume_subject_radio.setVisible(False)
         self.atlas_roi_picker.volume_mni_radio.setVisible(False)
-        roi_layout.addWidget(self.atlas_roi_picker)
+        atlas_layout.addWidget(self.atlas_roi_picker)
+
+        self.roi_mode_stack.addWidget(atlas_page)
+
+        self.roi_mode_sphere_radio.toggled.connect(
+            lambda _v: self._on_roi_mode_changed()
+        )
+        self._on_roi_mode_changed()  # Initialize to correct (sphere) page
 
         # Add ROI container to grid - Row 1, Column 0
         main_grid_layout.addWidget(roi_container, 1, 0)
@@ -1166,9 +1270,9 @@ class ExSearchTab(QtWidgets.QWidget):
         # ROW 1, COLUMN 1: Current Configuration
         # ============================================================
         self.current_container = QtWidgets.QGroupBox("Current Configuration")
-        self.current_container.setFixedHeight(
-            220
-        )  # Match ROI selection height (+mTI page)
+        self.current_container.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         current_layout = QtWidgets.QVBoxLayout(self.current_container)
         current_layout.setContentsMargins(10, 10, 10, 10)
         current_layout.setSpacing(8)
@@ -1187,7 +1291,9 @@ class ExSearchTab(QtWidgets.QWidget):
         # ROW 2, COLUMN 0-1: Leadfield Management (spanning both columns)
         # ============================================================
         leadfield_container = QtWidgets.QGroupBox("Leadfield Management")
-        leadfield_container.setFixedHeight(240)  # Fixed height for balance
+        leadfield_container.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
         leadfield_layout = QtWidgets.QVBoxLayout(leadfield_container)
         leadfield_layout.setContentsMargins(10, 10, 10, 10)
         leadfield_layout.setSpacing(8)
@@ -1245,6 +1351,11 @@ class ExSearchTab(QtWidgets.QWidget):
 
         # Add grid layout to scroll layout
         scroll_layout.addLayout(main_grid_layout)
+
+        # Trailing stretch absorbs the vertical slack freed by dropping the
+        # container setFixedHeight calls above (groups now hug their content
+        # via SizePolicy.Maximum instead of reserving dead space).
+        scroll_layout.addStretch(1)
 
         # Set scroll content and add to main layout
         scroll_area.setWidget(scroll_content)
@@ -1577,6 +1688,38 @@ class ExSearchTab(QtWidgets.QWidget):
             names.append(name)
         return names
 
+    def _on_roi_mode_changed(self):
+        """Switch the ROI Selection box between its Sphere and Atlas pages."""
+        is_atlas = self._current_roi_mode() == ROI_MODE_ATLAS
+        self.roi_mode_stack.setCurrentIndex(1 if is_atlas else 0)
+        self._resize_roi_mode_stack()
+
+    def _resize_roi_mode_stack(self):
+        """Size ``roi_mode_stack`` to its current page instead of the tallest.
+
+        Mirrors ``ROIPickerWidget._resize_stack_to_current``: collapse the
+        non-active page's vertical size policy to ``Ignored`` so the stack
+        (and the surrounding ``roi_container``, set to ``Maximum``) hugs
+        whichever page is showing instead of reserving room for both.
+        """
+        current = self.roi_mode_stack.currentWidget()
+        for i in range(self.roi_mode_stack.count()):
+            page = self.roi_mode_stack.widget(i)
+            if page is None:
+                continue
+            policy = page.sizePolicy()
+            policy.setVerticalPolicy(
+                QtWidgets.QSizePolicy.Preferred
+                if page is current
+                else QtWidgets.QSizePolicy.Ignored
+            )
+            page.setSizePolicy(policy)
+        if current is not None:
+            current.adjustSize()
+        self.roi_mode_stack.updateGeometry()
+        self.roi_mode_stack.adjustSize()
+        self.updateGeometry()
+
     def _on_search_mode_changed(self):
         """Swap electrode/current panels and toggle mode-specific controls."""
         is_mti = self._current_search_mode() == SEARCH_MODE_MTI
@@ -1598,6 +1741,22 @@ class ExSearchTab(QtWidgets.QWidget):
         self.combine_rois_cb.setEnabled(not is_mti)
         if is_mti:
             self.combine_rois_cb.setChecked(False)
+
+        # Atlas-only targeting is TI-only. tit/opt/ex/ex.py honours
+        # roi_names=[] and reads no sphere file, but tit/opt/mex/mex.py builds
+        # roi_file from config.roi_name unconditionally, so a multipolar run
+        # always needs a spherical ROI. Offering Atlas here would take the
+        # selection and then fail validation asking for a sphere, so the choice
+        # is disabled rather than left to mislead.
+        self.roi_mode_atlas_radio.setEnabled(not is_mti)
+        self.roi_mode_atlas_radio.setToolTip(
+            "Atlas-only targeting is not available for mTI: a multipolar run "
+            "still requires a spherical ROI."
+            if is_mti
+            else ""
+        )
+        if is_mti and self.roi_mode_atlas_radio.isChecked():
+            self.roi_mode_sphere_radio.setChecked(True)
 
         self.run_btn.setText("Run mTI Search" if is_mti else "Run Ex-Search")
         self.stop_btn.setText("Stop mTI Search" if is_mti else "Stop Ex-Search")
@@ -2000,17 +2159,31 @@ class ExSearchTab(QtWidgets.QWidget):
             self.update_status("Please select a leadfield for simulation", error=True)
             return False
 
-        # Check if ROIs are selected
-        if self.roi_list.count() == 0:
-            self.update_status("Please add at least one ROI", error=True)
-            return False
+        # ROI validation branches on ROI Type (Sphere/Atlas). mTI always needs
+        # a Sphere ROI regardless of the toggle: MExConfig has no roi_names=[]
+        # atlas-only escape hatch -- tit/opt/mex/mex.py builds roi_file from
+        # config.roi_name unconditionally and always merges it into
+        # roi_target, so the backend has no way to run without one.
+        if (
+            self._current_search_mode() == SEARCH_MODE_MTI
+            or self._current_roi_mode() == ROI_MODE_SPHERE
+        ):
+            # Check if ROIs are selected
+            if self.roi_list.count() == 0:
+                self.update_status("Please add at least one ROI", error=True)
+                return False
 
-        # Check if at least one ROI is selected
-        selected_rois = self.roi_list.selectedItems()
-        if not selected_rois:
-            self.update_status(
-                "Please select at least one ROI from the list", error=True
-            )
+            # Check if at least one ROI is selected
+            selected_rois = self.roi_list.selectedItems()
+            if not selected_rois:
+                self.update_status(
+                    "Please select at least one ROI from the list", error=True
+                )
+                return False
+        elif not self._current_roi_atlas_entries():
+            # TI + Atlas mode: Sphere ROI is optional, but an atlas target
+            # is required in its place.
+            self.update_status("Please select at least one atlas region", error=True)
             return False
 
         # mTI validates its own eight electrode buckets; the TI
@@ -2111,6 +2284,69 @@ class ExSearchTab(QtWidgets.QWidget):
             e2_plus = self.parse_electrode_input(self.e2_plus_input.text())
             e2_minus = self.parse_electrode_input(self.e2_minus_input.text())
             self.use_all_combinations = False
+
+        # ROI Type: Sphere is today's only real path and stays byte-for-byte
+        # identical below. Atlas mode has no ROI CSV selection at all, so it
+        # takes its own early-return branch instead of threading empty
+        # sphere state through the combine-ROI machinery below.
+        is_atlas_only = self._current_roi_mode() == ROI_MODE_ATLAS
+        if is_atlas_only:
+            atlas_region_keys = list(self.atlas_roi_picker.subcortical_chips.keys())
+            roi_label = self.atlas_only_roi_label(atlas_region_keys)
+
+            if self.use_all_combinations:
+                mode_str = "All-Combinations Mode"
+                electrode_info = f"Electrode Pool: {', '.join(e1_plus[:8])}{'...' if len(e1_plus) > 8 else ''}\n"
+                electrode_info += f"Total Electrodes: {len(e1_plus)}"
+            else:
+                mode_str = "Bucketed Mode"
+                electrode_info = (
+                    f"E1+: {len(e1_plus)} electrodes, E1-: {len(e1_minus)}\n"
+                    f"E2+: {len(e2_plus)} electrodes, E2-: {len(e2_minus)}"
+                )
+
+            details = (
+                f"Subject: {subject_id}\n"
+                f"Mode: {mode_str}\n"
+                f"{electrode_info}\n"
+                f"Atlas ROI: {', '.join(atlas_region_keys)}"
+            )
+
+            if not ConfirmationDialog.confirm(
+                self,
+                title="Confirm Ex-Search Optimization",
+                message="Are you sure you want to start the ex-search optimization?",
+                details=details,
+            ):
+                return
+
+            os.makedirs(ex_search_dir, exist_ok=True)
+
+            selected_roi_names = [f"{roi_label}.csv"]
+            if self.debug_mode:
+                self.update_output(
+                    f"Atlas-only ROI target: {', '.join(atlas_region_keys)}"
+                )
+
+            env = os.environ.copy()
+            env["SUBJECTS_DIR"] = project_dir
+
+            self.disable_controls()
+            self.update_status(f"Running optimization for subject {subject_id}...")
+
+            self._combine_rois = False
+            self._combined_roi_names = []
+            self.roi_processing_queue = selected_roi_names.copy()
+            self.current_roi_index = 0
+            self._exsearch_had_errors = False
+            self.e1_plus = e1_plus
+            self.e1_minus = e1_minus
+            self.e2_plus = e2_plus
+            self.e2_minus = e2_minus
+
+            self.log_exsearch_start(subject_id, len(selected_roi_names))
+            self.run_roi_pipeline(subject_id, project_dir, ex_search_dir, env)
+            return
 
         # Show confirmation dialog with mode and electrode information
         selected_rois = self.roi_list.selectedItems()
@@ -2312,12 +2548,13 @@ class ExSearchTab(QtWidgets.QWidget):
                 e2_minus=list(self.e2_minus),
             )
 
+        mode = self._current_roi_mode()
         return ExConfig(
             subject_id=subject_id,
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
-            roi_names=roi_names,
-            roi_atlas=self._current_roi_atlas_entries(),
+            roi_names=self.roi_names_for_mode(mode, roi_names),
+            roi_atlas=self.roi_atlas_for_mode(mode, self._current_roi_atlas_entries()),
             roi_coordinate_space=self.coordinate_space_value(
                 self.coord_space_mni.isChecked()
             ),
@@ -2376,11 +2613,12 @@ class ExSearchTab(QtWidgets.QWidget):
             MExConfig instance ready for serialization.
         """
         electrodes = MExConfig.BucketElectrodes(**self.mex_buckets)
+        mode = self._current_roi_mode()
         return MExConfig(
             subject_id=subject_id,
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
-            roi_atlas=self._current_roi_atlas_entries(),
+            roi_atlas=self.roi_atlas_for_mode(mode, self._current_roi_atlas_entries()),
             roi_coordinate_space=self.coordinate_space_value(
                 self.coord_space_mni.isChecked()
             ),
@@ -2450,43 +2688,65 @@ class ExSearchTab(QtWidgets.QWidget):
         # Get ROI coordinates
         pm = self.pm
         roi_dir = pm.rois(subject_id)
+        # Atlas-only mode (TI search mode + ROI_MODE_ATLAS) has no sphere ROI
+        # CSV at all -- see the early-return branch in run_optimization -- so
+        # there is nothing on disk to read coordinates from.
+        is_atlas_only = (
+            self._current_search_mode() != SEARCH_MODE_MTI
+            and self._current_roi_mode() == ROI_MODE_ATLAS
+        )
         if self._combine_rois:
             # Combined target: the queue holds one synthetic entry; read coords
             # from the first real ROI for logging while the backend unions all
             # selected ROI spheres (roi_names).
             roi_names_for_config = list(self._combined_roi_names)
             coord_source = self._combined_roi_names[0]
+        elif is_atlas_only:
+            roi_names_for_config = []
+            coord_source = None
         else:
             roi_names_for_config = None
             coord_source = current_roi
-        roi_file = os.path.join(roi_dir, coord_source)
 
-        try:
-            with open(roi_file, "r") as f:
-                coordinates = f.readline().strip()
-            x, y, z = [float(coord.strip()) for coord in coordinates.split(",")]
+        if is_atlas_only:
+            # No spherical center to read -- coordinates are display-only and
+            # unused by the backend when roi_names=[] (atlas-only target).
+            x = y = z = 0.0
             if self.debug_mode:
-                self.update_output(f"[DEBUG] ROI file: {roi_file}", "debug")
-                self.update_output(f"[DEBUG] Parsed ROI coords: {(x, y, z)}", "debug")
-        except (OSError, ValueError) as e:
-            if self._combine_rois:
-                # In combined mode these coords are display-only (the backend
-                # unions all selected roi_names itself), so a bad display-source
-                # read must NOT abort the whole union run.
                 self.update_output(
-                    f"Warning: could not read coords from {coord_source} "
-                    f"for logging: {str(e)}",
-                    "warning",
+                    "[DEBUG] Atlas-only ROI target -- no spherical coordinates",
+                    "debug",
                 )
-                x = y = z = 0.0
-            else:
-                self.update_output(
-                    f"Error reading ROI file {current_roi}: {str(e)}", "error"
-                )
-                # Move to next ROI
-                self.current_roi_index += 1
-                self.run_roi_pipeline(subject_id, project_dir, ex_search_dir, env)
-                return
+        else:
+            roi_file = os.path.join(roi_dir, coord_source)
+            try:
+                with open(roi_file, "r") as f:
+                    coordinates = f.readline().strip()
+                x, y, z = [float(coord.strip()) for coord in coordinates.split(",")]
+                if self.debug_mode:
+                    self.update_output(f"[DEBUG] ROI file: {roi_file}", "debug")
+                    self.update_output(
+                        f"[DEBUG] Parsed ROI coords: {(x, y, z)}", "debug"
+                    )
+            except (OSError, ValueError) as e:
+                if self._combine_rois:
+                    # In combined mode these coords are display-only (the backend
+                    # unions all selected roi_names itself), so a bad display-source
+                    # read must NOT abort the whole union run.
+                    self.update_output(
+                        f"Warning: could not read coords from {coord_source} "
+                        f"for logging: {str(e)}",
+                        "warning",
+                    )
+                    x = y = z = 0.0
+                else:
+                    self.update_output(
+                        f"Error reading ROI file {current_roi}: {str(e)}", "error"
+                    )
+                    # Move to next ROI
+                    self.current_roi_index += 1
+                    self.run_roi_pipeline(subject_id, project_dir, ex_search_dir, env)
+                    return
 
         # Build the backend config dataclass from UI state: TI -> ExConfig via
         # tit.opt.ex, mTI -> MExConfig via tit.opt.mex (see search_backend_for_mode).
@@ -2938,6 +3198,8 @@ class ExSearchTab(QtWidgets.QWidget):
     def disable_controls(self):
         """Disable controls during optimization or leadfield generation."""
         self.subject_combo.setEnabled(False)
+        self.roi_mode_sphere_radio.setEnabled(False)
+        self.roi_mode_atlas_radio.setEnabled(False)
         self.roi_list.setEnabled(False)
         self.roi_radius_spinbox.setEnabled(False)
         self.e1_plus_input.setEnabled(False)
@@ -2983,6 +3245,8 @@ class ExSearchTab(QtWidgets.QWidget):
     def enable_controls(self):
         """Enable controls after optimization."""
         self.subject_combo.setEnabled(True)
+        self.roi_mode_sphere_radio.setEnabled(True)
+        self.roi_mode_atlas_radio.setEnabled(True)
         self.roi_list.setEnabled(True)
         self.roi_radius_spinbox.setEnabled(True)
         self.e1_plus_input.setEnabled(True)

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -37,10 +37,7 @@ from tit.gui.components.console import (
 from tit.gui.components.action_buttons import RunStopButtons
 from tit.gui.components.base_thread import BaseProcessThread
 from tit.gui.components.help_icon import HelpIcon
-from tit.gui.components.atlas_region_finder import AtlasRegionFinderDialog
-from tit.gui.components.region_chips import RegionChipsWidget
-from tit.atlas import MNI_ATLAS_DIR, VoxelAtlasManager
-from tit.atlas.voxel import parse_region_label
+from tit.gui.components.roi_picker import ROIPickerWidget
 from tit.paths import get_path_manager
 from tit import logger as logging_util
 from tit.opt.ex.engine import ExSearchEngine
@@ -130,11 +127,10 @@ COORD_SPACE_HELP = (
 )
 
 ATLAS_ROI_HELP = (
-    "Adds a volumetric atlas region (or a whole mask file) as an additional "
-    "search target, unioned together with the spherical ROI(s) selected "
-    "above -- the field is evaluated over their combined coverage.\n\n"
-    "Region: only the voxels equal to the chosen atlas label are included. "
-    "Whole File: every nonzero voxel in the file is included (binary mask).\n\n"
+    "Adds a volumetric (subcortical) atlas region as an additional search "
+    "target, unioned together with the spherical ROI(s) selected above -- "
+    "the field is evaluated over their combined coverage. Optional; leave "
+    "empty to use only the spherical ROI(s) above.\n\n"
     "Atlas targets are always read in the subject's own space, regardless "
     "of the Coordinate Space setting above."
 )
@@ -394,34 +390,37 @@ class ExSearchTab(QtWidgets.QWidget):
         return "mni" if is_mni else "subject"
 
     @staticmethod
-    def atlas_roi_chip_key(atlas_path: str, label: int | None) -> str:
-        """Build the opaque chip key encoding an atlas ROI selection.
+    def build_roi_atlas_entries(
+        atlas_path: str | None, region_keys: list[str]
+    ) -> list[dict] | None:
+        """Map the subcortical ROIPickerWidget's state to ``ExConfig.AtlasROI`` dicts.
 
-        Uses a control character as separator (never valid in a filesystem
-        path or an integer) so the key round-trips exactly through
-        :meth:`atlas_roi_from_chip_key`.
+        ``ROIPickerWidget`` (subcortical mode, no "whole file" option) exposes
+        one shared volume-atlas path plus a set of integer label chips
+        (``subcortical_chips.keys()``); each selected label becomes its own
+        ``ExConfig.AtlasROI``-shaped dict sharing that atlas path, matching
+        the pre-existing per-region entry shape. ``ExConfig``/``MExConfig``
+        accept a plain dict for each entry (see their ``__post_init__``), so
+        callers can hand the result straight to ``roi_atlas=`` without
+        importing the dataclass here.
+
+        Returns ``None`` when no atlas or no region is selected -- the Atlas
+        ROI target is optional and this keeps ``roi_atlas`` unset in that
+        case (mirrors the previous "atlas ROI is optional" behavior).
         """
-        return f"{atlas_path}\x1f{'' if label is None else label}"
+        if not atlas_path:
+            return None
+        labels = [int(key) for key in region_keys if str(key).strip()]
+        if not labels:
+            return None
+        return [{"atlas_path": str(atlas_path), "label": label} for label in labels]
 
-    @staticmethod
-    def atlas_roi_from_chip_key(key: str) -> tuple[str, int | None]:
-        """Inverse of :meth:`atlas_roi_chip_key`."""
-        atlas_path, _, label_str = key.partition("\x1f")
-        return atlas_path, (int(label_str) if label_str else None)
-
-    @classmethod
-    def build_roi_atlas_entries(cls, chip_keys: list[str]) -> list[dict]:
-        """Map selected atlas-ROI chip keys to ``ExConfig.AtlasROI``-shaped dicts.
-
-        ``ExConfig``/``MExConfig`` accept a plain dict for each entry (see
-        their ``__post_init__``), so callers can hand this straight to
-        ``roi_atlas=`` without importing the dataclass here.
-        """
-        entries = []
-        for key in chip_keys:
-            atlas_path, label = cls.atlas_roi_from_chip_key(key)
-            entries.append({"atlas_path": atlas_path, "label": label})
-        return entries
+    def _current_roi_atlas_entries(self) -> list[dict] | None:
+        """Read the Atlas ROI picker's current state into ``roi_atlas`` entries."""
+        picker = self.atlas_roi_picker
+        atlas_path = picker.volume_atlas_combo.currentData()
+        region_keys = list(picker.subcortical_chips.keys())
+        return self.build_roi_atlas_entries(atlas_path, region_keys)
 
     def __init__(self, parent=None):
         super(ExSearchTab, self).__init__(parent)
@@ -1044,8 +1043,12 @@ class ExSearchTab(QtWidgets.QWidget):
         # ============================================================
         roi_container = QtWidgets.QGroupBox("ROI Selection")
         roi_container.setFixedHeight(
-            220 + 68
-        )  # Fixed height for balance (includes radius + combine + atlas controls)
+            220 + 68 + 90
+        )  # Fixed height for balance (includes radius + combine + atlas controls).
+        # The +90 accounts for the subcortical ROIPickerWidget page (atlas-space
+        # toggle + tissue combo + atlas combo/buttons + chips), taller than the
+        # single combo+chips row it replaced. Not verified visually -- no
+        # display available in this environment; re-check in a running GUI.
         roi_layout = QtWidgets.QVBoxLayout(roi_container)
         roi_layout.setContentsMargins(10, 10, 10, 10)
         roi_layout.setSpacing(8)
@@ -1121,41 +1124,40 @@ class ExSearchTab(QtWidgets.QWidget):
         space_layout.addStretch()
         roi_layout.addLayout(space_layout)
 
-        # Atlas ROI: optional volumetric atlas/mask target(s), unioned with
-        # the spherical ROI(s) selected above.
-        atlas_layout = QtWidgets.QHBoxLayout()
-        atlas_layout.addWidget(QtWidgets.QLabel("Atlas ROI:"))
-        self.atlas_roi_combo = QtWidgets.QComboBox()
-        self.atlas_roi_combo.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
-        )
-        atlas_layout.addWidget(self.atlas_roi_combo)
-        self.refresh_atlas_roi_btn = QtWidgets.QPushButton("Refresh")
-        self.refresh_atlas_roi_btn.clicked.connect(self._refresh_atlas_roi_combo)
-        atlas_layout.addWidget(self.refresh_atlas_roi_btn)
-        self.add_atlas_region_btn = QtWidgets.QPushButton("Add Region…")
-        self.add_atlas_region_btn.setToolTip(
-            "Browse and select one or more labeled regions from the chosen atlas."
-        )
-        self.add_atlas_region_btn.clicked.connect(self._on_add_atlas_region)
-        atlas_layout.addWidget(self.add_atlas_region_btn)
-        self.add_atlas_whole_btn = QtWidgets.QPushButton("Add Whole File")
-        self.add_atlas_whole_btn.setToolTip(
-            "Use every nonzero voxel in the selected file as a binary mask."
-        )
-        self.add_atlas_whole_btn.clicked.connect(self._on_add_atlas_whole_file)
-        atlas_layout.addWidget(self.add_atlas_whole_btn)
-        atlas_layout.addWidget(HelpIcon(ATLAS_ROI_HELP, title="Atlas ROI"))
-        roi_layout.addLayout(atlas_layout)
+        # Atlas ROI: optional subcortical (volumetric atlas) target(s), unioned
+        # with the spherical ROI(s) selected above. Shares the same
+        # ROIPickerWidget component flex-search uses, minus the cortical mode
+        # (ex-search has no surface-annotation ROI concept) -- this also gives
+        # it the same region-listing behavior (no synchronous FreeSurfer
+        # mri_segstats call on the UI thread; see ROIPickerWidget/VoxelAtlasManager).
+        atlas_header_layout = QtWidgets.QHBoxLayout()
+        atlas_header_layout.addWidget(QtWidgets.QLabel("Atlas ROI (optional):"))
+        atlas_header_layout.addWidget(HelpIcon(ATLAS_ROI_HELP, title="Atlas ROI"))
+        atlas_header_layout.addStretch()
+        roi_layout.addLayout(atlas_header_layout)
 
-        self.atlas_roi_chips = RegionChipsWidget(
-            placeholder="No atlas ROI targets — optional"
+        self.atlas_roi_picker = ROIPickerWidget(
+            enable_spherical=False,
+            enable_atlas=False,
+            enable_subcortical=True,
+            enable_freeview_button=False,
+            enable_mni_toggle=False,
         )
-        self.atlas_roi_chips.setToolTip(
-            "Selected atlas ROI target(s), unioned with the spherical ROI(s) "
-            "above. Press ✕ on a chip to remove it."
-        )
-        roi_layout.addWidget(self.atlas_roi_chips)
+        # Subcortical is the only enabled mode, so its radio is the sole member
+        # of the group and carries no information -- hide it rather than show a
+        # lone radio the user cannot change.
+        if self.atlas_roi_picker.radio_subcortical is not None:
+            self.atlas_roi_picker.radio_subcortical.setVisible(False)
+        # Force subject space for atlas targets. ExConfig.AtlasROI has no
+        # atlas_space field (unlike FlexConfig.SubcorticalROI), and the
+        # ex-search engine selects elements by testing barycenters against the
+        # mask directly, so an MNI atlas would be read as if it were already in
+        # subject space. Offering the choice would silently give wrong results,
+        # so the control is hidden until the backend can transform.
+        self.atlas_roi_picker.volume_subject_radio.setChecked(True)
+        self.atlas_roi_picker.volume_subject_radio.setVisible(False)
+        self.atlas_roi_picker.volume_mni_radio.setVisible(False)
+        roi_layout.addWidget(self.atlas_roi_picker)
 
         # Add ROI container to grid - Row 1, Column 0
         main_grid_layout.addWidget(roi_container, 1, 0)
@@ -1918,137 +1920,6 @@ class ExSearchTab(QtWidgets.QWidget):
         except OSError as e:
             self.update_status(f"Error updating ROI list: {str(e)}", error=True)
 
-    def _current_voxel_atlas_manager(self) -> VoxelAtlasManager | None:
-        """Build a VoxelAtlasManager for the currently selected subject.
-
-        Returns ``None`` when no subject is selected or its m2m directory
-        cannot be resolved, so callers can no-op gracefully.
-        """
-        subject_id = self.subject_combo.currentText()
-        if not subject_id:
-            return None
-        pm = self.pm
-        m2m_dir = pm.m2m(subject_id)
-        if not m2m_dir:
-            return None
-        seg_dir = os.path.join(m2m_dir, "segmentation")
-        return VoxelAtlasManager(
-            freesurfer_mri_dir=pm.freesurfer_mri(subject_id), seg_dir=seg_dir
-        )
-
-    def _refresh_atlas_roi_combo(self):
-        """Discover volumetric atlas/mask files for the selected subject.
-
-        Cheap discovery only (file listing) -- does not shell out to
-        FreeSurfer. Region listing (``list_regions``) only happens lazily,
-        when the user clicks "Add Region…".
-        """
-        self.atlas_roi_combo.clear()
-        mgr = self._current_voxel_atlas_manager()
-        if mgr is None:
-            return
-        try:
-            atlases = mgr.list_atlases()
-        except OSError:
-            return
-        # Also offer the bundled MNI atlases (mirrors flex-search's
-        # subcortical picker); these are read-only reference files, always
-        # subject-independent, and unaffected by the coordinate-space toggle.
-        try:
-            atlases = list(atlases) + [
-                (os.path.basename(p), p)
-                for p in VoxelAtlasManager.detect_mni_atlases(MNI_ATLAS_DIR)
-            ]
-        except OSError:
-            pass
-        for display_name, path in atlases:
-            self.atlas_roi_combo.addItem(display_name, path)
-
-    def _on_add_atlas_whole_file(self):
-        """Add the currently selected atlas/mask file as a whole-file (label=None) target."""
-        atlas_path = self.atlas_roi_combo.currentData()
-        if not atlas_path:
-            QtWidgets.QMessageBox.warning(
-                self,
-                "No Atlas Selected",
-                "Select an atlas or mask file first (use Refresh to discover files).",
-            )
-            return
-        atlas_path = str(atlas_path)
-        display = self.atlas_roi_combo.currentText()
-        key = self.atlas_roi_chip_key(atlas_path, None)
-        self.atlas_roi_chips.add_item(key=key, display=f"{display}: whole file")
-
-    def _on_add_atlas_region(self):
-        """Browse regions in the selected atlas and add chosen ones as targets.
-
-        ``list_regions`` shells out to FreeSurfer's ``mri_segstats`` (and
-        caches a label file next to the atlas), so it is only invoked here,
-        on explicit user action -- never at tab load or on subject change.
-        Failures (e.g. FreeSurfer unavailable) are reported and swallowed
-        rather than raised.
-        """
-        atlas_path = self.atlas_roi_combo.currentData()
-        if not atlas_path:
-            QtWidgets.QMessageBox.warning(
-                self,
-                "No Atlas Selected",
-                "Select an atlas or mask file first (use Refresh to discover files).",
-            )
-            return
-        atlas_path = str(atlas_path)
-        display = self.atlas_roi_combo.currentText()
-
-        try:
-            mgr = VoxelAtlasManager()
-            region_strings = mgr.list_regions(atlas_path)
-        except Exception as e:
-            QtWidgets.QMessageBox.warning(
-                self,
-                "Could Not List Regions",
-                f"Could not list regions for '{display}'. This atlas may not "
-                f"be a labeled segmentation, or FreeSurfer (mri_segstats) may "
-                f"not be available.\n\nDetails: {e}",
-            )
-            return
-
-        entries = []
-        for region_str in region_strings:
-            try:
-                label = parse_region_label(region_str)
-            except ValueError:
-                continue
-            name = region_str.rsplit(" (ID:", 1)[0].strip()
-            entries.append((label, name, None))
-
-        if not entries:
-            QtWidgets.QMessageBox.warning(
-                self, "No Regions Found", f"No labeled regions found in '{display}'."
-            )
-            return
-
-        preselected = [
-            str(label)
-            for key in self.atlas_roi_chips.keys()
-            for path, label in [self.atlas_roi_from_chip_key(key)]
-            if path == atlas_path and label is not None
-        ]
-
-        dlg = AtlasRegionFinderDialog(
-            self,
-            f"Atlas Regions - {display}",
-            entries,
-            return_field="id",
-            multi=True,
-            preselected=preselected,
-        )
-        if dlg.exec_() == QtWidgets.QDialog.Accepted:
-            for label, name in zip(dlg.selected_ids(), dlg.selected_names()):
-                key = self.atlas_roi_chip_key(atlas_path, label)
-                self.atlas_roi_chips.add_item(
-                    key=key, display=f"{display}: {name} (ID: {label})"
-                )
-
     def show_add_roi_dialog(self):
         """Show dialog for adding a new ROI."""
         dialog = AddROIDialog(self)
@@ -2446,7 +2317,7 @@ class ExSearchTab(QtWidgets.QWidget):
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
             roi_names=roi_names,
-            roi_atlas=self.build_roi_atlas_entries(self.atlas_roi_chips.keys()) or None,
+            roi_atlas=self._current_roi_atlas_entries(),
             roi_coordinate_space=self.coordinate_space_value(
                 self.coord_space_mni.isChecked()
             ),
@@ -2509,7 +2380,7 @@ class ExSearchTab(QtWidgets.QWidget):
             subject_id=subject_id,
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
-            roi_atlas=self.build_roi_atlas_entries(self.atlas_roi_chips.keys()) or None,
+            roi_atlas=self._current_roi_atlas_entries(),
             roi_coordinate_space=self.coordinate_space_value(
                 self.coord_space_mni.isChecked()
             ),
@@ -3156,7 +3027,9 @@ class ExSearchTab(QtWidgets.QWidget):
         """Handle subject selection changes."""
         self.refresh_leadfields()
         self.update_roi_list()
-        self._refresh_atlas_roi_combo()
+        subject_id = self.subject_combo.currentText()
+        if subject_id and self.pm.project_dir:
+            self.atlas_roi_picker.set_subject(subject_id, self.pm.project_dir)
 
 
 class AddROIDialog(QtWidgets.QDialog):


### PR DESCRIPTION
Four GUI complaints that all traced back to hand-rolled ROI pickers.

## ex-search

Now uses `ROIPickerWidget` for its optional volumetric-atlas target, replacing the bespoke combo / `Add Region…` / `Add Whole File` / chips block from last session.

**"Add Whole File" is gone**, and so is the freeze. The old handler called `VoxelAtlasManager.list_regions()`, which shells out to FreeSurfer's `mri_segstats` **synchronously on the UI thread**. The shared picker never calls it — it resolves region names from a sidecar LUT, falling back to nibabel and numpy. Verified by grep: the only `subprocess` use in the picker is launching freeview, and the only `mri_segstats` mentions are comments saying it is *not* invoked. So this is a structural fix, not a timing improvement.

The tab's own ROI-CSV list is untouched — the picker contributes one additional mask, unioned in exactly as the bespoke code did.

### Two things the swap exposed

The mode radio is hidden: subcortical is the only enabled mode, so a lone radio carried no information.

More importantly, the atlas Subject/MNI radios are hidden with subject forced. `ExConfig.AtlasROI` has **no `atlas_space` field** (unlike `FlexConfig.SubcorticalROI`), and the ex engine tests barycenters against the mask directly — so an MNI atlas would have been read as though already in subject space. Offering that choice would have quietly produced wrong results. The capability needs backend work; until then the control should not exist.

## analyzer

The two target groups move into a `QStackedWidget` instead of being shown and hidden. They have different natural widths, so toggling Spherical against Cortical reflowed the entire right column. A stack reserves its largest page and the width stops moving.

Spherical analysis accepts several spheres, as a table of rows in the manner of the flex-search picker. `Analyzer.analyze_sphere` takes a single centre, so each row runs as its own analysis with results reported per sphere — which is what an analyzer is for, its output already being per-ROI rows. One row behaves exactly as the single input did, down to error messages: the row number is only prefixed when there is more than one row.

## Testability

The sphere parsers live in `tit/analyzer/spheres.py`, not on the tab. They are pure, and their docstring said so — but sitting on a class in a PyQt5-importing module made them untestable wherever PyQt5 is absent, which is the test environment, so the test skipped and verified nothing. **Fourth occurrence of that pattern in this branch series.** They now have eleven tests that run.

## Verification

Suite **2356 passed / 12 skipped / 0 failed** (baseline 2342). Both tabs compile; `black` clean.

**Rendering unverified** — PyQt5 is absent on the host. The `roi_container` fixed height was raised 90px by line-count arithmetic since the picker page is taller than the row it replaced; whether the stacked widget truly stops the column resizing, and the sphere table's Add/Remove behaviour, all want a look in Docker.

## Known limitations

- Group mode still accepts one sphere and says so, rather than silently using the first row. Extending group-script generation to loop was left out of scope.
- The analyzer's sphere table recycles the flex picker's *design* but not its code. Genuine sharing would mean extracting a component and rewiring flex-search, risking a working tab for a cosmetic win — happy to do it as a follow-up if you want real reuse.