### PR TITLE
gui/opt: fix ex-search layout slack, allow atlas targeting in mTI

### DIFF
--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -341,22 +341,53 @@ class TestGuiImports:
         py_compile.compile(str(GUI_ROOT / "analyzer_tab.py"), doraise=True)
 
     @pytest.mark.unit
-    def test_ex_search_atlas_roi_mode_is_ti_only(self):
-        """Atlas-only ROI targeting must be disabled in mTI mode.
+    def test_ex_search_atlas_roi_mode_available_in_both_search_modes(self):
+        """Atlas targeting must not be gated on the TI/mTI choice.
 
-        tit/opt/ex/ex.py honours ``roi_names=[]`` and reads no sphere file, so
-        a TI run can target an atlas alone. tit/opt/mex/mex.py builds
-        ``roi_file`` from ``config.roi_name`` unconditionally, so a multipolar
-        run always needs a spherical ROI. Leaving the Atlas choice selectable
-        under mTI would accept the selection and then fail validation asking
-        for a sphere, so the mode handler disables it and falls back to Sphere.
+        It used to be: tit/opt/mex/mex.py built the sphere path from
+        ``roi_name`` unconditionally, so a multipolar run always needed a
+        spherical ROI and the Atlas radio was disabled under mTI. MExConfig now
+        carries ``roi_names`` like ExConfig and mex.py honours the empty list,
+        so both mechanisms work in both modes.
         """
         source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
         body = source.split("def _on_search_mode_changed(self):", 1)[1]
         body = body.split("\n    def ", 1)[0]
-        assert "self.roi_mode_atlas_radio.setEnabled(not is_mti)" in body
-        # and it must not leave the stack showing a page the user cannot reach
-        assert "self.roi_mode_sphere_radio.setChecked(True)" in body
+        assert "roi_mode_atlas_radio.setEnabled" not in body
+        # and the handler must not force the user back to Sphere
+        assert "self.roi_mode_sphere_radio.setChecked(True)" not in body
+        # ROI validation branches on ROI Type alone, not on the search mode
+        validate = source.split("def validate_inputs(self):", 1)[1]
+        validate = validate.split("\n    def ", 1)[0]
+        assert "if self._current_roi_mode() == ROI_MODE_SPHERE:" in validate
+        assert (
+            "SEARCH_MODE_MTI\n            or self._current_roi_mode()" not in validate
+        )
+
+    def test_ex_search_mex_config_passes_roi_names(self):
+        """The mTI config builder must send roi_names, or atlas mode is inert.
+
+        ``roi_names=[]`` is the only thing telling mex.py to skip the sphere
+        CSV; omitting the field leaves it None and the backend falls back to
+        reading ``roi_name`` as a file that does not exist.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        body = source.split("def _build_mex_config(self", 1)[1]
+        body = body.split("\n    @", 1)[0]
+        assert "roi_names=self.roi_names_for_mode(mode, None)" in body
+
+    def test_ex_search_roi_mode_stack_keeps_a_stable_height(self):
+        """Switching ROI Type must not move anything below the ROI box.
+
+        The stack's default "tallest page" sizing is what holds the column
+        still; sizing it to the current page instead made everything below jump
+        on every Sphere/Atlas toggle. The region chips get a reserved height
+        for the same reason -- a flow layout grows as chips are added.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        assert "self._size_stack_to_current(self.roi_mode_stack)" not in source
+        assert "_resize_roi_mode_stack" not in source
+        assert "subcortical_chips.setMinimumHeight(" in source
 
     def test_ex_search_stacks_size_to_current_page(self):
         """Every QStackedWidget in the tab must track its current page.
@@ -372,11 +403,9 @@ class TestGuiImports:
         assert "def _size_stack_to_current(self, stack):" in source
         assert "policy.setHorizontalPolicy(" in source
         # and all three stacks are wired to it
-        for stack in (
-            "self.roi_mode_stack",
-            "self.electrode_stack",
-            "self.current_config_stack",
-        ):
+        # the ROI stack is deliberately excluded -- see
+        # test_ex_search_roi_mode_stack_keeps_a_stable_height
+        for stack in ("self.electrode_stack", "self.current_config_stack"):
             assert f"self._size_stack_to_current({stack})" in source, stack
 
     def test_ex_search_uses_independent_columns_not_a_grid(self):

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -358,20 +358,55 @@ class TestGuiImports:
         # and it must not leave the stack showing a page the user cannot reach
         assert "self.roi_mode_sphere_radio.setChecked(True)" in body
 
-    def test_ex_search_grid_rows_pinned_and_no_internal_vstretch(self):
-        """Leftover height must go to the trailing stretch, not between boxes.
+    def test_ex_search_stacks_size_to_current_page(self):
+        """Every QStackedWidget in the tab must track its current page.
 
-        Two things reserved vertical space after the container fixed heights
-        were dropped. A QGridLayout hands spare height to any row that can
-        grow, so SizePolicy.Maximum stopped the boxes stretching but not the
-        rows -- hence the explicit setRowStretch(row, 0). And the trailing
-        "push content to top" addStretch() calls inside the vertical container
-        layouts were correct while the boxes had fixed heights, but once the
-        boxes hug their content they simply re-reserve the space the fixed
-        heights used to. Only scroll_layout keeps a stretch.
+        A stack reserves the maximum over all pages on both axes. Vertically
+        that is dead space; horizontally it was a real defect -- the mTI
+        electrode panel is a four-column grid of eight inputs, about twice the
+        width of the two-pair panel, so the TI view was forced that wide and
+        its inputs ran off the right edge behind a horizontal scrollbar.
         """
         source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
-        assert "main_grid_layout.setRowStretch(_row, 0)" in source
+        # the helper collapses both axes, not just height
+        assert "def _size_stack_to_current(self, stack):" in source
+        assert "policy.setHorizontalPolicy(" in source
+        # and all three stacks are wired to it
+        for stack in (
+            "self.roi_mode_stack",
+            "self.electrode_stack",
+            "self.current_config_stack",
+        ):
+            assert f"self._size_stack_to_current({stack})" in source, stack
+
+    def test_ex_search_grid_rows_pinned_and_no_internal_vstretch(self):
+        """Leftover height must go to a spacer, not between or around the boxes.
+
+        Three things reserved vertical space once the container fixed heights
+        were dropped. A QGridLayout spreads spare height across its rows, and
+        when no row carries a stretch factor it spreads it *equally* -- so
+        setting every row to zero achieved nothing; the stretch belongs on a
+        trailing spacer row. A box that will not grow (SizePolicy.Maximum) then
+        floats in the middle of an oversized cell unless it is top-aligned,
+        which is what left the gap above Subject Selection. And the trailing
+        "push content to top" addStretch() calls inside the vertical container
+        layouts were right while the boxes had fixed heights, but once the boxes
+        hug their content they simply re-reserve the space the fixed heights
+        used to. Only scroll_layout keeps a stretch.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        # the stretch goes on a trailing spacer row, not on the content rows
+        assert "main_grid_layout.setRowStretch(3, 1)" in source
+        assert "setRowStretch(_row, 0)" not in source
+        # and every box is top-aligned in its cell
+        for widget in (
+            "subject_container, 0, 0",
+            "electrode_container, 0, 1",
+            "roi_container, 1, 0",
+            "self.current_container, 1, 1",
+            "leadfield_container, 2, 0, 1, 2",
+        ):
+            assert f"addWidget({widget}, QtCore.Qt.AlignTop)" in source, widget
 
         orientation = {}
         for line in source.splitlines():

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -389,6 +389,26 @@ class TestGuiImports:
         assert "_resize_roi_mode_stack" not in source
         assert "subcortical_chips.setMinimumHeight(" in source
 
