### PR TITLE
Hosted TI-Toolbox via JupyterHub + DockerSpawner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ dev/telemetry/dashboard/.env
 !dev/telemetry/dashboard/.env.example
 
 .playwright-mcp/
+deploy/jupyterhub/.env

--- a/deploy/jupyterhub/.env.example
+++ b/deploy/jupyterhub/.env.example
@@ -1,0 +1,34 @@
+# ---- copy to .env and fill in ------------------------------------------
+# Public URL of the hub (used for the OAuth callback). With the caddy profile: https://<HUB_DOMAIN>
+HUB_URL=https://hub.example.org
+HUB_DOMAIN=hub.example.org
+
+# Authentication: "github" (production) or "dummy" (local testing only)
+HUB_AUTH=github
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+# Comma-separated GitHub logins that are hub admins (can stop/inspect any server)
+ADMIN_USERS=idossha
+# true = any GitHub account may log in (you pay for their CPU). false = allowed_users.txt + admins only.
+ALLOW_ALL_GITHUB_USERS=false
+# Only used when HUB_AUTH=dummy
+DUMMY_PASSWORD=ti-toolbox
+
+# Per-user image (build with: docker compose --profile build-only build singleuser)
+TIT_IMAGE=idossha/simnibs:v2.4.0
+SINGLEUSER_IMAGE=ti-toolbox-singleuser:latest
+TI_TOOLBOX_VERSION=v2.4.0
+
+# Host directory holding the seed project (built with make_seed.py). Copied into
+# each user's private volume on first start. Leave empty for empty projects.
+SEED_DIR=/srv/tit-seed/000
+PROJECT_DIR_NAME=000
+
+# Resource caps per user container
+USER_CPU_LIMIT=2
+USER_MEM_LIMIT=10G
+# Stop servers idle for this many seconds
+CULL_TIMEOUT=3600
+
+# Where the hub listens on the host. Keep loopback when caddy fronts it.
+HUB_BIND=127.0.0.1:8000

--- a/deploy/jupyterhub/Caddyfile
+++ b/deploy/jupyterhub/Caddyfile
@@ -1,0 +1,3 @@
+{$HUB_DOMAIN} {
+    reverse_proxy jupyterhub:8000
+}

--- a/deploy/jupyterhub/Dockerfile.hub
+++ b/deploy/jupyterhub/Dockerfile.hub
@@ -1,0 +1,10 @@
+FROM quay.io/jupyterhub/jupyterhub:5.5.1
+
+RUN pip install --no-cache-dir \
+        "dockerspawner==14.0.0" \
+        "oauthenticator==17.4.0" \
+        "jupyterhub-idle-culler==2.0.0"
+
+COPY jupyterhub_config.py /srv/jupyterhub/jupyterhub_config.py
+WORKDIR /srv/jupyterhub
+CMD ["jupyterhub", "-f", "/srv/jupyterhub/jupyterhub_config.py"]

--- a/deploy/jupyterhub/Dockerfile.singleuser
+++ b/deploy/jupyterhub/Dockerfile.singleuser
@@ -1,0 +1,24 @@
+# Per-user server image for the TI-Toolbox JupyterHub.
+# Build context is the REPO ROOT (see docker-compose.yml): the image is the
+# published TI-Toolbox container plus (a) the jupyterhub client packages and
+# (b) this checkout's `tit` package and example notebook, so the hub always
+# runs the code that matches the docs. Rebuild on every release / checkout.
+ARG TIT_IMAGE=idossha/simnibs:v2.4.0
+FROM ${TIT_IMAGE}
+
+ARG JUPYTERHUB_VERSION=5.5.1
+RUN simnibs_python -m pip install --no-cache-dir \
+        "jupyterhub==${JUPYTERHUB_VERSION}" \
+        "nbgitpuller==1.3.0"
+
+# Toolbox code + example notebook from this checkout
+COPY tit /ti-toolbox/tit
+COPY version.py /ti-toolbox/version.py
+COPY docs/assets/notebooks /opt/tit-hub/notebooks
+
+COPY deploy/jupyterhub/start-singleuser.sh /usr/local/bin/start-singleuser.sh
+RUN chmod +x /usr/local/bin/start-singleuser.sh
+
+# entrypoint.sh (from the base image) still runs first: it sets PYTHONPATH,
+# FreeSurfer env, and PROJECT_DIR, then exec's this.
+CMD ["/usr/local/bin/start-singleuser.sh"]

