### PR TITLE
sim: define the output fields in the help popup instead of classifying them

### DIFF
--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -181,3 +181,35 @@ class TestValidFsavgFieldsConsumer:
     def test_valid_fsavg_fields_all_come_from_registry(self):
         registry_names = set(const.get_field_names())
         assert set(VALID_FSAVG_FIELDS).issubset(registry_names)
+
+
+@pytest.mark.unit
+class TestOutputFieldHelpText:
+    """The output-field help must define fields, not classify them."""
+
+    def test_help_gives_definition_equation_and_reference_per_field(self):
+        defs = const.OUTPUT_FIELD_DEFINITIONS
+        help_text = const.output_fields_help_text()
+
+        selectable = set(const.SELECTABLE_OUTPUT_FIELDS)
+        assert {d[0] for d in defs} == selectable
+        for name, units, definition, equation, reference in defs:
+            assert units and definition and equation and reference
+            for part in (name, units, definition, equation, reference):
+                assert part in help_text
+        assert "Equation:" in help_text
+        assert "Reference:" in help_text
+
+    def test_no_functional_versus_safety_framing_in_user_facing_text(self):
+        """Which fields bear on efficacy vs safety is debated; do not assert it.
+
+        The registry still groups fields by ``kind`` for programmatic subset
+        selection, but nothing the user reads may present that as a claim.
+        """
+        user_text = [const.output_fields_help_text()] + [
+            spec.description for spec in const.FIELD_REGISTRY
+        ]
+        for text in user_text:
+            lowered = text.lower()
+            assert "safety metric" not in lowered
+            assert "functional" not in lowered

--- a/tit/constants.py
+++ b/tit/constants.py
@@ -159,9 +159,14 @@ FIELD_HF_PEAK = "hf_peak"  # peak carrier field, max over sign choices of the
 # vector sum; at N=2 this is max(|E1+E2|,|E1-E2|) (Cassarà 2025)
 FIELD_HF_SAR = "hf_sar"  # carrier heating driver, sum_i |E_i|^2 (∝ SAR)
 
-# Field "kind" classification used by FieldSpec below.
-FIELD_KIND_FUNCTIONAL = "functional"  # stimulation metrics
-FIELD_KIND_SAFETY = "safety"  # carrier-exposure / safety metrics
+# Field "kind" classification used by FieldSpec below. This groups fields by
+# what they are computed from -- the low-frequency envelope versus the carrier
+# fields themselves -- and is used only to select subsets programmatically. It
+# is deliberately not surfaced in the UI: which of these bear on efficacy and
+# which on safety is still debated, so the interface states each field's
+# definition and lets the user decide.
+FIELD_KIND_FUNCTIONAL = "functional"  # envelope-derived
+FIELD_KIND_SAFETY = "safety"  # carrier-derived
 
 
 @dataclass(frozen=True)