+    def test_mti_electrode_grid_gives_spare_width_to_the_inputs(self):
+        """Label columns must not absorb spare width.
+
+        A QGridLayout with no column stretch spreads leftover width equally
+        over every column, so the label columns grew along with the input
+        columns -- that is the gap between each "E1+:" and its box, and it made
+        the panel demand more width than it needed. Stretch belongs on the
+        input columns only.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        body = source.split("def _build_mti_bucketed_panel(self):", 1)[1]
+        body = body.split("\n    def ", 1)[0]
+        for col, stretch in ((0, 0), (1, 1), (2, 0), (3, 1)):
+            assert f"layout.setColumnStretch({col}, {stretch})" in body
+        # labels hug their text and sit against the box
+        assert "QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Preferred" in body
+        assert "QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter" in body
+        # and the inputs carry the width requirement, not the panel
+        assert "setMinimumWidth(MTI_BUCKET_INPUT_MIN_WIDTH)" in body
+
     def test_ex_search_stacks_size_to_current_page(self):
         """Every QStackedWidget in the tab must track its current page.
 

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -379,47 +379,37 @@ class TestGuiImports:
         ):
             assert f"self._size_stack_to_current({stack})" in source, stack
 
-    def test_ex_search_grid_rows_pinned_and_no_internal_vstretch(self):
-        """Leftover height must go to a spacer, not between or around the boxes.
+    def test_ex_search_uses_independent_columns_not_a_grid(self):
+        """Paired boxes must not share a row height.
 
-        Three things reserved vertical space once the container fixed heights
-        were dropped. A QGridLayout spreads spare height across its rows, and
-        when no row carries a stretch factor it spreads it *equally* -- so
-        setting every row to zero achieved nothing; the stretch belongs on a
-        trailing spacer row. A box that will not grow (SizePolicy.Maximum) then
-        floats in the middle of an oversized cell unless it is top-aligned,
-        which is what left the gap above Subject Selection. And the trailing
-        "push content to top" addStretch() calls inside the vertical container
-        layouts were right while the boxes had fixed heights, but once the boxes
-        hug their content they simply re-reserve the space the fixed heights
-        used to. Only scroll_layout keeps a stretch.
+        A QGridLayout makes every cell in a row as tall as the tallest box in
+        it, so a short box beside a tall one is stuck in an oversized cell no
+        matter how it is aligned or how little it wants to grow. Subject
+        Selection sat beside the taller Electrode Selection, and ROI Selection
+        beside the shorter Current Configuration -- the two dead gaps. Aligning
+        the boxes to the top of their cells moved them but could not shrink the
+        rows, so the grid is gone in favour of two independent QVBoxLayouts.
+
+        Only the trailing scroll_layout stretch may absorb slack; a stretch at
+        the end of either column would reserve the space again.
         """
         source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
-        # the stretch goes on a trailing spacer row, not on the content rows
-        assert "main_grid_layout.setRowStretch(3, 1)" in source
-        assert "setRowStretch(_row, 0)" not in source
-        # and every box is top-aligned in its cell
-        for widget in (
-            "subject_container, 0, 0",
-            "electrode_container, 0, 1",
-            "roi_container, 1, 0",
-            "self.current_container, 1, 1",
-            "leadfield_container, 2, 0, 1, 2",
+        # inner panels (e.g. the mTI electrode grid) may still use a grid --
+        # it is the top-level box placement that must not
+        assert "main_grid_layout" not in source
+        assert "left_column = QtWidgets.QVBoxLayout()" in source
+        assert "right_column = QtWidgets.QVBoxLayout()" in source
+        for widget, column in (
+            ("subject_container", "left_column"),
+            ("roi_container", "left_column"),
+            ("electrode_container", "right_column"),
+            ("self.current_container", "right_column"),
         ):
-            assert f"addWidget({widget}, QtCore.Qt.AlignTop)" in source, widget
-
-        orientation = {}
-        for line in source.splitlines():
-            m = re.search(r"(\w+)\s*=\s*QtWidgets\.(QVBoxLayout|QHBoxLayout)", line)
-            if m:
-                orientation[m.group(1)] = m.group(2)
-        vertical_stretches = [
-            m.group(1)
-            for line in source.splitlines()
-            if (m := re.match(r"\s*(\w+)\.addStretch\(", line))
-            and orientation.get(m.group(1)) == "QVBoxLayout"
-        ]
-        assert vertical_stretches == ["scroll_layout"], vertical_stretches
+            assert f"{column}.addWidget({widget})" in source, widget
+        # full-width box lives below the columns, not inside one
+        assert "scroll_layout.addWidget(leadfield_container)" in source
+        assert "left_column.addStretch" not in source
+        assert "right_column.addStretch" not in source
 
     def test_ex_search_containers_hug_content_not_fixed_height(self):
         """ROI/Subject/Electrode/Current/Leadfield containers no longer reserve dead space.

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -403,9 +403,11 @@ class TestGuiImports:
         body = body.split("\n    def ", 1)[0]
         for col, stretch in ((0, 0), (1, 1), (2, 0), (3, 1)):
             assert f"layout.setColumnStretch({col}, {stretch})" in body
-        # labels hug their text and sit against the box
-        assert "QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Preferred" in body
-        assert "QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter" in body
+        # Uniform label width, left-aligned: lines up the "E" glyphs AND the
+        # inputs. Right-aligning lines up the colons instead, which leaves the
+        # E's ragged because "E1+:" is wider than "E1-:".
+        assert "label.setFixedWidth(MTI_BUCKET_LABEL_WIDTH)" in body
+        assert "QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter" in body
         # and the inputs carry the width requirement, not the panel
         assert "setMinimumWidth(MTI_BUCKET_INPUT_MIN_WIDTH)" in body
 

--- a/tests/test_gui_imports.py
+++ b/tests/test_gui_imports.py
@@ -8,6 +8,7 @@ be imported without crashing.
 
 import json
 import os
+import re
 import sys
 import types
 from pathlib import Path
@@ -356,6 +357,34 @@ class TestGuiImports:
         assert "self.roi_mode_atlas_radio.setEnabled(not is_mti)" in body
         # and it must not leave the stack showing a page the user cannot reach
         assert "self.roi_mode_sphere_radio.setChecked(True)" in body