--- a/deploy/jupyterhub/README.md
+++ b/deploy/jupyterhub/README.md
@@ -1,0 +1,81 @@
+# Hosted TI-Toolbox (JupyterHub)
+
+One VM runs JupyterHub; each logged-in user gets their **own TI-Toolbox container**
+(the same `idossha/simnibs` image everyone runs locally, with this checkout's `tit` and the example notebook baked in), a private project volume
+pre-seeded with `sub-ernie`, and the `SimNIBS + TI-Toolbox` Jupyter kernel.
+Nothing to install on the user's side.
+
+```
+browser ──HTTPS──▶ caddy ──▶ jupyterhub (DockerSpawner, GitHub login)
+                                 │ docker.sock
+                                 ▼
+                    tit-user-<login>  ← ti-toolbox-singleuser image
+                    ├─ /mnt/000         per-user volume, seeded from SEED_DIR on first start
+                    ├─ /mnt/notebooks   example_workflow.ipynb (and nbgitpuller checkouts)
+                    └─ JupyterLab, 2 CPU / 6 GB cap, culled after 1 h idle
+```
+
+## Host requirements
+
+- Linux VM with Docker + compose plugin. Sizing rule of thumb: each active user
+  container is capped at `USER_CPU_LIMIT` cores / `USER_MEM_LIMIT` (defaults 2 / 10 GB).
+  The example notebook (one TI simulation on ernie + analyses) took 8.5 min native on
+  one core and 12 min under the 2-core cap on an emulated host; the mesh→NIfTI/MNI step
+  is the memory peak — 6 GB was OOM-killed, 10 GB was not. 8 vCPU / 32 GB serves ~3
+  concurrent simulations comfortably.
+- Disk: base image (~18 GB) + ~1.5 GB per user volume (+ their outputs). 200 GB is comfortable.
+- A DNS name pointing at the VM (for HTTPS via Caddy) and a GitHub OAuth app.
+
+## Setup
+
+1. **Seed project** – on the VM, from any full TI-Toolbox project that has a finished
+   `m2m_ernie`:
+   ```bash
+   python3 make_seed.py /data/000 /srv/tit-seed/000 --subject ernie   # add --with-leadfields for ex-search
+   ```
+2. **GitHub OAuth app** – <https://github.com/settings/developers> → *New OAuth App*:
+   Homepage `https://<HUB_DOMAIN>`, callback `https://<HUB_DOMAIN>/hub/oauth_callback`.
+3. **Configure** – `cp .env.example .env`, fill in `HUB_DOMAIN`, `HUB_URL`, the OAuth
+   client id/secret, `ADMIN_USERS`, `SEED_DIR`. Add GitHub logins to `allowed_users.txt`
+   (or set `ALLOW_ALL_GITHUB_USERS=true` — every GitHub account can then burn your CPU).
+4. **Build & run**
+   ```bash
+   docker compose --profile build-only build singleuser   # per-user image (installs jupyterhub into the TI image)
+   docker compose build jupyterhub
+   docker compose --profile tls up -d                      # hub + caddy
+   ```
+5. Open `https://<HUB_DOMAIN>`, log in with GitHub, and the example notebook is at
+   `/mnt/notebooks/example_workflow.ipynb`. Deep link (used by the docs site):
+   `https://<HUB_DOMAIN>/hub/user-redirect/lab/tree/notebooks/example_workflow.ipynb`
+
+## Local smoke test (no domain, no GitHub)
+
+```bash
+cp .env.example .env
+sed -i 's/^HUB_AUTH=.*/HUB_AUTH=dummy/; s#^SEED_DIR=.*#SEED_DIR=#' .env
+docker compose --profile build-only build singleuser && docker compose build jupyterhub
+docker compose up -d jupyterhub
+# http://127.0.0.1:8000 – any username, password "ti-toolbox"
+```
+
+## Operations
+
+| Task | Command |
+|---|---|
+| Who is running | `docker ps --filter name=tit-user` |
+| Stop one user | admin panel at `/hub/admin`, or `docker stop tit-user-<login>` |
+| Wipe a user's project | `docker volume rm tit-project-<login>` (their server must be stopped) |
+| New toolbox release | `git checkout vX.Y.Z`, bump `TIT_IMAGE` in `.env` to the matching tag, rebuild `singleuser`; users get it on next start |
+| Logs | `docker compose logs -f jupyterhub` |
+| Bigger simulations | raise `USER_CPU_LIMIT` / `USER_MEM_LIMIT` in `.env`, restart the hub (`USER_CPU_LIMIT` also sets `TI_NIFTI_WORKERS`/`OMP_NUM_THREADS` in user containers — pools size from `os.cpu_count()`, which ignores the cgroup quota) |
+
+Not for: `charm` head-model creation, recon-all, DWI — hours of CPU per subject.
+Users who need those run the toolbox locally.
+
+## Security notes
+
+- The hub container has the Docker socket: it is root-equivalent on the VM. Do not run
+  other tenants on the same host.
+- User containers run as root *inside* their container (the TI image assumes it), with no
+  access to the socket, the seed is mounted read-only, and their project is a private volume.
+- Keep `ALLOW_ALL_GITHUB_USERS=false` unless you accept unbounded compute usage.

--- a/deploy/jupyterhub/allowed_users.txt
+++ b/deploy/jupyterhub/allowed_users.txt
@@ -1,0 +1,2 @@
+# One GitHub login per line. Lines starting with # are ignored.
+# Admins from ADMIN_USERS in .env are always allowed.

--- a/deploy/jupyterhub/docker-compose.yml
+++ b/deploy/jupyterhub/docker-compose.yml
@@ -1,0 +1,59 @@
+# Hosted TI-Toolbox JupyterHub. See README.md.
+#   cp .env.example .env   # fill in
+#   docker compose build && docker compose up -d
+services:
+  jupyterhub:
+    build:
+      context: .
+      dockerfile: Dockerfile.hub
+    image: ti-toolbox-hub:latest
+    container_name: ti-toolbox-hub
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      DOCKER_NETWORK: tit-hub
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock   # DockerSpawner talks to the host daemon
+      - hub_data:/srv/jupyterhub/data
+      - ./allowed_users.txt:/srv/jupyterhub/allowed_users.txt:ro
+    ports:
+      - "${HUB_BIND:-127.0.0.1:8000}:8000"
+    networks:
+      - tit-hub
+
+  # Reverse proxy with automatic HTTPS. Requires HUB_DOMAIN to resolve to this host.
+  # Comment out (and set HUB_BIND=0.0.0.0:8000) if you terminate TLS elsewhere.
+  caddy:
+    image: caddy:2
+    container_name: ti-toolbox-caddy
+    restart: unless-stopped
+    profiles: ["tls"]
+    env_file: .env
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+    networks:
+      - tit-hub
+
+  # Build target only (never runs as a compose service): the per-user image.
+  singleuser:
+    platform: linux/amd64        # the TI image is amd64-only (emulated on Apple Silicon)
+    build:
+      context: ../..                       # repo root: copies tit/ and the example notebook in
+      dockerfile: deploy/jupyterhub/Dockerfile.singleuser
+      args:
+        TIT_IMAGE: ${TIT_IMAGE:-idossha/simnibs:v2.4.0}
+    image: ti-toolbox-singleuser:latest
+    profiles: ["build-only"]
+    command: ["true"]
+
+networks:
+  tit-hub:
+    name: tit-hub
+
+volumes:
+  hub_data:
+  caddy_data:

--- a/deploy/jupyterhub/jupyterhub_config.py
+++ b/deploy/jupyterhub/jupyterhub_config.py
@@ -1,0 +1,118 @@
+"""JupyterHub configuration for the hosted TI-Toolbox.
+
+Every user gets their own container from the TI-Toolbox image (built by
+Dockerfile.singleuser), a private project volume seeded from SEED_DIR on
+first start, and a CPU/memory cap. All knobs come from the environment —
+see .env.example and README.md.
+"""
+import os
+
+from dockerspawner import DockerSpawner
+from jupyterhub.auth import DummyAuthenticator
+
+c = get_config()  # noqa: F821
+
+def env(name, default=None):
+    return os.environ.get(name, default)
+
+# --------------------------------------------------------------------------
+# Hub
+# --------------------------------------------------------------------------
+c.JupyterHub.hub_ip = "0.0.0.0"
+c.JupyterHub.hub_connect_ip = "jupyterhub"     # service name in docker-compose
+c.JupyterHub.port = 8000
+c.JupyterHub.cookie_secret_file = "/srv/jupyterhub/data/cookie_secret"
+c.JupyterHub.db_url = "sqlite:////srv/jupyterhub/data/jupyterhub.sqlite"
+c.JupyterHub.cleanup_servers = False           # leave user servers up across hub restarts
+c.JupyterHub.allow_named_servers = False
+
+# --------------------------------------------------------------------------
+# Authentication: GitHub OAuth (production) or a dummy password (local test)
+# --------------------------------------------------------------------------
+_allowed = {
+    u.strip()
+    for u in open(env("ALLOWED_USERS_FILE", "/srv/jupyterhub/allowed_users.txt")).read().splitlines()
+    if u.strip() and not u.strip().startswith("#")
+} if os.path.exists(env("ALLOWED_USERS_FILE", "/srv/jupyterhub/allowed_users.txt")) else set()
+_admins = {u.strip() for u in env("ADMIN_USERS", "").split(",") if u.strip()}
+
+if env("HUB_AUTH", "github") == "dummy":
+    c.JupyterHub.authenticator_class = DummyAuthenticator
+    c.DummyAuthenticator.password = env("DUMMY_PASSWORD", "ti-toolbox")
+    c.Authenticator.allow_all = True
+else:
+    from oauthenticator.github import GitHubOAuthenticator
+    c.JupyterHub.authenticator_class = GitHubOAuthenticator
+    c.GitHubOAuthenticator.client_id = env("GITHUB_CLIENT_ID")
+    c.GitHubOAuthenticator.client_secret = env("GITHUB_CLIENT_SECRET")
+    c.GitHubOAuthenticator.oauth_callback_url = f"{env('HUB_URL').rstrip('/')}/hub/oauth_callback"
+    if env("ALLOW_ALL_GITHUB_USERS", "false").lower() == "true":
+        c.Authenticator.allow_all = True           # anyone with a GitHub account
+    else:
+        c.Authenticator.allowed_users = _allowed | _admins
+c.Authenticator.admin_users = _admins
+
+# --------------------------------------------------------------------------
+# Spawner: one TI-Toolbox container per user
+# --------------------------------------------------------------------------
+c.JupyterHub.spawner_class = DockerSpawner
+c.DockerSpawner.image = env("SINGLEUSER_IMAGE", "ti-toolbox-singleuser:latest")
+c.DockerSpawner.network_name = env("DOCKER_NETWORK", "tit-hub")
+c.DockerSpawner.use_internal_ip = True
+c.DockerSpawner.remove = True                  # container removed on stop; data lives in the volume
+c.DockerSpawner.prefix = "tit-user"
+c.DockerSpawner.cmd = ["/usr/local/bin/start-singleuser.sh"]
+c.DockerSpawner.notebook_dir = "/mnt"
+c.Spawner.default_url = "/lab"
+c.Spawner.http_timeout = 180                   # first start copies the ~1.5 GB seed
+c.Spawner.start_timeout = 300
+
+# Per-user project volume at /mnt/000 (seeded on first start), shared read-only seed at /seed.
+PROJECT_NAME = env("PROJECT_DIR_NAME", "000")
+c.DockerSpawner.volumes = {
+    "tit-project-{username}": f"/mnt/{PROJECT_NAME}",
+}
+if env("SEED_DIR"):
+    c.DockerSpawner.read_only_volumes = {env("SEED_DIR"): "/seed"}
+
+_cpus = max(1, int(float(env("USER_CPU_LIMIT", "2"))))
+c.DockerSpawner.environment = {
+    "PROJECT_DIR_NAME": PROJECT_NAME,
+    # Worker pools size themselves from os.cpu_count(), which ignores the cgroup
+    # quota; without these a 2-core container spawns 8 mesh->NIfTI workers and OOMs.
+    "TI_NIFTI_WORKERS": str(_cpus),
+    "OMP_NUM_THREADS": str(_cpus),
+    "LOCAL_PROJECT_DIR": f"/mnt/{PROJECT_NAME}",
+    "USER": "root",
+    "KMP_AFFINITY": "disabled",
+    "TI_TOOLBOX_VERSION": env("TI_TOOLBOX_VERSION", "hub"),
+    "TIT_HOST_OS": "jupyterhub",
+}
+
+# Resource caps per user
+c.DockerSpawner.cpu_limit = float(env("USER_CPU_LIMIT", "2"))   # also drives TI_NIFTI_WORKERS above
+c.DockerSpawner.mem_limit = env("USER_MEM_LIMIT", "10G")
+c.DockerSpawner.extra_host_config = {
+    "shm_size": "1g",
+}
+
+# --------------------------------------------------------------------------
+# Idle culler: stop servers idle for CULL_TIMEOUT seconds (default 1 h)
+# --------------------------------------------------------------------------
+c.JupyterHub.load_roles = [
+    {
+        "name": "jupyterhub-idle-culler-role",
+        "scopes": ["list:users", "read:users:activity", "read:servers", "delete:servers"],
+        "services": ["jupyterhub-idle-culler-service"],
+    }
+]
+c.JupyterHub.services = [
+    {
+        "name": "jupyterhub-idle-culler-service",
+        "command": [
+            "python3", "-m", "jupyterhub_idle_culler",
+            f"--timeout={env('CULL_TIMEOUT', '3600')}",
+            "--cull-every=300",
+        ],
+    }
+]

--- a/deploy/jupyterhub/make_seed.py
+++ b/deploy/jupyterhub/make_seed.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Build the seed project that every hub user starts from.
+
+Copies the minimum of an existing TI-Toolbox project needed to run the example
+notebook (anatomy + m2m head model + toolbox config) into SEED_DIR:
+
+    python3 make_seed.py /path/to/000 /srv/tit-seed/000 --subject ernie
+    python3 make_seed.py /path/to/000 /srv/tit-seed/000 --subject ernie --with-leadfields
+
+Size: ~1.5 GB (ernie), +3.3 GB with leadfields (needed for ex-search only).
+"""
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+def copy(src: Path, dst: Path, required: bool = True) -> None:
+    if not src.exists():
+        if required:
+            sys.exit(f"missing: {src}")
+        print(f"skip (absent): {src}")
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+    else:
+        shutil.copy2(src, dst)
+    print(f"copied {src} -> {dst}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("project", type=Path, help="existing project root (e.g. .../000)")
+    ap.add_argument("seed", type=Path, help="output seed directory (SEED_DIR in .env)")
+    ap.add_argument("--subject", default="ernie")
+    ap.add_argument("--with-leadfields", action="store_true", help="include derivatives/SimNIBS/sub-X/leadfields")
+    a = ap.parse_args()
+
+    src, dst, s = a.project, a.seed, a.subject
+    copy(src / "dataset_description.json", dst / "dataset_description.json")
+    copy(src / f"sub-{s}", dst / f"sub-{s}")
+    copy(src / "derivatives/SimNIBS" / f"sub-{s}" / f"m2m_{s}", dst / "derivatives/SimNIBS" / f"sub-{s}" / f"m2m_{s}")
+    copy(src / "code/ti-toolbox/config", dst / "code/ti-toolbox/config")
+    copy(src / "derivatives/ti-toolbox/dataset_description.json",
+         dst / "derivatives/ti-toolbox/dataset_description.json", required=False)
+    if a.with_leadfields:
+        copy(src / "derivatives/SimNIBS" / f"sub-{s}" / "leadfields", dst / "derivatives/SimNIBS" / f"sub-{s}" / "leadfields")
+    # A fresh project must not think it already ran things it did not.
+    status = dst / "code/ti-toolbox/config/project_status.json"
+    if status.exists():
+        status.write_text('{"example_data_copied": true}\n')
+    print("seed ready:", dst)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/jupyterhub/start-singleuser.sh
+++ b/deploy/jupyterhub/start-singleuser.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Seed the user's project volume on first start, then hand over to JupyterHub.
+set -euo pipefail
+
+# This checkout's tit/ (baked into the image) must shadow the base image's site-packages copy.
+export PYTHONPATH="/ti-toolbox:${PYTHONPATH:-}"
+
+PROJECT="/mnt/${PROJECT_DIR_NAME:-000}"
+SEED="/seed"
+
+if [ -d "$SEED" ] && [ ! -e "$PROJECT/dataset_description.json" ]; then
+    echo "[tit-hub] seeding $PROJECT from $SEED ..."
+    mkdir -p "$PROJECT"
+    cp -a "$SEED"/. "$PROJECT"/
+    echo "[tit-hub] seed complete"
+fi
+
+# The example notebook, ready to open (nbgitpuller keeps it in sync with main).
+mkdir -p /mnt/notebooks
+if [ -d /opt/tit-hub/notebooks ]; then
+    cp -n /opt/tit-hub/notebooks/*.ipynb /mnt/notebooks/ 2>/dev/null || true
+fi
+
+exec simnibs_python -m jupyterhub.singleuser \
+    --ServerApp.root_dir=/mnt \
+    --allow-root \
+    "$@"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,6 +31,9 @@ kramdown:
 # Google Analytics (enabled by default, disabled only when ENABLE_ANALYTICS=false is set)
 google_analytics: G-YMJPLLDT3Q
 
+# Hosted JupyterHub (deploy/jupyterhub). Leave empty to hide the "Run it in your browser" button.
+jupyterhub_url: ""
+
 # Exclude files
 exclude:
   - Gemfile

--- a/docs/wiki/example-notebook.md
+++ b/docs/wiki/example-notebook.md
@@ -8,6 +8,10 @@ permalink: /wiki/example-notebook/
 <a href="{{ site.baseurl }}/assets/notebooks/example_workflow.ipynb" download>&#11015; Download example_workflow.ipynb</a>
 &nbsp;&nbsp;
 <a href="https://github.com/idossha/TI-Toolbox/blob/main/docs/assets/notebooks/example_workflow.ipynb">View on GitHub</a>
+{% if site.jupyterhub_url %}
+&nbsp;&nbsp;
+<a href="{{ site.jupyterhub_url }}/hub/user-redirect/lab/tree/notebooks/example_workflow.ipynb"><strong>&#9654; Run it in your browser</strong></a> (hosted TI-Toolbox, GitHub login)
+{% endif %}
 </p>
 
 This page is a Jupyter notebook that was executed inside the TI-Toolbox container against Dataset 000 and exported as-is. Every output, table and figure below is real. Download the `.ipynb`, drop it into the container's JupyterLab (`NOTEBOOK`, then <http://localhost:8888>) and run it against your own project.


### PR DESCRIPTION
## Summary
- `deploy/jupyterhub/`: one VM runs JupyterHub; each GitHub-authenticated user gets their own container from the TI-Toolbox image, a private project volume seeded with `sub-ernie` (`make_seed.py`, ~1.5 GB), and the `SimNIBS + TI-Toolbox` kernel. Caddy TLS, idle culler (1 h), per-user CPU/memory caps (2 / 10 GB), README with setup, sizing, ops and security notes.
- The per-user image builds from the repo root so it carries this checkout's `tit/` and `docs/assets/notebooks/example_workflow.ipynb` — the published image imports `tit` 2.4.0 from site-packages (no `output_fields`).
- Spawner sets `TI_NIFTI_WORKERS` / `OMP_NUM_THREADS` to the CPU cap: the mesh→NIfTI pool sizes from `os.cpu_count()` (ignores the cgroup quota) and OOM-killed a 6 GB container with 8 workers.
- Docs: `jupyterhub_url` in `_config.yml` gates a "▶ Run it in your browser" button on the Example Notebook page (hidden while empty). These two bits were removed from `main` in fc298a12 and return here with the deployment.

## Test plan
- [x] Local smoke test with `HUB_AUTH=dummy`: login → spawn → JupyterLab → `simnibs` kernel → seeded `/mnt/000` → deep link `/hub/user-redirect/lab/tree/notebooks/example_workflow.ipynb` → idle culler polling
- [x] Full example notebook executed inside the spawned container under the 2-core / 10 GB caps (734 s, both figures, `oom_kill 0`)
- [ ] Production: VM + DNS + GitHub OAuth app, `make_seed.py`, `docker compose --profile tls up -d`, then set `jupyterhub_url` in `docs/_config.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvazZqBQS5fJGY5VgAa1q3