@@ -199,7 +204,8 @@ FIELD_REGISTRY: tuple[FieldSpec, ...] = (
         kind=FIELD_KIND_FUNCTIONAL,
         units="V/m",
         description=(
-            "Modulation depth (peak-to-trough envelope), maximum over direction."
+            "Envelope modulation depth (peak-to-trough), maximised over "
+            "direction (Grossman et al. 2017; Hirata et al. 2024)."
         ),
     ),
     FieldSpec(
@@ -224,7 +230,10 @@ FIELD_REGISTRY: tuple[FieldSpec, ...] = (
         label=FIELD_TI_AVG,
         kind=FIELD_KIND_FUNCTIONAL,
         units="V/m",
-        description="Modulation depth (peak-to-trough envelope), averaged over direction.",
+        description=(
+            "Envelope modulation depth (peak-to-trough), averaged over "
+            "sampled directions rather than maximised."
+        ),
     ),
     FieldSpec(
         name=FIELD_HF_PEAK,
@@ -232,8 +241,9 @@ FIELD_REGISTRY: tuple[FieldSpec, ...] = (
         kind=FIELD_KIND_SAFETY,
         units="V/m",
         description=(
-            "Worst-case instantaneous carrier field (peak-to-zero). "
-            "Safety metric, Cassarà et al. 2025."
+            "Largest instantaneous magnitude of the summed carrier fields "
+            "(peak-to-zero): max over sign choices of |sum_i s_i*E_i| "
+            "(Cassarà et al. 2025, Eq. 3)."
         ),
     ),
     FieldSpec(
@@ -241,7 +251,10 @@ FIELD_REGISTRY: tuple[FieldSpec, ...] = (
         label=FIELD_HF_SAR,
         kind=FIELD_KIND_SAFETY,
         units="(V/m)^2",
-        description="Carrier heating driver, proportional to SAR. Safety metric.",
+        description=(
+            "Sum of carrier power, sum_i |E_i|^2. Proportional to SAR but not "
+            "calibrated: SAR = (sigma/2*rho)*hf_sar (Cassarà et al. 2025)."
+        ),
     ),
 )
 
@@ -262,6 +275,77 @@ def get_field_names(kind: str | None = None) -> tuple[str, ...]:
 def get_fields_by_kind(kind: str) -> tuple[FieldSpec, ...]:
     """Return all :class:`FieldSpec` entries with the given ``kind``."""
     return tuple(spec for spec in FIELD_REGISTRY if spec.kind == kind)
+
+
+#: Definitions for the output-field help popup, as
+#: ``(name, units, definition, equation, reference)``. Equations match the
+#: implementations in :mod:`tit.calc` and :mod:`tit.fields`; ``E_i`` is the
+#: field from electrode pair *i* and ``n`` a unit direction. Kept here rather
+#: than in the GUI module so it is verifiable without PyQt5.
+OUTPUT_FIELD_DEFINITIONS: tuple[tuple[str, str, str, str, str], ...] = (
+    (
+        FIELD_TI_MAX,
+        "V/m",
+        "Depth of the low-frequency envelope modulation (peak-to-trough), "
+        "maximised over direction.",
+        "Two pairs: 2*min(|E1.n|, |E2.n|) at the optimal n, evaluated via a "
+        "closed form. K channels: sqrt(2)*(sqrt(P+Q) - sqrt(P-Q)), where "
+        "P = 0.5*sum_k(a_k^2 + b_k^2), Q = |sum_k a_k*b_k*exp(i*psi_k)|, "
+        "a_k = E_ka.n and b_k = E_kb.n; maximised over n.",
+        "Grossman et al. 2017, Cell 169(6):1029-1041; "
+        "Hirata et al. 2024, Comput Biol Med 178:108697.",
+    ),
+    (
+        FIELD_TI_AVG,
+        "V/m",
+        "The same envelope depth averaged over sampled directions instead of "
+        "maximised, i.e. what an arbitrarily oriented element sees on average.",
+        "Mean over a Fibonacci-sphere direction sweep of the expression above "
+        "(no local refinement, which only sharpens a single best direction).",
+        "Direction-averaged form of Grossman et al. 2017.",
+    ),
+    (
+        FIELD_HF_PEAK,
+        "V/m",
+        "Largest instantaneous magnitude the summed carrier fields can reach "
+        "(peak-to-zero, not peak-to-trough).",
+        "max over s_i in {-1,+1} of |sum_i s_i*E_i| -- exact sign enumeration "
+        "up to 8 fields, otherwise a direction sweep whose implied sign "
+        "pattern is evaluated exactly.",
+        "Cassara et al. 2025, Eq. 3.",
+    ),
+    (
+        FIELD_HF_SAR,
+        "(V/m)^2",
+        "Sum of carrier power. The carriers sit at different, incommensurate "
+        "frequencies, so their power adds rather than their amplitudes. This "
+        "is a field-domain quantity, not calibrated SAR: that is "
+        "(sigma/2*rho)*hf_sar and needs per-tissue conductivity and density.",
+        "sum_i |E_i|^2",
+        "Cassara et al. 2025.",
+    ),
+)
+
+
+def output_fields_help_text() -> str:
+    """Compose the output-field help popup text.
+
+    States each field's definition, equation and reference. Deliberately does
+    not group the fields into "functional" and "safety" -- which of them bear
+    on efficacy and which on exposure is still debated, so the popup gives the
+    definitions and leaves the interpretation to the reader.
+    """
+    body = "\n\n".join(
+        f"{name} [{units}]\n{definition}\nEquation: {equation}\n"
+        f"Reference: {reference}"
+        for name, units, definition, equation, reference in OUTPUT_FIELD_DEFINITIONS
+    )
+    return (
+        "Which volume fields to compute and write for each simulation.\n\n"
+        + body
+        + "\n\nCost: TI_avg adds a direction sweep; hf_peak and hf_sar are "
+        "effectively free alongside a field that is already being computed."
+    )
 
 
 def get_selectable_output_field_specs() -> tuple[FieldSpec, ...]:

--- a/tit/gui/simulator_tab.py
+++ b/tit/gui/simulator_tab.py
@@ -44,7 +44,7 @@ from tit.paths import get_path_manager
 from tit.config_io import serialize_config
 from tit.reporting import SimulationReportGenerator
 from tit import constants as const
-from tit.constants import get_selectable_output_field_specs
+from tit.constants import get_selectable_output_field_specs, output_fields_help_text
 
 from tit.sim import (
     Montage,
@@ -57,15 +57,6 @@ from tit.sim.utils import (
     save_montage_data,
     ensure_montage_file,
     upsert_montage,
-)
-
-OUTPUT_FIELDS_HELP = (
-    "Which volume fields to compute and write for each simulation.\n\n"
-    "TI_max and TI_avg are stimulation (functional) metrics. hf_peak and "
-    "hf_sar are carrier-exposure safety metrics (Cassarà 2025) and are "
-    "off by default -- enable them if you need safety reporting.\n\n"
-    "TI_avg costs extra compute time (a direction sweep); hf_peak/hf_sar "
-    "are effectively free."
 )
 
 
@@ -303,7 +294,7 @@ class SimulatorTab(QtWidgets.QWidget):
             cb.setToolTip(spec.description)
             self.output_field_checkboxes[spec.name] = cb
             row3.addWidget(cb)
-        row3.addWidget(HelpIcon(OUTPUT_FIELDS_HELP, title="Output Fields"))
+        row3.addWidget(HelpIcon(output_fields_help_text(), title="Output Fields"))
         row3.addStretch()
         global_layout.addLayout(row3)
 


### PR DESCRIPTION
The output-field help popup split the four selectable fields into "stimulation
(functional) metrics" and "carrier-exposure safety metrics". Which of them bear
on efficacy and which on exposure is still debated, so the interface should not
assert it.

Each field now gets its definition, the equation as implemented, and a
literature reference:

```
hf_peak [V/m]
Largest instantaneous magnitude the summed carrier fields can reach
(peak-to-zero, not peak-to-trough).
Equation: max over s_i in {-1,+1} of |sum_i s_i*E_i| -- exact sign
enumeration up to 8 fields, otherwise a direction sweep whose implied
sign pattern is evaluated exactly.
Reference: Cassarà et al. 2025, Eq. 3.
```

The per-checkbox tooltips carried the same framing and got the same treatment —
otherwise the popup and the tooltips would contradict each other.

## Notes

- The definitions live in `tit/constants.py` beside `FIELD_REGISTRY`, not in the
  GUI module: it is field metadata, and behind a PyQt5 import it would not be
  verifiable in this test environment. That is not hypothetical — the first
  version of this change put it in `simulator_tab.py` and both new tests failed
  on `ModuleNotFoundError`.
- `FieldSpec.kind` stays. No production code branches on it (only tests select
  subsets by it), so removing it would churn ~14 assertions for no user-visible
  gain. Its comment now states that the grouping is by what a field is computed
  from — envelope versus carrier — and is deliberately not surfaced.
- Equations were read off the implementations in `tit/calc.py` and
  `tit/fields.py` rather than from the literature, so they describe what the
  code actually computes.

## Not included

`docs/wiki/mti.md` still has a "Safety metrics" section heading, and the v2.4.0
changelog/release notes describe these as safety metrics. The changelog is a
historical record and should not be rewritten; the wiki page is a candidate for
the same treatment but was outside this ask.

## Verification

2368 passed / 16 skipped. Two new tests: every selectable field has a
definition, equation and reference that reach the popup text, and no
user-facing string carries the functional/safety framing.