+
+    def test_ex_search_grid_rows_pinned_and_no_internal_vstretch(self):
+        """Leftover height must go to the trailing stretch, not between boxes.
+
+        Two things reserved vertical space after the container fixed heights
+        were dropped. A QGridLayout hands spare height to any row that can
+        grow, so SizePolicy.Maximum stopped the boxes stretching but not the
+        rows -- hence the explicit setRowStretch(row, 0). And the trailing
+        "push content to top" addStretch() calls inside the vertical container
+        layouts were correct while the boxes had fixed heights, but once the
+        boxes hug their content they simply re-reserve the space the fixed
+        heights used to. Only scroll_layout keeps a stretch.
+        """
+        source = (GUI_ROOT / "ex_search_tab.py").read_text(encoding="utf-8")
+        assert "main_grid_layout.setRowStretch(_row, 0)" in source
+
+        orientation = {}
+        for line in source.splitlines():
+            m = re.search(r"(\w+)\s*=\s*QtWidgets\.(QVBoxLayout|QHBoxLayout)", line)
+            if m:
+                orientation[m.group(1)] = m.group(2)
+        vertical_stretches = [
+            m.group(1)
+            for line in source.splitlines()
+            if (m := re.match(r"\s*(\w+)\.addStretch\(", line))
+            and orientation.get(m.group(1)) == "QVBoxLayout"
+        ]
+        assert vertical_stretches == ["scroll_layout"], vertical_stretches
 
     def test_ex_search_containers_hug_content_not_fixed_height(self):
         """ROI/Subject/Electrode/Current/Leadfield containers no longer reserve dead space.

--- a/tests/test_opt_config.py
+++ b/tests/test_opt_config.py
@@ -673,6 +673,42 @@ class TestAtlasRoiConfigIORoundtrip:
 
             os.unlink(path)
 
+    def test_mex_config_atlas_only_roundtrip_preserves_empty_roi_names(self, tmp_path):
+        """An empty roi_names must survive the JSON hop as [] and not None.
+
+        The GUI runs mTI by writing this config to JSON and invoking
+        tit.opt.mex, and ``roi_names=[]`` is the only thing telling the backend
+        to skip the sphere CSV. If the round-trip turned it into None (or
+        dropped it), an atlas-only mTI run would try to read the naming label
+        as a file path.
+        """
+        from tit.config_io import read_config_json, write_config_json
+
+        config = MExConfig(
+            subject_id="001",
+            leadfield_hdf="/lf.hdf5",
+            roi_name="Left-Hippocampus",
+            roi_names=[],
+            electrodes=MExConfig.PoolElectrodes(electrodes=_pool_electrodes(8)),
+            roi_atlas=[MExConfig.AtlasROI(atlas_path="/atlas/aseg.mgz", label=17)],
+        )
+        path = write_config_json(config, prefix="mex_atlas_only_test")
+        try:
+            data = read_config_json(path)
+            assert data["roi_names"] == []
+            data.pop("project_dir")
+            rebuilt = MExConfig(
+                electrodes=MExConfig.PoolElectrodes(electrodes=_pool_electrodes(8)),
+                **{k: v for k, v in data.items() if k != "electrodes"},
+            )
+            assert rebuilt.roi_names == []
+            # the label is still suffixed, it is just never opened
+            assert rebuilt.roi_name == "Left-Hippocampus.csv"
+        finally:
+            import os
+
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # ROI type defaults

--- a/tests/test_opt_mex.py
+++ b/tests/test_opt_mex.py
@@ -639,10 +639,85 @@ class TestRunMExSearchAtlasAndMni:
     @patch("tit.opt.mex.mex.MExSearchEngine")
     @patch("tit.opt.mex.mex.add_file_handler")
     @patch("tit.opt.mex.mex.get_path_manager")
+    def test_atlas_only_target_reads_no_sphere_csv(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        """roi_names=[] must drop the sphere CSV, leaving an atlas-only target.
+
+        This is what lets the GUI offer Atlas ROI in mTI mode. Previously mex.py
+        built the sphere path from roi_name unconditionally, so a multipolar run
+        always needed a spherical ROI; roi_name is now only a naming label when
+        roi_names is empty, and no CSV is opened.
+        """
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {"m1": {}}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.mex.mex import run_m_ex_search
+
+        config = _mex_pool_config(
+            roi_name="Left-Hippocampus",
+            roi_names=[],
+            roi_atlas=[{"atlas_path": "/atlas/aseg.mgz", "label": 17}],
+        )
+        run_m_ex_search(config)
+
+        roi_arg = mock_engine_cls.call_args[0][1]
+        assert roi_arg == [("/atlas/aseg.mgz", 17)]
+        # the label still names the run, it just is not a file to read
+        assert mock_engine_cls.call_args[0][2] == "Left-Hippocampus.csv"
+
+    @patch("tit.opt.mex.mex.process_and_save")
+    @patch("tit.opt.mex.mex.MExSearchEngine")
+    @patch("tit.opt.mex.mex.add_file_handler")
+    @patch("tit.opt.mex.mex.get_path_manager")
+    def test_atlas_only_target_skips_the_mni_transform(
+        self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
+    ):
+        """With no sphere centers there is nothing to transform.
+
+        Guards the ``if roi_names and ...`` condition: dropping the roi_names
+        half would send an empty list through simnibs.mni2subject_coords.
+        """
+        pm = self._pm(tmp_path)
+        mock_gpm.return_value = pm
+
+        engine = MagicMock()
+        mock_engine_cls.return_value = engine
+        engine.run.return_value = {"m1": {}}
+        mock_save.return_value = {"config_json_path": "/j", "csv_path": "/c"}
+
+        from tit.opt.mex.mex import run_m_ex_search
+
+        config = _mex_pool_config(
+            roi_names=[],
+            roi_coordinate_space="mni",
+            roi_atlas=[{"atlas_path": "/atlas/aseg.mgz", "label": 17}],
+        )
+        with patch("simnibs.mni2subject_coords") as mock_transform:
+            run_m_ex_search(config)
+
+        mock_transform.assert_not_called()
+        assert mock_engine_cls.call_args[0][1] == [("/atlas/aseg.mgz", 17)]
+
+    @patch("tit.opt.mex.mex.process_and_save")
+    @patch("tit.opt.mex.mex.MExSearchEngine")
+    @patch("tit.opt.mex.mex.add_file_handler")
+    @patch("tit.opt.mex.mex.get_path_manager")
     def test_no_roi_atlas_passes_bare_roi_file_string(
         self, mock_gpm, mock_afh, mock_engine_cls, mock_save, tmp_path
     ):
-        """Regression guard: default config keeps the pre-existing bare-string call."""
+        """A default (spherical) config passes exactly one ROI target.
+
+        mex.py used to hand the engine a bare string here and a list only when
+        atlas entries existed. It now always passes a list, mirroring
+        tit/opt/ex/ex.py -- ``ExSearchEngine`` (which ``MExSearchEngine``
+        extends) accepts either, and one shape means one code path.
+        """
         pm = self._pm(tmp_path)
         mock_gpm.return_value = pm
 
@@ -656,7 +731,7 @@ class TestRunMExSearchAtlasAndMni:
         run_m_ex_search(_mex_pool_config())
 
         roi_arg = mock_engine_cls.call_args[0][1]
-        assert roi_arg == os.path.join(str(tmp_path / "rois"), "motor.csv")
+        assert roi_arg == [os.path.join(str(tmp_path / "rois"), "motor.csv")]
 
     @patch("tit.opt.mex.mex.process_and_save")
     @patch("tit.opt.mex.mex.MExSearchEngine")
@@ -691,7 +766,7 @@ class TestRunMExSearchAtlasAndMni:
         mock_transform.assert_called_once()
         assert mock_transform.call_args[0][1] == str(tmp_path / "m2m_001")
 
-        roi_arg = mock_engine_cls.call_args[0][1]
+        [roi_arg] = mock_engine_cls.call_args[0][1]
         assert roi_arg != str(rois_dir / "motor.csv")
         with open(roi_arg) as f:
             row = next(csv.reader(f))

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -151,6 +151,10 @@ ROI_MODE_HELP = (
 #: regions are added or removed -- roughly two rows of chips.
 ATLAS_CHIPS_RESERVED_HEIGHT = 56
 
+#: Minimum width of an mTI electrode bucket input -- room for two electrode
+#: names ("Fp1, T7"). The grid's column stretch grows them beyond this.
+MTI_BUCKET_INPUT_MIN_WIDTH = 130
+
 
 def _get_and_display_electrodes(subject_id, cap_name, parent_widget, path_manager=None):
     """
@@ -1494,8 +1498,18 @@ class ExSearchTab(QtWidgets.QWidget):
         panel = QtWidgets.QWidget()
         layout = QtWidgets.QGridLayout(panel)
         layout.setContentsMargins(5, 5, 5, 5)
-        layout.setHorizontalSpacing(16)
+        # Spare width must go to the inputs, not to the label columns. With no
+        # column stretch a QGridLayout spreads it equally over all four, which
+        # widened the label columns and left a gap between each "E1+:" and its
+        # box -- and made the panel wider than it needed to be, which is what
+        # forced the horizontal scrollbar. Stretch on the input columns only,
+        # labels hugging their text and sitting against the box.
+        layout.setHorizontalSpacing(6)
         layout.setVerticalSpacing(8)
+        layout.setColumnStretch(0, 0)
+        layout.setColumnStretch(1, 1)
+        layout.setColumnStretch(2, 0)
+        layout.setColumnStretch(3, 1)
 
         self.mti_e1_plus_input = QtWidgets.QLineEdit()
         self.mti_e1_minus_input = QtWidgets.QLineEdit()
@@ -1531,6 +1545,9 @@ class ExSearchTab(QtWidgets.QWidget):
         }
         for key, field_widget in self.mti_bucket_inputs.items():
             field_widget.setFixedHeight(30)
+            # Wide enough for a couple of electrode names; the column stretch
+            # grows them from here rather than the panel demanding the width.
+            field_widget.setMinimumWidth(MTI_BUCKET_INPUT_MIN_WIDTH)
             field_widget.setPlaceholderText(placeholders[key])
             field_widget.setToolTip(
                 f"Electrodes for pair {key[1]} "
@@ -1539,11 +1556,15 @@ class ExSearchTab(QtWidgets.QWidget):
 
         left_keys = ["e1_plus", "e1_minus", "e2_plus", "e2_minus"]
         right_keys = ["e3_plus", "e3_minus", "e4_plus", "e4_minus"]
+        label_align = QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter
         for row, (lkey, rkey) in enumerate(zip(left_keys, right_keys)):
-            layout.addWidget(QtWidgets.QLabel(f"{MEX_BUCKET_LABELS[lkey]}:"), row, 0)
-            layout.addWidget(self.mti_bucket_inputs[lkey], row, 1)
-            layout.addWidget(QtWidgets.QLabel(f"{MEX_BUCKET_LABELS[rkey]}:"), row, 2)
-            layout.addWidget(self.mti_bucket_inputs[rkey], row, 3)
+            for col, key in ((0, lkey), (2, rkey)):
+                label = QtWidgets.QLabel(f"{MEX_BUCKET_LABELS[key]}:")
+                label.setSizePolicy(
+                    QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Preferred
+                )
+                layout.addWidget(label, row, col, label_align)
+                layout.addWidget(self.mti_bucket_inputs[key], row, col + 1)
 
         self.electrode_stack.addWidget(panel)
 

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -155,6 +155,11 @@ ATLAS_CHIPS_RESERVED_HEIGHT = 56
 #: names ("Fp1, T7"). The grid's column stretch grows them beyond this.
 MTI_BUCKET_INPUT_MIN_WIDTH = 130
 
+#: Width of an mTI electrode bucket label. Uniform across all eight so the
+#: left-aligned "E" glyphs line up and every input starts at the same x --
+#: wide enough for the longest ("E1+:").
+MTI_BUCKET_LABEL_WIDTH = 40
+
 
 def _get_and_display_electrodes(subject_id, cap_name, parent_widget, path_manager=None):
     """
@@ -1556,13 +1561,15 @@ class ExSearchTab(QtWidgets.QWidget):
 
         left_keys = ["e1_plus", "e1_minus", "e2_plus", "e2_minus"]
         right_keys = ["e3_plus", "e3_minus", "e4_plus", "e4_minus"]
-        label_align = QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter
+        # Left-aligned in a uniform-width column, so the "E" glyphs line up in a
+        # column and the inputs still start at the same x. Right-aligning
+        # instead lines up the colons, which leaves the E's ragged because
+        # "E1+:" is wider than "E1-:".
+        label_align = QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter
         for row, (lkey, rkey) in enumerate(zip(left_keys, right_keys)):
             for col, key in ((0, lkey), (2, rkey)):
                 label = QtWidgets.QLabel(f"{MEX_BUCKET_LABELS[key]}:")
-                label.setSizePolicy(
-                    QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Preferred
-                )
+                label.setFixedWidth(MTI_BUCKET_LABEL_WIDTH)
                 layout.addWidget(label, row, col, label_align)
                 layout.addWidget(self.mti_bucket_inputs[key], row, col + 1)
 

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -993,20 +993,27 @@ class ExSearchTab(QtWidgets.QWidget):
         scroll_layout.setContentsMargins(10, 10, 10, 10)
         scroll_layout.setSpacing(10)
 
-        # Main grid layout for organized component placement
-        main_grid_layout = QtWidgets.QGridLayout()
-        main_grid_layout.setSpacing(15)  # Add spacing between components
-        # A QGridLayout hands leftover height to any row that can grow, so the
-        # SizePolicy.Maximum on each group box stops the boxes stretching but
-        # not the rows holding them. Pin every content row to its natural
-        # height and let the trailing scroll_layout stretch take the slack.
-        # A QGridLayout spreads spare height across its rows -- and when no row
-        # has a stretch factor it spreads it *equally*, so pinning them all to
-        # zero achieves nothing. Give a trailing spacer row the stretch instead,
-        # and top-align each box in its cell; without the alignment a box that
-        # will not grow (SizePolicy.Maximum) just floats in the middle of an
-        # oversized cell, which is what left the gaps above Subject Selection.
-        main_grid_layout.setRowStretch(3, 1)
+        # Two independent columns, NOT a QGridLayout.
+        #
+        # A grid forces the cells in a row to share that row's height, so a
+        # short box paired with a tall one is stuck in an oversized cell no
+        # matter how it is aligned or how little it wants to grow. Subject
+        # Selection sat beside the much taller Electrode Selection and ROI
+        # Selection beside the much shorter Current Configuration, which is
+        # exactly where the two dead gaps appeared. Top-aligning the boxes
+        # moved them within their cells but could not shrink the rows.
+        #
+        # Independent QVBoxLayouts have no shared row heights, so each column
+        # packs its boxes against the one above it and any leftover height
+        # falls to the trailing scroll_layout stretch. Leadfield Management
+        # spans the full width, so it goes below the columns rather than in
+        # them.
+        columns_layout = QtWidgets.QHBoxLayout()
+        columns_layout.setSpacing(15)
+        left_column = QtWidgets.QVBoxLayout()
+        left_column.setSpacing(15)
+        right_column = QtWidgets.QVBoxLayout()
+        right_column.setSpacing(15)
 
         # ============================================================
         # ROW 0, COLUMN 0: Subject Selection
@@ -1037,8 +1044,7 @@ class ExSearchTab(QtWidgets.QWidget):
         subject_button_layout.addWidget(self.clear_subject_selection_btn)
         subject_layout.addLayout(subject_button_layout)
 
-        # Add subject container to grid - Row 0, Column 0
-        main_grid_layout.addWidget(subject_container, 0, 0, QtCore.Qt.AlignTop)
+        left_column.addWidget(subject_container)
 
         # ============================================================
         # ROW 0, COLUMN 1: Electrode Selection
@@ -1110,7 +1116,7 @@ class ExSearchTab(QtWidgets.QWidget):
         )
 
         # Add electrode container to grid - Row 0, Column 1
-        main_grid_layout.addWidget(electrode_container, 0, 1, QtCore.Qt.AlignTop)
+        right_column.addWidget(electrode_container)
 
         # ============================================================
         # ROW 1, COLUMN 0: ROI Selection
@@ -1272,7 +1278,7 @@ class ExSearchTab(QtWidgets.QWidget):
         self._on_roi_mode_changed()  # Initialize to correct (sphere) page
 
         # Add ROI container to grid - Row 1, Column 0
-        main_grid_layout.addWidget(roi_container, 1, 0, QtCore.Qt.AlignTop)
+        left_column.addWidget(roi_container)
 
         # ============================================================
         # ROW 1, COLUMN 1: Current Configuration
@@ -1293,7 +1299,7 @@ class ExSearchTab(QtWidgets.QWidget):
         self._build_mti_current_panel()
 
         # Add current container to grid - Row 1, Column 1
-        main_grid_layout.addWidget(self.current_container, 1, 1, QtCore.Qt.AlignTop)
+        right_column.addWidget(self.current_container)
 
         # ============================================================
         # ROW 2, COLUMN 0-1: Leadfield Management (spanning both columns)
@@ -1355,10 +1361,14 @@ class ExSearchTab(QtWidgets.QWidget):
         )
 
         # Add leadfield container to grid - Row 2, Column 0-1 (spanning both columns)
-        main_grid_layout.addWidget(leadfield_container, 2, 0, 1, 2, QtCore.Qt.AlignTop)
+        # Both columns end where their content ends; the shorter one simply
+        # stops. Adding a stretch here would re-introduce the reserved space.
+        columns_layout.addLayout(left_column)
+        columns_layout.addLayout(right_column)
 
         # Add grid layout to scroll layout
-        scroll_layout.addLayout(main_grid_layout)
+        scroll_layout.addLayout(columns_layout)
+        scroll_layout.addWidget(leadfield_container)
 
         # Trailing stretch absorbs the vertical slack freed by dropping the
         # container setFixedHeight calls above (groups now hug their content

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -1000,8 +1000,13 @@ class ExSearchTab(QtWidgets.QWidget):
         # SizePolicy.Maximum on each group box stops the boxes stretching but
         # not the rows holding them. Pin every content row to its natural
         # height and let the trailing scroll_layout stretch take the slack.
-        for _row in range(3):
-            main_grid_layout.setRowStretch(_row, 0)
+        # A QGridLayout spreads spare height across its rows -- and when no row
+        # has a stretch factor it spreads it *equally*, so pinning them all to
+        # zero achieves nothing. Give a trailing spacer row the stretch instead,
+        # and top-align each box in its cell; without the alignment a box that
+        # will not grow (SizePolicy.Maximum) just floats in the middle of an
+        # oversized cell, which is what left the gaps above Subject Selection.
+        main_grid_layout.setRowStretch(3, 1)
 
         # ============================================================
         # ROW 0, COLUMN 0: Subject Selection
@@ -1033,7 +1038,7 @@ class ExSearchTab(QtWidgets.QWidget):
         subject_layout.addLayout(subject_button_layout)
 
         # Add subject container to grid - Row 0, Column 0
-        main_grid_layout.addWidget(subject_container, 0, 0)
+        main_grid_layout.addWidget(subject_container, 0, 0, QtCore.Qt.AlignTop)
 
         # ============================================================
         # ROW 0, COLUMN 1: Electrode Selection
@@ -1105,7 +1110,7 @@ class ExSearchTab(QtWidgets.QWidget):
         )
 
         # Add electrode container to grid - Row 0, Column 1
-        main_grid_layout.addWidget(electrode_container, 0, 1)
+        main_grid_layout.addWidget(electrode_container, 0, 1, QtCore.Qt.AlignTop)
 
         # ============================================================
         # ROW 1, COLUMN 0: ROI Selection
@@ -1267,7 +1272,7 @@ class ExSearchTab(QtWidgets.QWidget):
         self._on_roi_mode_changed()  # Initialize to correct (sphere) page
 
         # Add ROI container to grid - Row 1, Column 0
-        main_grid_layout.addWidget(roi_container, 1, 0)
+        main_grid_layout.addWidget(roi_container, 1, 0, QtCore.Qt.AlignTop)
 
         # ============================================================
         # ROW 1, COLUMN 1: Current Configuration
@@ -1288,7 +1293,7 @@ class ExSearchTab(QtWidgets.QWidget):
         self._build_mti_current_panel()
 
         # Add current container to grid - Row 1, Column 1
-        main_grid_layout.addWidget(self.current_container, 1, 1)
+        main_grid_layout.addWidget(self.current_container, 1, 1, QtCore.Qt.AlignTop)
 
         # ============================================================
         # ROW 2, COLUMN 0-1: Leadfield Management (spanning both columns)
@@ -1350,7 +1355,7 @@ class ExSearchTab(QtWidgets.QWidget):
         )
 
         # Add leadfield container to grid - Row 2, Column 0-1 (spanning both columns)
-        main_grid_layout.addWidget(leadfield_container, 2, 0, 1, 2)
+        main_grid_layout.addWidget(leadfield_container, 2, 0, 1, 2, QtCore.Qt.AlignTop)
 
         # Add grid layout to scroll layout
         scroll_layout.addLayout(main_grid_layout)
@@ -1465,6 +1470,7 @@ class ExSearchTab(QtWidgets.QWidget):
             self.electrode_stack.setCurrentIndex(0)  # Bucketed panel
         elif self.rb_all_combinations.isChecked():
             self.electrode_stack.setCurrentIndex(1)  # All combinations panel
+        self._size_stack_to_current(self.electrode_stack)
 
     def _build_mti_bucketed_panel(self):
         """Build the mTI bucketed-mode electrode input panel (four pairs, eight buckets).
@@ -1693,31 +1699,44 @@ class ExSearchTab(QtWidgets.QWidget):
         self.roi_mode_stack.setCurrentIndex(1 if is_atlas else 0)
         self._resize_roi_mode_stack()
 
-    def _resize_roi_mode_stack(self):
-        """Size ``roi_mode_stack`` to its current page instead of the tallest.
+    def _size_stack_to_current(self, stack):
+        """Size a ``QStackedWidget`` to its current page, not to the largest.
 
-        Mirrors ``ROIPickerWidget._resize_stack_to_current``: collapse the
-        non-active page's vertical size policy to ``Ignored`` so the stack
-        (and the surrounding ``roi_container``, set to ``Maximum``) hugs
-        whichever page is showing instead of reserving room for both.
+        A stack reserves the maximum size over all its pages on both axes.
+        Vertically that leaves dead space on the compact page; horizontally it
+        is worse -- the mTI electrode panel is a four-column grid of eight
+        inputs, roughly twice the width of the two-pair panel, so the TI view
+        was forced that wide and the inputs ran off the right edge behind a
+        horizontal scrollbar. Collapsing both axes on every non-current page
+        makes the stack track whichever page is showing.
         """
-        current = self.roi_mode_stack.currentWidget()
-        for i in range(self.roi_mode_stack.count()):
-            page = self.roi_mode_stack.widget(i)
+        current = stack.currentWidget()
+        for i in range(stack.count()):
+            page = stack.widget(i)
             if page is None:
                 continue
             policy = page.sizePolicy()
+            active = page is current
             policy.setVerticalPolicy(
                 QtWidgets.QSizePolicy.Preferred
-                if page is current
+                if active
+                else QtWidgets.QSizePolicy.Ignored
+            )
+            policy.setHorizontalPolicy(
+                QtWidgets.QSizePolicy.Preferred
+                if active
                 else QtWidgets.QSizePolicy.Ignored
             )
             page.setSizePolicy(policy)
         if current is not None:
             current.adjustSize()
-        self.roi_mode_stack.updateGeometry()
-        self.roi_mode_stack.adjustSize()
+        stack.updateGeometry()
+        stack.adjustSize()
         self.updateGeometry()
+
+    def _resize_roi_mode_stack(self):
+        """Size ``roi_mode_stack`` to whichever ROI page is showing."""
+        self._size_stack_to_current(self.roi_mode_stack)
 
     def _on_search_mode_changed(self):
         """Swap electrode/current panels and toggle mode-specific controls."""
@@ -1759,6 +1778,9 @@ class ExSearchTab(QtWidgets.QWidget):
 
         self.run_btn.setText("Run mTI Search" if is_mti else "Run Ex-Search")
         self.stop_btn.setText("Stop mTI Search" if is_mti else "Stop Ex-Search")
+
+        self._size_stack_to_current(self.electrode_stack)
+        self._size_stack_to_current(self.current_config_stack)
 
     def initial_setup(self):
         """Initial setup when the tab is first loaded."""

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -126,13 +126,6 @@ COORD_SPACE_HELP = (
     "are always read directly from the subject's own segmentation."
 )
 
-ATLAS_ROI_HELP = (
-    "Volumetric (subcortical) atlas region(s) used as the search target "
-    "when ROI Type is set to Atlas.\n\n"
-    "Atlas targets are always read in the subject's own space, regardless "
-    "of the Coordinate Space setting on the Sphere page."
-)
-
 #: ROI-mechanism modes for the ROI Selection box: sphere (ROI CSVs, radius,
 #: coordinate space) or atlas (volumetric ROIPickerWidget). These are
 #: alternatives, not companions -- see ExConfig.roi_names ("an explicit
@@ -147,12 +140,16 @@ ROI_MODE_HELP = (
     "Sphere: one or more spherical ROIs (from ROI CSVs), sized by ROI "
     "Radius, in either Subject or MNI coordinate space. This is the "
     "default and the only path in common use.\n\n"
-    "Atlas: a volumetric (subcortical) atlas region instead of any "
-    "spherical ROI. Always read in the subject's own space.\n\n"
-    "mTI (4-pair) search always requires a Sphere ROI regardless of this "
-    "toggle -- the multipolar backend has no atlas-only equivalent to "
-    "ExConfig's roi_names=[] escape hatch."
+    "Atlas: one or more volumetric (subcortical) atlas regions instead of "
+    "any spherical ROI, unioned into a single target. Always read in the "
+    "subject's own space, regardless of the Coordinate Space setting on the "
+    "Sphere page.\n\n"
+    "Both work with either search mode (TI and mTI)."
 )
+
+#: Height reserved for the atlas region chips so the column does not shift as
+#: regions are added or removed -- roughly two rows of chips.
+ATLAS_CHIPS_RESERVED_HEIGHT = 56
 
 
 def _get_and_display_electrodes(subject_id, cap_name, parent_widget, path_manager=None):
@@ -1123,9 +1120,10 @@ class ExSearchTab(QtWidgets.QWidget):
         # ============================================================
         # Sphere ROI(s) and Atlas ROI are alternatives, not companions --
         # a ROI Type toggle drives a QStackedWidget with one page per
-        # mechanism (same idiom as electrode_stack above). The group hugs
-        # whichever page is showing (Maximum) instead of reserving room for
-        # both; see _resize_roi_mode_stack.
+        # mechanism (same idiom as electrode_stack above). Unlike the
+        # electrode stack this one keeps its default "tallest page" height so
+        # switching ROI Type does not shift everything below it; see
+        # _on_roi_mode_changed.
         roi_container = QtWidgets.QGroupBox("ROI Selection")
         roi_container.setSizePolicy(
             QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
@@ -1241,12 +1239,6 @@ class ExSearchTab(QtWidgets.QWidget):
         atlas_layout.setContentsMargins(0, 0, 0, 0)
         atlas_layout.setSpacing(8)
 
-        atlas_header_layout = QtWidgets.QHBoxLayout()
-        atlas_header_layout.addWidget(QtWidgets.QLabel("Atlas ROI:"))
-        atlas_header_layout.addWidget(HelpIcon(ATLAS_ROI_HELP, title="Atlas ROI"))
-        atlas_header_layout.addStretch()
-        atlas_layout.addLayout(atlas_header_layout)
-
         self.atlas_roi_picker = ROIPickerWidget(
             enable_spherical=False,
             enable_atlas=False,
@@ -1268,6 +1260,14 @@ class ExSearchTab(QtWidgets.QWidget):
         self.atlas_roi_picker.volume_subject_radio.setChecked(True)
         self.atlas_roi_picker.volume_subject_radio.setVisible(False)
         self.atlas_roi_picker.volume_mni_radio.setVisible(False)
+        # RegionChipsWidget is a flow layout with a 24px minimum, so it grows
+        # as regions are added and would push the column down on every "List
+        # Regions". Reserve two rows up front: the space is there whether or
+        # not chips occupy it, so adding and removing regions is visually
+        # stable.
+        self.atlas_roi_picker.subcortical_chips.setMinimumHeight(
+            ATLAS_CHIPS_RESERVED_HEIGHT
+        )
         atlas_layout.addWidget(self.atlas_roi_picker)
 
         self.roi_mode_stack.addWidget(atlas_page)
@@ -1703,11 +1703,37 @@ class ExSearchTab(QtWidgets.QWidget):
             names.append(name)
         return names
 
+    def _mti_roi_targets(self):
+        """Return ``(display_names, csv_names)`` for one mTI run.
+
+        In Sphere mode these are the selected ROI list entries, one run each.
+        In Atlas mode there is no ROI CSV to select, so the union of chosen
+        atlas regions becomes a single synthetic target named by
+        :meth:`atlas_only_roi_label` -- the same convention the TI path uses.
+        The name is only a label: ``roi_names=[]`` tells the backend to read no
+        sphere CSV at all.
+        """
+        if self._current_roi_mode() == ROI_MODE_ATLAS:
+            region_keys = list(self.atlas_roi_picker.subcortical_chips.keys())
+            label = self.atlas_only_roi_label(region_keys)
+            return region_keys, [f"{label}.csv"]
+        display = [
+            item.text().split(":")[0].strip() for item in self.roi_list.selectedItems()
+        ]
+        return display, self._selected_roi_csv_names()
+
     def _on_roi_mode_changed(self):
-        """Switch the ROI Selection box between its Sphere and Atlas pages."""
+        """Switch the ROI Selection box between its Sphere and Atlas pages.
+
+        Deliberately does NOT resize the stack. A QStackedWidget reserves the
+        maximum height over its pages, which is what keeps everything below the
+        ROI box still while the user flips between Sphere and Atlas -- sizing
+        to the current page instead made the whole column jump. The cost is
+        some slack on the shorter page, which is the right trade here: the
+        Atlas page needs room for region chips to appear anyway.
+        """
         is_atlas = self._current_roi_mode() == ROI_MODE_ATLAS
         self.roi_mode_stack.setCurrentIndex(1 if is_atlas else 0)
-        self._resize_roi_mode_stack()
 
     def _size_stack_to_current(self, stack):
         """Size a ``QStackedWidget`` to its current page, not to the largest.
@@ -1744,10 +1770,6 @@ class ExSearchTab(QtWidgets.QWidget):
         stack.adjustSize()
         self.updateGeometry()
 
-    def _resize_roi_mode_stack(self):
-        """Size ``roi_mode_stack`` to whichever ROI page is showing."""
-        self._size_stack_to_current(self.roi_mode_stack)
-
     def _on_search_mode_changed(self):
         """Swap electrode/current panels and toggle mode-specific controls."""
         is_mti = self._current_search_mode() == SEARCH_MODE_MTI
@@ -1764,28 +1786,16 @@ class ExSearchTab(QtWidgets.QWidget):
             "mTI Configuration" if is_mti else "Current Configuration"
         )
 
-        # MExConfig has no ROI-union equivalent to ExConfig.roi_names, so
-        # Combine ROIs only applies in TI mode.
+        # Combine ROIs stays TI-only: the mTI run path processes selected
+        # spherical ROIs one at a time and never builds a union, even though
+        # MExConfig.roi_names could now express one.
         self.combine_rois_cb.setEnabled(not is_mti)
         if is_mti:
             self.combine_rois_cb.setChecked(False)
 
-        # Atlas-only targeting is TI-only. tit/opt/ex/ex.py honours
-        # roi_names=[] and reads no sphere file, but tit/opt/mex/mex.py builds
-        # roi_file from config.roi_name unconditionally, so a multipolar run
-        # always needs a spherical ROI. Offering Atlas here would take the
-        # selection and then fail validation asking for a sphere, so the choice
-        # is disabled rather than left to mislead.
-        self.roi_mode_atlas_radio.setEnabled(not is_mti)
-        self.roi_mode_atlas_radio.setToolTip(
-            "Atlas-only targeting is not available for mTI: a multipolar run "
-            "still requires a spherical ROI."
-            if is_mti
-            else ""
-        )
-        if is_mti and self.roi_mode_atlas_radio.isChecked():
-            self.roi_mode_sphere_radio.setChecked(True)
-
+        # Atlas targeting works in both modes: MExConfig now carries roi_names
+        # like ExConfig, and tit/opt/mex/mex.py honours roi_names=[] by reading
+        # no sphere CSV, so the ROI Type choice is free in mTI too.
         self.run_btn.setText("Run mTI Search" if is_mti else "Run Ex-Search")
         self.stop_btn.setText("Stop mTI Search" if is_mti else "Stop Ex-Search")
 
@@ -2190,15 +2200,10 @@ class ExSearchTab(QtWidgets.QWidget):
             self.update_status("Please select a leadfield for simulation", error=True)
             return False
 
-        # ROI validation branches on ROI Type (Sphere/Atlas). mTI always needs
-        # a Sphere ROI regardless of the toggle: MExConfig has no roi_names=[]
-        # atlas-only escape hatch -- tit/opt/mex/mex.py builds roi_file from
-        # config.roi_name unconditionally and always merges it into
-        # roi_target, so the backend has no way to run without one.
-        if (
-            self._current_search_mode() == SEARCH_MODE_MTI
-            or self._current_roi_mode() == ROI_MODE_SPHERE
-        ):
+        # ROI validation branches on ROI Type alone -- both search modes now
+        # honour either mechanism, since MExConfig carries roi_names like
+        # ExConfig and tit/opt/mex/mex.py reads no sphere CSV when it is empty.
+        if self._current_roi_mode() == ROI_MODE_SPHERE:
             # Check if ROIs are selected
             if self.roi_list.count() == 0:
                 self.update_status("Please add at least one ROI", error=True)
@@ -2478,9 +2483,9 @@ class ExSearchTab(QtWidgets.QWidget):
         Mirrors the TI flow in ``run_optimization`` above: same
         subject/leadfield/ROI plumbing, confirmation dialog, and per-ROI
         pipeline via ``run_roi_pipeline``. mTI always searches bucketed
-        (there is no all-combinations page) and ``MExConfig`` has no
-        ROI-union equivalent to ``ExConfig.roi_names``, so ROIs are always
-        processed separately here (no Combine ROIs path).
+        (there is no all-combinations page), and selected spherical ROIs are
+        processed separately rather than unioned -- the Combine ROIs checkbox
+        stays TI-only. Atlas targeting works here as it does for TI.
         """
         subject_id = self.subject_combo.currentText()
         project_dir = self.pm.project_dir
@@ -2490,8 +2495,8 @@ class ExSearchTab(QtWidgets.QWidget):
         self.mex_buckets = self._current_mti_buckets()
         self.use_all_combinations = False
 
-        selected_rois = self.roi_list.selectedItems()
-        roi_names = [item.text().split(":")[0].strip() for item in selected_rois]
+        roi_names, selected_roi_names = self._mti_roi_targets()
+        is_atlas_only = self._current_roi_mode() == ROI_MODE_ATLAS
 
         bucket_counts = ", ".join(
             f"{MEX_BUCKET_LABELS[key]}: {len(values)}"
@@ -2508,8 +2513,11 @@ class ExSearchTab(QtWidgets.QWidget):
             f"Current per Pair: {self.mex_current_spinbox.value():.1f} mA\n"
             f"Carrier Wiring: {self.mex_channels_combo.currentText()}\n"
             f"Search Space: up to {n_combos_upper:,} eight-electrode combinations\n"
-            f"ROIs: {', '.join(roi_names)}\n"
-            f"Total ROIs: {len(roi_names)}"
+            + (
+                f"Atlas ROI: {', '.join(roi_names)}"
+                if is_atlas_only
+                else f"ROIs: {', '.join(roi_names)}\n" f"Total ROIs: {len(roi_names)}"
+            )
         )
         if self.mex_symmetric_bucket_cb.isChecked():
             details += (
@@ -2528,9 +2536,11 @@ class ExSearchTab(QtWidgets.QWidget):
         # Create m_ex_search directory if it doesn't exist
         os.makedirs(mex_search_dir, exist_ok=True)
 
-        selected_roi_names = self._selected_roi_csv_names()
         if self.debug_mode:
-            self.update_output(f"Selected ROI(s): {', '.join(selected_roi_names)}")
+            if is_atlas_only:
+                self.update_output(f"Atlas-only ROI target: {', '.join(roi_names)}")
+            else:
+                self.update_output(f"Selected ROI(s): {', '.join(selected_roi_names)}")
 
         # Set up environment variables
         env = os.environ.copy()
@@ -2649,6 +2659,7 @@ class ExSearchTab(QtWidgets.QWidget):
             subject_id=subject_id,
             leadfield_hdf=leadfield_hdf,
             roi_name=roi_name,
+            roi_names=self.roi_names_for_mode(mode, None),
             roi_atlas=self.roi_atlas_for_mode(mode, self._current_roi_atlas_entries()),
             roi_coordinate_space=self.coordinate_space_value(
                 self.coord_space_mni.isChecked()

--- a/tit/gui/ex_search_tab.py
+++ b/tit/gui/ex_search_tab.py
@@ -996,6 +996,12 @@ class ExSearchTab(QtWidgets.QWidget):
         # Main grid layout for organized component placement
         main_grid_layout = QtWidgets.QGridLayout()
         main_grid_layout.setSpacing(15)  # Add spacing between components
+        # A QGridLayout hands leftover height to any row that can grow, so the
+        # SizePolicy.Maximum on each group box stops the boxes stretching but
+        # not the rows holding them. Pin every content row to its natural
+        # height and let the trailing scroll_layout stretch take the slack.
+        for _row in range(3):
+            main_grid_layout.setRowStretch(_row, 0)
 
         # ============================================================
         # ROW 0, COLUMN 0: Subject Selection
@@ -1025,9 +1031,6 @@ class ExSearchTab(QtWidgets.QWidget):
         subject_button_layout.addWidget(self.list_subjects_btn)
         subject_button_layout.addWidget(self.clear_subject_selection_btn)
         subject_layout.addLayout(subject_button_layout)
-
-        # Add stretch to push content to top
-        subject_layout.addStretch()
 
         # Add subject container to grid - Row 0, Column 0
         main_grid_layout.addWidget(subject_container, 0, 0)
@@ -1588,9 +1591,6 @@ class ExSearchTab(QtWidgets.QWidget):
         channel_limit_layout.addStretch()
         current_layout.addLayout(channel_limit_layout)
 
-        # Add stretch to push content to top
-        current_layout.addStretch()
-
         self.current_config_stack.addWidget(panel)
 
     def _build_mti_current_panel(self):
@@ -1659,7 +1659,6 @@ class ExSearchTab(QtWidgets.QWidget):
         symmetric_layout.addStretch()
         layout.addLayout(symmetric_layout)
 
-        layout.addStretch()
         self.current_config_stack.addWidget(panel)
 
     def _current_search_mode(self):

--- a/tit/opt/config.py
+++ b/tit/opt/config.py
@@ -865,6 +865,13 @@ class MExConfig:
         expressed.
     roi_radius : float
         Spherical ROI radius in mm for the target region.
+    roi_names : list of str or None
+        Optional list of ROI CSV filenames to **union** into a single
+        target.  ``None`` (default) keeps single-ROI behavior driven by
+        *roi_name*.  An explicit empty list means "no spherical centers at
+        all" -- required for a purely atlas-driven ROI (*roi_atlas* only),
+        in which case *roi_name* is only a naming label and no CSV is read.
+        Each entry gets the ``".csv"`` suffix appended if missing.
     roi_atlas : list of AtlasROI or None
         Volumetric atlas or mask ROI(s) to union with the spherical center
         from *roi_name*.  ``None`` (default) keeps the existing
@@ -967,6 +974,7 @@ class MExConfig:
 
     # ── ROI ────────────────────────────────────────────────────────────
     roi_radius: float = 3.0
+    roi_names: list[str] | None = None
     roi_atlas: list[AtlasROI] | None = None
     roi_coordinate_space: Literal["subject", "mni"] = "subject"
 
@@ -986,6 +994,10 @@ class MExConfig:
                 self.electrodes = MExConfig.BucketElectrodes(**self.electrodes)
         if not self.roi_name.endswith(".csv"):
             self.roi_name += ".csv"
+        if self.roi_names is not None:
+            self.roi_names = [
+                n if n.endswith(".csv") else f"{n}.csv" for n in self.roi_names
+            ]
         if self.roi_atlas is not None:
             self.roi_atlas = [
                 a if isinstance(a, MExConfig.AtlasROI) else MExConfig.AtlasROI(**a)

--- a/tit/opt/mex/mex.py
+++ b/tit/opt/mex/mex.py
@@ -47,20 +47,25 @@ def _run_m_ex_search_inner(config: MExConfig) -> MExResult:
     os.makedirs(output_dir, exist_ok=True)
     logger.info("Output: %s", output_dir)
 
+    # Mirrors tit/opt/ex/ex.py. roi_names=[] means "no spherical centers",
+    # which is how an atlas-only target is expressed -- roi_name is then just
+    # the naming label and no CSV is read.
+    roi_names = config.roi_names if config.roi_names is not None else [config.roi_name]
     roi_dir = pm.rois(config.subject_id)
-    if config.roi_coordinate_space == "mni":
-        [roi_file] = mni_roi_files_to_subject_space(
-            [config.roi_name], roi_dir, pm.m2m(config.subject_id), output_dir, logger
+    if roi_names and config.roi_coordinate_space == "mni":
+        roi_files = mni_roi_files_to_subject_space(
+            roi_names, roi_dir, pm.m2m(config.subject_id), output_dir, logger
         )
     else:
-        roi_file = os.path.join(roi_dir, config.roi_name)
+        roi_files = [os.path.join(roi_dir, name) for name in roi_names]
+    if len(roi_files) > 1:
+        logger.info("Combining %d ROIs into one target: %s", len(roi_files), roi_names)
 
     atlas_entries = atlas_roi_entries(config)
     if atlas_entries:
         logger.info("Adding %d atlas ROI target(s)", len(atlas_entries))
-        roi_target = [roi_file] + atlas_entries
-    else:
-        roi_target = roi_file
+        roi_files = roi_files + atlas_entries
+    roi_target = roi_files
 
     if isinstance(config.electrodes, MExConfig.PoolElectrodes):
         buckets_or_pool = config.electrodes.electrodes


### PR DESCRIPTION
Follow-ups on the ex-search tab, driven by screenshots of the running GUI.

## Layout

Three separate symptoms, all the same Qt behaviour — a layout distributes spare
space equally when nothing declares a stretch factor:

- **Vertical gaps between boxes.** The top-level `QGridLayout` made paired
  cells share a row height, so Subject Selection (beside the taller Electrode
  Selection) and Current Configuration (beside the taller ROI Selection) sat in
  oversized cells. Top-aligning them moved the boxes but could not shrink the
  rows, so the grid is gone in favour of two independent column layouts.
- **Horizontal overflow.** A `QStackedWidget` reserves the maximum over all its
  pages on both axes, and the mTI electrode panel is roughly twice the width of
  the two-pair panel, so the TI view was forced that wide and its inputs ran off
  the right edge. The stack-sizing helper now collapses both axes and is shared
  by all three stacks.
- **Label-to-input gap in the mTI grid.** No column stretch meant the label
  columns grew along with the input columns. Stretch now sits on the input
  columns only; labels have a uniform width and are left-aligned so the `E`
  glyphs line up.

Switching ROI Type no longer shifts the column: that stack deliberately keeps
its default tallest-page height, and the atlas region chips get a reserved
height since a flow layout grows as chips are added.

## Atlas targeting in mTI

Previously disabled for a real reason — `tit/opt/mex/mex.py` built the sphere
CSV path from `roi_name` unconditionally, so a multipolar run could not run
without a spherical ROI. `MExConfig` now carries `roi_names` like `ExConfig`,
and `mex.py` mirrors `ex.py`'s construction: `roi_names=[]` means "no spherical
centres", leaving `roi_name` as a naming label that is never opened.
`MExSearchEngine` already extends `ExSearchEngine` and accepts a target list, so
it needed no change.

Note: `mex.py` now always passes a target list where it used to pass a bare
string for the spherical case. Both are accepted; one shape means one code path.

Combine ROIs stays TI-only — `MExConfig.roi_names` could express a union now,
but the mTI run path processes selected spheres one at a time.

Also removed the redundant "Atlas ROI:" header (the Atlas radio and ROI Type
help icon already say it), folding its text into `ROI_MODE_HELP`, which had a
stale claim that mTI always requires a sphere.

## Verification

2366 passed / 16 skipped. New coverage: atlas-only mTI skips the sphere CSV and
the MNI transform, `roi_names=[]` survives the JSON round-trip (the GUI ships
this config as JSON, so that is load-bearing), and the layout invariants above.

PyQt5 is absent on the host, so nothing here was verified by rendering — the
layout tests assert mechanisms in source, not appearance. Atlas-only mTI has not
been run end to end.