### PR TITLE
Share EEG, source and graph analysis functions for notebook workflows

### DIFF
--- a/desktop/tests/unit/optimizer-roi.test.ts
+++ b/desktop/tests/unit/optimizer-roi.test.ts
@@ -70,9 +70,10 @@ describe("exTargets", () => {
     expect(targets).toHaveLength(1);
     expect(targets[0]?.roiName).toBe("CIT168_2regions");
     expect(targets[0]?.roiNames).toEqual([]);
+    // CircleCI 985: resolved atlas targets also retain their coordinate frame.
     expect(targets[0]?.roiAtlas).toEqual([
-      { atlas_path: "/atlases/CIT168.nii.gz", label: 10 },
-      { atlas_path: "/atlases/CIT168.nii.gz", label: 11 },
+      { atlas_path: "/atlases/CIT168.nii.gz", label: 10, atlas_space: "subject" },
+      { atlas_path: "/atlases/CIT168.nii.gz", label: 11, atlas_space: "subject" },
     ]);
   });
 

--- a/docs/assets/notebooks/eeg_workflow.ipynb
+++ b/docs/assets/notebooks/eeg_workflow.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "320cd155",
+   "metadata": {},
+   "source": [
+    "# TI-Toolbox EEG and field workflow\n",
+    "\n",
+    "Start with the fully synthetic checks below. The second part is a real-data workflow and deliberately stops unless `TIT_WORKFLOW_CONFIG` names an explicit external configuration. Select the TI-Toolbox/SimNIBS kernel for that part. This notebook ships without outputs or participant data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98ec0b92",
+   "metadata": {},
+   "source": [
+    "# Synthetic EEG, field and graph examples\n",
+    "\n",
+    "Run with a kernel containing the current TI-Toolbox, NumPy, SciPy and MNE. An installed toolbox is preferred; `TIT_SOURCE_DIR` may explicitly name a development checkout.\n",
+    "\n",
+    "Everything here is generated in memory. No participant files, head models, downloads or output files are needed. The 256 permutations are a quick teaching example, not the settings used in the sleep study. The study modules remain responsible for cohort selection, event detection, contrasts, masks and inference families."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b03f7310",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "import sys\n",
+    "\n",
+    "# Use an installed TI-Toolbox, or explicitly select a development checkout.\n",
+    "if os.environ.get(\"TIT_SOURCE_DIR\"):\n",
+    "    toolbox_source = Path(os.environ[\"TIT_SOURCE_DIR\"]).expanduser().resolve()\n",
+    "    if not (toolbox_source / \"tit\").is_dir():\n",
+    "        raise FileNotFoundError(\"TIT_SOURCE_DIR must contain the tit package\")\n",
+    "    sys.path.insert(0, str(toolbox_source))\n",
+    "\n",
+    "import numpy as np\n",
+    "from scipy import sparse\n",
+    "from tit.fields import carrier_metrics\n",
+    "from tit.atlas.surface import parcel_means\n",
+    "from tit.stats.graph import cluster_permutation, correlation_cluster_permutation\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cd5d203",
+   "metadata": {},
+   "source": [
+    "## Carrier vectors and parcel summaries\n",
+    "\n",
+    "At each of six vertices, both carrier vectors and the unit normal share one coordinate frame. Parallel, orthogonal and opposing pairs repeat twice. `hf_peak` is the worst-case carrier magnitude in V/m; `hf_sar` is a field-squared heating proxy, not calibrated SAR. `TI_normal` is the surface-normal envelope summary for two carriers.\n",
+    "\n",
+    "Parcel labels align with the final vertex axis. These are two synthetic parcels, not an anatomical atlas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "613519a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e1 = np.tile([1.0, 0.0, 0.0], (6, 1))\n",
+    "e2 = np.array([[0.5, 0, 0], [0, 1, 0], [-0.5, 0, 0]] * 2, dtype=float)\n",
+    "normals = np.tile([1.0, 0.0, 0.0], (6, 1))\n",
+    "fields = carrier_metrics([e1, e2], normals=normals)\n",
+    "\n",
+    "# Independent geometric expectations, rather than copied implementation output.\n",
+    "np.testing.assert_allclose(fields[\"hf_peak\"], [1.5, np.sqrt(2), 1.5] * 2)\n",
+    "np.testing.assert_allclose(fields[\"hf_sar\"], [1.25, 2.0, 1.25] * 2)\n",
+    "np.testing.assert_allclose(fields[\"TI_normal\"], [1.0, 0.0, 1.0] * 2)\n",
+    "labels = np.array([0, 0, 0, 1, 1, 1])\n",
+    "means, region_ids = parcel_means(fields[\"hf_peak\"], labels)\n",
+    "np.testing.assert_array_equal(region_ids, [0, 1])\n",
+    "np.testing.assert_allclose(means, [(3 + np.sqrt(2)) / 3] * 2)\n",
+    "print(\"Carrier and parcel checks passed.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e9c6892",
+   "metadata": {},
+   "source": [
+    "## Participant-level graph inference\n",
+    "\n",
+    "Rows represent independent synthetic participants; columns represent the six vertices. The line graph defines spatial neighbors. A paired-change test flips participant rows, and the field–response test permutes complete response rows. Each call controls its own graph family; it does not jointly correct the two demonstrations.\n",
+    "\n",
+    "The first three vertices receive a strong simulated effect. Statistical maps describe this toy example only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f80c9dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(314)\n",
+    "adjacency = sparse.diags([np.ones(5), np.ones(5)], [-1, 1], shape=(6, 6), format=\"csr\")\n",
+    "changes = rng.normal(0, 0.25, size=(24, 6))\n",
+    "changes[:, :3] += 2.5\n",
+    "paired = cluster_permutation(\n",
+    "    changes, adjacency, statistic=\"t\", n_permutations=256, seed=42,\n",
+    "    threshold_p=0.05, alpha=0.05, tail=0, sign_policy=\"separate\",\n",
+    ")\n",
+    "assert paired.significant_mask[:3].all()\n",
+    "assert paired.null_distribution.shape == (256,)\n",
+    "\n",
+    "exposure = rng.normal(size=(24, 6))\n",
+    "response = rng.normal(size=(24, 6))\n",
+    "response[:, :3] = exposure[:, :3] + rng.normal(0, 0.1, size=(24, 3))\n",
+    "association = correlation_cluster_permutation(\n",
+    "    exposure, response, adjacency, method=\"spearman\",\n",
+    "    n_permutations=256, seed=43, threshold_p=0.05, alpha=0.05,\n",
+    ")\n",
+    "assert association.significant_mask[:3].all()\n",
+    "assert np.all((association.pvalues >= 0) & (association.pvalues <= 1))\n",
+    "print(\"Paired graph p-values:\", paired.pvalues)\n",
+    "print(\"Correlation graph p-values:\", association.pvalues)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adf1c691",
+   "metadata": {},
+   "source": [
+    "## MNE events and explicit interval boundaries\n",
+    "\n",
+    "This synthetic recording has a nonzero first sample. The generic annotation helper returns seconds relative to the first stored sample. Comparison windows are constructed explicitly; the helper does not remove artifacts, restore deleted time or clip intervals to the recording. These decisions belong to the analysis.\n",
+    "\n",
+    "For real recordings, preserve the same MNE metadata and supply the actual markers and interval policy. Do not substitute these toy markers or durations into a study."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2ec7b2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mne\n",
+    "from tit.eeg import annotation_pairs, stimulation_windows\n",
+    "from tit.source.reconstruction import epochs_from_intervals, diffusion_smoother\n",
+    "\n",
+    "info = mne.create_info([\"Fp1\", \"Fp2\", \"Cz\", \"Pz\"], sfreq=100.0, ch_types=\"eeg\")\n",
+    "raw = mne.io.RawArray(rng.normal(0, 1e-6, (4, 1000)), info, first_samp=500, verbose=False)\n",
+    "raw.set_annotations(mne.Annotations([2.0, 4.0], [0.0, 0.0], [\"example start\", \"example end\"]))\n",
+    "pairs = annotation_pairs(raw, \"example start\", \"example end\", relative_to_raw=True)\n",
+    "np.testing.assert_allclose(pairs, [(2.0, 4.0)])\n",
+    "windows = stimulation_windows(pairs, pre_duration=1.0, post_duration=1.0)\n",
+    "assert (windows[0].pre_start_sec, windows[0].post_end_sec) == (1.0, 5.0)\n",
+    "noise_epochs = epochs_from_intervals(raw, [(0.0, 2.0)], epoch_duration=1.0)\n",
+    "assert len(noise_epochs) == 2\n",
+    "np.testing.assert_array_equal(noise_epochs.events[:, 0], [500, 600])\n",
+    "\n",
+    "# Neighbor averaging must preserve a constant surface map.\n",
+    "smoother = diffusion_smoother(adjacency, n_iters=2)\n",
+    "np.testing.assert_allclose(smoother @ np.ones(6), np.ones(6))\n",
+    "print(\"MNE timing, interval and smoothing checks passed.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "818f7e9b",
+   "metadata": {},
+   "source": [
+    "## Continue with actual data\n",
+    "\n",
+    "Open `02_models_projection_source.ipynb` in the TI-Toolbox/SimNIBS kernel when you have explicit input files and approved configuration. The generic functions above do not select sleep stages, detect slow waves, define origin/involvement, or choose study contrasts. Keep those choices in the study modules; avoid copying their scientific settings into notebook cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "312c5c4e",
+   "metadata": {},
+   "source": [
+    "# Head model → simulation → projection → EEG source windows\n",
+    "\n",
+    "This notebook calls TI-Toolbox directly inside its SimNIBS environment. It can run structural preprocessing, configured FEM simulations, a recording-aligned EEG forward model, carrier projection and explicit inverse windows. It does not invent a montage, current, coordinate transform, reference, frequency band or event selection.\n",
+    "\n",
+    "Set `TIT_WORKFLOW_CONFIG` to an external JSON file. Paths in that file are absolute or relative to the JSON's directory. Keep subject metadata, recordings and derived outputs outside the source repository. Running these cells performs the selected work; preprocessing and FEM can take substantial time.\n",
+    "\n",
+    "The required JSON keys are:\n",
+    "\n",
+    "- `project_root`, `subject_id` (without `sub-`), `head_model_dir`.\n",
+    "- `preprocessing`: explicit `run_pipeline` keyword arguments, or `null` to reuse the supplied existing head model.\n",
+    "- `simulation_config_json`: a saved serialized `SimulationConfig`; `simulation_overwrite`: explicit boolean.\n",
+    "- `forward_config_json`: a saved serialized `ForwardConfig`; `recording_fif`: prepared MNE recording; `trans_fif`: supplied head-to-MRI transform or `null` to use the recording's digitized fiducials; `forward_output_dir`.\n",
+    "- `carrier_meshes`: explicit list of carrier E-vector mesh paths; `fsaverage_spacing`; `projected_fields_npz`.\n",
+    "- `source`: `noise_intervals_seconds`, `exclusions_seconds`, `epoch_duration_seconds`, `covariance_method`, `rank`, `loose`, `depth`, `peak_samples_npy`, `offset_samples_npy`, `lambda2`, `method`, `pick_ori`, `output_npz`.\n",
+    "\n",
+    "Use serialized configs from your actual project. The notebook requires all simulation/forward config fields to be present, so omitted scientific settings cannot silently acquire library defaults. The recording must already carry the intended filtering, reference, bad-channel annotations and digitization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1fa6a2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "manifest_name = os.environ.get(\"TIT_WORKFLOW_CONFIG\")\n",
+    "if not manifest_name:\n",
+    "    raise RuntimeError(\"Set TIT_WORKFLOW_CONFIG to your external workflow JSON before running real-data cells.\")\n",
+    "manifest = Path(manifest_name).expanduser().resolve()\n",
+    "if not manifest.is_file():\n",
+    "    raise FileNotFoundError(f\"Workflow JSON not found: {manifest}\")\n",
+    "job = json.loads(manifest.read_text())\n",
+    "required = {\"project_root\", \"subject_id\", \"head_model_dir\", \"preprocessing\",\n",
+    "            \"simulation_config_json\", \"simulation_overwrite\", \"forward_config_json\",\n",
+    "            \"recording_fif\", \"trans_fif\", \"forward_output_dir\", \"carrier_meshes\",\n",
+    "            \"fsaverage_spacing\", \"projected_fields_npz\", \"source\"}\n",
+    "if missing := required - job.keys():\n",
+    "    raise ValueError(f\"Workflow JSON is missing keys: {sorted(missing)}\")\n",
+    "\n",
+    "def resolve_path(value):\n",
+    "    path = Path(value).expanduser()\n",
+    "    return (path if path.is_absolute() else manifest.parent / path).resolve()\n",
+    "\n",
+    "project_root = resolve_path(job[\"project_root\"])\n",
+    "if not project_root.is_dir():\n",
+    "    raise FileNotFoundError(f\"Project root not found: {project_root}\")\n",
+    "subject_id = str(job[\"subject_id\"])\n",
+    "if not subject_id or subject_id.startswith(\"sub-\"):\n",
+    "    raise ValueError(\"subject_id must be the explicit bare subject label (without sub-)\")\n",
+    "head_model = resolve_path(job[\"head_model_dir\"])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95cff0ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "import sys\n",
+    "\n",
+    "# Use an installed TI-Toolbox, or explicitly select a development checkout.\n",
+    "if os.environ.get(\"TIT_SOURCE_DIR\"):\n",
+    "    toolbox_source = Path(os.environ[\"TIT_SOURCE_DIR\"]).expanduser().resolve()\n",
+    "    if not (toolbox_source / \"tit\").is_dir():\n",
+    "        raise FileNotFoundError(\"TIT_SOURCE_DIR must contain the tit package\")\n",
+    "    sys.path.insert(0, str(toolbox_source))\n",
+    "\n",
+    "from dataclasses import fields as dataclass_fields\n",
+    "import inspect\n",
+    "import numpy as np\n",
+    "import mne\n",
+    "from tit.paths import reset_path_manager, get_path_manager\n",
+    "from tit.config_io import deserialize_config\n",
+    "from tit.pre import run_pipeline\n",
+    "from tit.sim import SimulationConfig, run_simulation\n",
+    "from tit.source import ForwardConfig, prepare_forward, project_carrier_fields\n",
+    "from tit.source.reconstruction import covariance_from_intervals, prepare_inverse, apply_inverse_windows\n",
+    "\n",
+    "# Select this explicitly supplied project for the current notebook kernel.\n",
+    "reset_path_manager()\n",
+    "pm = get_path_manager(str(project_root))\n",
+    "if Path(pm.m2m(subject_id)).resolve() != head_model:\n",
+    "    raise ValueError(\"run_simulation uses the selected project's m2m directory; \"\n",
+    "                     \"head_model_dir must refer to that same model for this workflow\")\n",
+    "\n",
+    "def read_config(cls, filename):\n",
+    "    contents = json.loads(resolve_path(filename).read_text())\n",
+    "    expected = {field.name for field in dataclass_fields(cls) if field.init}\n",
+    "    if missing := expected - contents.keys():\n",
+    "        raise ValueError(f\"Supply a complete serialized {cls.__name__}: missing {sorted(missing)}\")\n",
+    "    return deserialize_config(cls, contents, strict=True)\n",
+    "\n",
+    "simulation_config = read_config(SimulationConfig, job[\"simulation_config_json\"])\n",
+    "forward_config = read_config(ForwardConfig, job[\"forward_config_json\"])\n",
+    "if simulation_config.subject_id.removeprefix(\"sub-\") != subject_id:\n",
+    "    raise ValueError(\"Workflow and simulation config identify different subjects\")\n",
+    "if type(job[\"simulation_overwrite\"]) is not bool:\n",
+    "    raise ValueError(\"simulation_overwrite must be an explicit JSON boolean\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62eb140d",
+   "metadata": {},
+   "source": [
+    "## Build or reuse the supplied head model\n",
+    "\n",
+    "A `null` preprocessing configuration explicitly requests reuse and verifies the directory exists. Otherwise, at least one preprocessing step must be selected. `run_pipeline` uses the chosen TI-Toolbox project layout; the supplied `head_model_dir` must point to its intended output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53d6d29a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preprocessing = job[\"preprocessing\"]\n",
+    "if preprocessing is None:\n",
+    "    if not head_model.is_dir():\n",
+    "        raise FileNotFoundError(f\"Requested existing head model is absent: {head_model}\")\n",
+    "    print(\"Using the supplied existing head model; no preprocessing was requested.\")\n",
+    "else:\n",
+    "    step_names = (\"convert_dicom\", \"create_m2m\", \"run_fastsurfer\", \"run_freesurfer\",\n",
+    "                  \"run_tissue_analysis\", \"run_qsiprep\", \"run_qsirecon\", \"extract_dti\")\n",
+    "    if not isinstance(preprocessing, dict) or not any(preprocessing.get(k) is True for k in step_names):\n",
+    "        raise ValueError(\"Select at least one preprocessing step, or set preprocessing to null.\")\n",
+    "    inspect.signature(run_pipeline).bind([subject_id], **preprocessing)\n",
+    "    status = run_pipeline([subject_id], **preprocessing)\n",
+    "    if status != 0:\n",
+    "        raise RuntimeError(f\"Structural pipeline failed with status {status}\")\n",
+    "    if not head_model.is_dir():\n",
+    "        raise FileNotFoundError(f\"Configured head-model output was not produced: {head_model}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "385ffdd7",
+   "metadata": {},
+   "source": [
+    "## Simulate the saved montage and current configuration\n",
+    "\n",
+    "The serialized configuration is the authority for electrode geometry, conductivities and delivered currents. No stimulation settings are supplied by this notebook. Inspect the returned simulation results before selecting the explicit carrier meshes used below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a292421",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simulation_results = run_simulation(simulation_config, overwrite=job[\"simulation_overwrite\"])\n",
+    "if not simulation_results:\n",
+    "    raise RuntimeError(\"Simulation returned no results\")\n",
+    "simulation_results\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faefb8aa",
+   "metadata": {},
+   "source": [
+    "## Prepare the forward solution with recording metadata\n",
+    "\n",
+    "The recorded `Info` supplies channel identities and digitization. A supplied head-to-MRI transform takes precedence; otherwise TI-Toolbox uses the recording's fiducials. This cell does not estimate a guessed transform or substitute a generic EEG cap for missing recording metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27e03031",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording_path = resolve_path(job[\"recording_fif\"])\n",
+    "if not recording_path.is_file():\n",
+    "    raise FileNotFoundError(f\"Prepared recording not found: {recording_path}\")\n",
+    "raw = mne.io.read_raw_fif(recording_path, preload=True, verbose=False)\n",
+    "trans = None if job[\"trans_fif\"] is None else mne.read_trans(resolve_path(job[\"trans_fif\"]))\n",
+    "forward_path, source_path, morph_path = prepare_forward(\n",
+    "    subject_id, forward_config,\n",
+    "    output_dir=resolve_path(job[\"forward_output_dir\"]), head_model_dir=head_model,\n",
+    "    info=raw.info, trans=trans,\n",
+    ")\n",
+    "assert all(Path(path).is_file() for path in (forward_path, source_path, morph_path))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fefbe36",
+   "metadata": {},
+   "source": [
+    "## Project the explicit carrier vector fields\n",
+    "\n",
+    "Carrier vectors are interpolated onto a common native central surface, combined there, then scalar summaries are morphed to fsaverage. The output concatenates left then right hemisphere vertices. This preserves the order of vector operations; it is not equivalent to combining independently morphed scalar magnitudes. No projected file is silently overwritten."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b851cd4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "carrier_meshes = [resolve_path(path) for path in job[\"carrier_meshes\"]]\n",
+    "if len(carrier_meshes) < 2 or not all(path.is_file() for path in carrier_meshes):\n",
+    "    raise FileNotFoundError(\"Supply at least two existing carrier E-vector meshes\")\n",
+    "projected_path = resolve_path(job[\"projected_fields_npz\"])\n",
+    "if projected_path.exists():\n",
+    "    raise FileExistsError(f\"Choose a new output path or explicitly remove the prior output: {projected_path}\")\n",
+    "projected = project_carrier_fields(carrier_meshes, head_model, spacing=job[\"fsaverage_spacing\"])\n",
+    "projected_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "np.savez_compressed(projected_path, **projected)\n",
+    "print(\"Projected fields:\", {name: values.shape for name, values in projected.items()})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4609f97a",
+   "metadata": {},
+   "source": [
+    "## Reconstruct explicitly selected EEG windows\n",
+    "\n",
+    "Noise intervals and exclusions are seconds relative to the stored recording. Peak indices and offsets are integer samples on that same recording, after all intended resampling. They are supplied externally; this notebook does not detect or merge events. The source result retains vertex × event × time dimensions (plus orientation when requested). Choose inverse parameters in the external configuration.\n",
+    "\n",
+    "Origin/involvement rules, sleep-stage selection, historical timing conventions, outcome definitions and statistical families remain in study modules. Do not treat this generic reconstruction as a replacement for those adapters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72a6613d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source = job[\"source\"]\n",
+    "noise_cov = covariance_from_intervals(\n",
+    "    raw, source[\"noise_intervals_seconds\"], exclusions=source[\"exclusions_seconds\"],\n",
+    "    epoch_duration=source[\"epoch_duration_seconds\"], method=source[\"covariance_method\"],\n",
+    "    rank=source[\"rank\"], legacy_sampling=False, reject_by_annotation=True,\n",
+    ")\n",
+    "forward = mne.read_forward_solution(forward_path, verbose=False)\n",
+    "inverse = prepare_inverse(raw.info, forward, noise_cov, loose=source[\"loose\"],\n",
+    "                          depth=source[\"depth\"], rank=source[\"rank\"])\n",
+    "peak_samples = np.load(resolve_path(source[\"peak_samples_npy\"]), allow_pickle=False)\n",
+    "offsets = np.load(resolve_path(source[\"offset_samples_npy\"]), allow_pickle=False)\n",
+    "morph = mne.read_source_morph(morph_path)\n",
+    "source_windows = apply_inverse_windows(\n",
+    "    raw.get_data(), raw.info, inverse, peak_samples, offsets,\n",
+    "    lambda2=source[\"lambda2\"], method=source[\"method\"], pick_ori=source[\"pick_ori\"], morph=morph,\n",
+    ")\n",
+    "source_output = resolve_path(source[\"output_npz\"])\n",
+    "if source_output.exists():\n",
+    "    raise FileExistsError(f\"Choose a new source output path: {source_output}\")\n",
+    "source_output.parent.mkdir(parents=True, exist_ok=True)\n",
+    "np.savez_compressed(source_output, source_windows=source_windows,\n",
+    "                    peak_samples=peak_samples, offset_samples=offsets,\n",
+    "                    sfreq=raw.info[\"sfreq\"])\n",
+    "print(\"Source-window shape:\", source_windows.shape)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (TI-Toolbox environment)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -552,3 +552,14 @@ FastSurfer and FreeSurfer thread preferences live in the shared user configurati
 
 
 Settings groups project preferences, preprocessing defaults, extensions, viewer management, and server details into horizontal tabs. Inactive panels retain unsaved drafts. The preprocessing page selects stages; FreeSurfer operation defaults and reconstruction/QSI resources are edited in Settings and resolved into each submitted configuration.
+
+
+## 13. Reusable EEG and array analysis
+
+Generic EEG processing lives in `tit.eeg` and `tit.source.reconstruction`; forward construction accepts explicit recording Info or a head-to-MRI transform. Explicit paths support external dataset layouts. Cohorts, slow-wave definitions, outcomes, contrasts, and figure composition stay in downstream study repositories.
+
+`tit.stats.graph`, `associations`, `effects` and `robustness` accept participant-by-feature arrays and sparse adjacency without importing FEM, plotting or EEG packages. The graph default keeps opposite signs separate. Published compatibility policies are explicit parameters; a migrated study must retain its original thresholds, seeds, mass, rank-score and sampling policies until a separately reviewed reanalysis.
+
+`tit.fields.carrier_metrics` computes carrier and normal-envelope quantities in native space before scalar cortical morphing. `tit.source.fsaverage` supports explicit mesh/head-model paths and canonical left-then-right outputs. `tit.atlas.surface` aligns explicit vertex identities and reduces parcels with a declared weighting/NaN policy. Projection cache reuse requires matching input fingerprints, settings and all requested fields; pre-provenance caches are regenerated.
+
+Notebooks call these Python functions and existing head-model/simulation APIs. They do not introduce a parallel orchestration framework. Synthetic validation and participant/FEM reproduction are distinct gates; see [requirements](../requirements/2026-09-13-eeg-study-consolidation.md).

--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -9,6 +9,11 @@ Detailed technical changelog for all versions of the Temporal Interference Toolb
 ---
 ### v3.0.0 (Unreleased)
 
+- EEG and other graph-based studies can call shared channel/event preparation, inverse-window reconstruction, seeded cluster inference, associations, robustness, and parcel reduction functions from Python notebooks. Published downstream statistical choices remain explicit.
+- Forward construction accepts recording fiducials or an explicit transform. Completed carrier simulations can be projected through explicit mesh/head-model paths, calculating nonlinear metrics before scalar morphing.
+- Cortical projection caches require matching input fingerprints, runtime versions, settings and requested fields. Older, partial or interrupted caches are recomputed rather than silently reused.
+- New array statistics treat fully explained partial correlations as undefined, ignore stored zero graph edges, and mark singular moderation bootstrap draws invalid with a reported valid fraction. Downstream published bootstrap behavior requires an explicit compatibility policy.
+
 - Canvas edits preserve complete saved scientific configurations. Montage selection uses real catalog definitions; invalid drafts block actions, and undo/redo restores matching forms.
 - Notebook export writes ordered calls to existing scientific functions with full inputs. Canvas dynamic bindings use specific producer results per subject and isolated run files instead of historical output scans.
 

--- a/docs/dev/DECISIONS.md
+++ b/docs/dev/DECISIONS.md
@@ -686,3 +686,14 @@ form tests must prove settings survive page and node edits without duplicate sta
 
 **Revisit if:** an existing scientific function cannot express a supported job configuration;
 report that limitation rather than creating notebook-specific science.
+
+
+## 2026-09-13 — Reusable EEG and array analysis (architecture §13)
+
+**Decision:** Extract array statistics, EEG preparation, inverse-window reconstruction and surface projection/atlas utilities from sleepTI into callable `tit` modules. Keep the published study's explicit policies and all cohort/outcome/figure logic downstream. Reuse existing modeling and simulation APIs in notebooks.
+
+**Why:** Future EEG studies can share tested calculations without inheriting a sleep protocol. Explicit compatibility prevents a code move from silently becoming a scientific reanalysis.
+
+**Cost:** The downstream study depends on a pinned toolbox revision and retains thin compatibility adapters. Real-library numerical tests supplement host mocks. Full FEM and participant-data reproduction require the approved dataset and a compatible runtime.
+
+**Revisit if:** Another study needs a genuinely different data model, or a deliberate reanalysis replaces a published policy. Avoid expanding these modules into a new study framework.

--- a/docs/dev/ROADMAP.md
+++ b/docs/dev/ROADMAP.md
@@ -10,6 +10,7 @@ The internal image is published on Docker Hub; manual acceptance continues. No s
 
 | Remaining acceptance work | Completion criterion |
 |---|---|
+| EEG consolidation reproduction | Run notebook modeling/projection/source stages on approved data in the compatible container; compare manuscript tables before promoting the migration |
 | Manual workflow testing | Colleagues exercise representative copied projects and report output/result behavior |
 | Rebuild the distribution candidate | Bake current source, renderer and compatible Tetravox embed; record immutable identities |
 | Clean image and loader acceptance | Test without checkout mounts; verify Python/Bash launchers, packaged cross-project Attach/Recreate, project switching and Electron close-stop on each supported host |

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -196,3 +196,22 @@ Verified on 2026-09-10: 20 focused desktop tests and 54 backend tests passed (on
 ### GPU-preferred container acceptance
 
 Run `python3 -m pytest tests/test_launch_gpu.py tests/test_launch.py tests/test_bash_loader_lifecycle.py tests/test_pre_fastsurfer.py tests/test_native_fastsurfer.py -q` for launcher and job selection. Desktop GPU probe cases are in `src/main/docker/gpu.test.ts`. The image's `verify_runtime.py` rejects CPU-only PyTorch and validates the scientific ABI. A build-time CUDA version assertion proves packaging only: an NVIDIA host must also run the same-image launcher probe and a real FastSurfer job to prove GPU execution. Apple Silicon validates the unavailable-CUDA and native fallback routes.
+
+
+## EEG consolidation
+
+Independent small-array tests are in `tests/numerical/test_eeg_array_stats.py`, `test_eeg_fields.py`, and `test_eeg_source.py`. Run them with a real NumPy/SciPy/MNE stack:
+
+```sh
+python -m pytest tests/numerical/test_eeg_array_stats.py tests/numerical/test_eeg_fields.py tests/numerical/test_eeg_source.py -q
+```
+
+The source tests isolate MNE from host-suite mocks in a subprocess; `TIT_EEG_TEST_PYTHON` selects a compatible real-MNE interpreter. They compare actual MNE operations, authored array/graph expectations and exhaustive or independently generated permutation cases. Downstream snapshot parity reads the pre-migration Git tag rather than distributing private source snapshots.
+
+Native macOS checks do not establish Linux container path behavior. The installed SimNIBS 4.6 interpreter currently combines MNE 1.5 with NumPy 2; some MNE covariance/coregistration paths fail in that combination. The source numerical leg passes with the study's real MNE 1.12.1 interpreter. No participant-data or FEM rerun is claimed; the study drive was unavailable during extraction. The synthetic notebook demonstrates API execution only.
+
+2026-09-13 branch verification: 4,886 host tests passed, 48 environment-dependent
+skips; 40 EEG numerical/parity tests passed with both study tags supplied.
+The route import guard passed all 27 routes, and contracts_check passed with
+247 existing schema warnings. These counts cover the extraction on this branch;
+they do not establish hosted CI or a new container image.

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -215,3 +215,10 @@ skips; 40 EEG numerical/parity tests passed with both study tags supplied.
 The route import guard passed all 27 routes, and contracts_check passed with
 247 existing schema warnings. These counts cover the extraction on this branch;
 they do not establish hosted CI or a new container image.
+
+CircleCI desktop run 985 exposed a pre-existing stale atlas-target assertion:
+the unchanged optimizer returns the declared `atlas_space`, but the fixture
+omitted it. The failure reproduced locally on the identical baseline desktop
+tree. After correcting that assertion, all 1,739 desktop unit tests passed
+locally (146 files). This is a test-only correction; the pinned scientific
+implementation remains commit `2124ba401ba93badaafce57bacfaff5138306436`.

--- a/docs/requirements/2026-09-13-eeg-study-consolidation.md
+++ b/docs/requirements/2026-09-13-eeg-study-consolidation.md
@@ -1,0 +1,18 @@
+# EEG study consolidation — 2026-09-13
+
+[Architecture §13](../dev/ARCHITECTURE.md#13-reusable-eeg-and-array-analysis) owns the ongoing contract. This records the requested scope and acceptance evidence; [testing](../dev/TESTING.md) owns runtime limits.
+
+The user requested a branch that moves reusable study functions into TI-Toolbox, with notebooks calling its modeling, simulation, cortical projection, source and cluster APIs. Study-specific outcomes, cohorts, figure composition and scientific contrasts remain downstream. The sleepTI pre-migration state is preserved as `v1.0-preliminary`.
+
+| Requirement | Gate |
+|---|---|
+| Reusable functions accept arrays, explicit paths and settings | Pure graph/association/effect/atlas imports; no study paths or participant files |
+| Preserve published calculations in downstream adapters | Frozen `v1.0-preliminary` synthetic parity, including null distributions, confidence intervals, source scoring and event policy |
+| Safe defaults for new studies | Signed clusters remain separate; zero handling, rank-score convention, sampling and fiducial choices explicit |
+| Reuse existing modeling and simulation APIs | Notebook imports/cells call existing preprocessing and simulation functions |
+| Compute nonlinear field metrics before scalar morph | Independent cancellation fixture plus manual carrier-vector expectations |
+| Do not reuse incomplete/stale projection caches | Required-field and SHA-256 input provenance tests |
+| Notebook entrypoints are readable and contain no participant data | Valid output-free notebooks; execute the synthetic notebook |
+| Full scientific reproduction remains separate | Rerun approved participant data in a compatible SimNIBS/MNE container before claiming manuscript numerical reproduction |
+
+No REST, desktop, job schema or public release changes are requested. No dataset or FEM rerun is inferred from passing small-array tests.

--- a/docs/wiki/scripting.md
+++ b/docs/wiki/scripting.md
@@ -452,3 +452,28 @@ Config files are generated programmatically via `tit.config_io.write_config_json
 Full guide: [AI Assistant]({{ site.baseurl }}/wiki/ai-assistant/).
 
 If you write scripts with an AI assistant (Claude Code, Codex, Cursor, ...), install the [TI-Toolbox agent plugin](https://github.com/idossha/TI-Toolbox/tree/main/agent-plugin). It gives the assistant this wiki, the `tit` source and a read-only view of your project directory through an MCP server, so it stops guessing API fields. In Claude Code: `/plugin marketplace add idossha/TI-Toolbox` then `/plugin install ti-toolbox@ti-toolbox`.
+
+## EEG and graph-analysis notebooks
+
+The [EEG workflow notebook]({{ site.baseurl }}/assets/notebooks/eeg_workflow.ipynb)
+contains a data-free numerical example followed by explicit head-model, simulation,
+projection and source calls. Copy it into your project's
+`code/ti-toolbox/notebooks/` directory to open it in the toolbox Notebooks page.
+The real-data section requires external configurations and prepared recordings.
+Use a compatible MNE/SimNIBS kernel; MNE 1.12.1 is the validated numerical stack
+for the new reconstruction functions. No private dataset is bundled.
+
+| Task | Python API |
+|---|---|
+| Channels, event pairs and interval construction | `tit.eeg` |
+| Covariance, inverse windows, graph smoothing | `tit.source.reconstruction` |
+| Recording-aligned forward/FEM preparation | `tit.source.prepare_forward` |
+| Native carrier metrics and cortical projection | `tit.fields.carrier_metrics`, `tit.source.project_carrier_fields` |
+| Atlas labels and parcel means | `tit.atlas.surface` |
+| Seeded sensor/source graph inference | `tit.stats.graph` |
+| Partial correlations, declared FDR families, rank moderation | `tit.stats.associations` |
+| Effect intervals and participant influence | `tit.stats.effects`, `tit.stats.robustness` |
+
+Array functions do not choose your cohort, outcome, contrasts or correction family.
+A study migrating earlier code should retain its explicit compatibility policies;
+see [architecture §13](https://github.com/idossha/TI-Toolbox/blob/main/docs/dev/ARCHITECTURE.md#13-reusable-eeg-and-array-analysis).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ include = ["tit*"]
 # a VCS plugin, and this project installs none. It is declared here explicitly so an installed
 # TI-Toolbox can serve /api/guide/* without a project on disk.
 [tool.setuptools.package-data]
+"tit" = ["STUDY_CODE_NOTICE.txt"]
 "tit.blender" = ["Electrode.blend"]
 "tit.scene" = [
   "guide/manifest.json",

--- a/tests/numerical/eeg_study_parity_probe.py
+++ b/tests/numerical/eeg_study_parity_probe.py
@@ -1,0 +1,270 @@
+"""Frozen preliminary-study versus migrated adapters, synthetic inputs only."""
+
+import ast, json, sys, warnings, tempfile, subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from dataclasses import dataclass
+import logging
+import numpy as np
+import pandas as pd
+from scipy import stats, sparse
+from scipy.sparse.csgraph import connected_components
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from tit.stats import graph, effects, associations, robustness
+
+warnings.filterwarnings("ignore")
+checkouts = [Path(p).resolve() for p in sys.argv[1:]]
+if not checkouts:
+    raise SystemExit("at least one study checkout is required")
+_snapshot = tempfile.TemporaryDirectory(prefix="tit-study-parity-")
+snap = Path(_snapshot.name)
+for root in checkouts:
+    paths = [
+        "src/detect/detect/stats.py",
+        "src/source/source/group.py",
+        "src/simulation/simulation/stats.py",
+        "src/qc/qc/sensitivity.py",
+    ]
+    global_path = (
+        "src/exploratory/field_vs_global"
+        if (root / "src/exploratory/field_vs_global").exists()
+        else "src/simulation/global_response"
+    )
+    paths += [
+        global_path + "/" + n
+        for n in [
+            "hfmax_group_moderation.py",
+            "field_orientation_global_density_dkatlas.py",
+            "hfmax_perparcel_interaction.py",
+            "hfmax_sham_jackknife.py",
+        ]
+    ]
+    for rel in paths:
+        result = subprocess.run(
+            ["git", "-C", str(root), "show", "v1.0-preliminary:" + rel],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        target = snap / root.name / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(result.stdout)
+
+CFG = SimpleNamespace(
+    n_permutations=31, alpha=0.05, tail=0, seed=42, n_bootstrap=51, ci_alpha=0.05
+)
+config = SimpleNamespace(UNCORRECTED_P_THRESHOLD=0.05, MIN_CLUSTER_VERTICES=1)
+
+
+def load(path, names=None):
+    tree = ast.parse(Path(path).read_text())
+    nodes = []
+    for n in tree.body:
+        if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and (
+            names is None or n.name in names
+        ):
+            nodes.append(n)
+        elif (
+            isinstance(n, ast.Assign)
+            and isinstance(n.value, ast.Attribute)
+            and isinstance(n.value.value, ast.Name)
+            and n.value.value.id.startswith("_")
+        ):
+            nodes.append(n)
+    env = dict(
+        np=np,
+        pd=pd,
+        sparse=sparse,
+        stats=stats,
+        sp_stats=stats,
+        sstats=stats,
+        connected_components=connected_components,
+        dataclass=dataclass,
+        Path=Path,
+        ClusterConfig=object,
+        logging=logging,
+        logger=logging.getLogger("parity"),
+        CFG_STATS=CFG,
+        config=config,
+        _rank=stats.rankdata,
+        _ols_coef=lambda X, y: np.linalg.lstsq(X, y, rcond=None)[0],
+        _design=lambda d, g, full: np.column_stack(
+            [np.ones(len(d)), d, g] + ([d * g] if full else [])
+        ),
+        _graph=graph,
+        _effects=effects,
+        _associations=associations,
+        _robustness=robustness,
+        _mne_cluster_test=graph.mne_cluster_test,
+        MODIFIED_Z_OUTLIER=3.5,
+        N_PERM=31,
+        N_BOOT=51,
+        CONTRAST="stim_vs_pre",
+    )
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(path), "exec"), env)
+    return env
+
+
+def equal(a, b):
+    if hasattr(a, "__dataclass_fields__"):
+        a = a.__dict__
+        b = b.__dict__
+    if isinstance(a, dict):
+        assert a.keys() == b.keys(), (a.keys(), b.keys())
+        for k in a:
+            equal(a[k], b[k])
+    elif isinstance(a, (tuple, list)):
+        assert len(a) == len(b)
+        for aa, bb in zip(a, b):
+            equal(aa, bb)
+    elif isinstance(a, (float, np.floating, int, np.integer, np.ndarray)):
+        np.testing.assert_allclose(a, b, rtol=1e-13, atol=1e-13, equal_nan=True)
+    else:
+        assert a == b, (a, b)
+
+
+rng = np.random.default_rng(19)
+a = rng.normal(size=(8, 4)) + 0.7
+b = rng.normal(size=(5, 4))
+a[0, 1] = np.nan
+a[1, 1] = 0
+adj = sparse.diags([np.ones(3), np.ones(3)], [-1, 1], shape=(4, 4)).tocsr()
+results = []
+for root in checkouts:
+    repo = root.name
+    path = "src/detect/detect/stats.py"
+    old, new = load(snap / repo / path), load(root / path)
+    for env in [old, new]:
+        env["_adjacency"] = lambda ch: (adj, list(range(4)))
+    for name, args in [
+        ("run_within_group_topo_test", (a, list("abcd"), CFG)),
+        ("run_between_group_topo_test", (a, b, list("abcd"), CFG)),
+    ]:
+        equal(old[name](*args), new[name](*args))
+        results.append(repo + ":" + name)
+    for name, args in [
+        ("_boot_within", (np.array([0.0, 1.0, -2.0, 4.0, np.nan]), 51)),
+        ("_boot_between", (np.array([1.0, 2.0, 5.0]), np.array([0.0, 3.0, 8.0]), 51)),
+    ]:
+        equal(
+            old[name](*args, np.random.default_rng(4)),
+            new[name](*args, np.random.default_rng(4)),
+        )
+        results.append(repo + ":" + name)
+    path = "src/source/source/group.py"
+    ns = {
+        "_sig_mask_from_clusters",
+        "_sig_cluster_labels",
+        "cluster_perm_1samp",
+        "cluster_perm_between",
+        "_rb_within",
+        "_rb_between",
+        "_boot_within",
+        "_boot_between",
+        "_percentile_ci",
+    }
+    old, new = load(snap / repo / path, ns), load(root / path, ns)
+    # n_jobs=-1 is the same study convention; force MNE joblib to one process externally.
+    clean = np.nan_to_num(a)
+    for name, args in [
+        ("cluster_perm_1samp", (clean, adj)),
+        ("cluster_perm_between", (clean, b, adj)),
+    ]:
+        equal(old[name](*args), new[name](*args))
+        results.append(repo + ":" + name)
+    path = "src/simulation/simulation/stats.py"
+    old, new = load(snap / repo / path), load(root / path)
+    for name, args in [
+        ("pearson_vectorized", (a, clean)),
+        ("spearman_vectorized", (a, clean)),
+    ]:
+        equal(old[name](*args), new[name](*args))
+        results.append(repo + ":" + name)
+    equal(
+        old["permutation_max_cluster_masses"](
+            a, clean, adj, n_permutations=31, rng=np.random.default_rng(9)
+        ),
+        new["permutation_max_cluster_masses"](
+            a, clean, adj, n_permutations=31, rng=np.random.default_rng(9)
+        ),
+    )
+    results.append(repo + ":field_null")
+    kwargs = dict(statistic="spearman", n_bootstrap=51, ci_alpha=0.05)
+    equal(
+        old["bootstrap_cluster_mean_r_ci"](
+            a, clean, rng=np.random.default_rng(3), **kwargs
+        ),
+        new["bootstrap_cluster_mean_r_ci"](
+            a, clean, rng=np.random.default_rng(3), **kwargs
+        ),
+    )
+    results.append(repo + ":field_bootstrap")
+    path = "src/qc/qc/sensitivity.py"
+    old, new = load(snap / repo / path), load(root / path)
+    for name, args in [
+        ("loso_subject_effects", (np.array([0.0, 1.0, 2.0, 3.0, 8.0]), list("abcde"))),
+        ("modified_zscores", (np.array([1.0, 1.0, 1.0, 9.0]),)),
+    ]:
+        equal(old[name](*args), new[name](*args))
+        results.append(repo + ":" + name)
+    gp = (
+        "src/exploratory/field_vs_global"
+        if (root / "src/exploratory/field_vs_global").exists()
+        else "src/simulation/global_response"
+    )
+    path = gp + "/hfmax_group_moderation.py"
+    names = {"_ols_coef", "_rank", "_design", "moderation"}
+    old, new = load(snap / repo / path, names), load(root / path, names)
+    da = pd.DataFrame(
+        {"hf_max@roi": rng.normal(size=9), "density__stim_vs_pre": rng.normal(size=9)}
+    )
+    db = pd.DataFrame(
+        {"hf_max@roi": rng.normal(size=7), "density__stim_vs_pre": rng.normal(size=7)}
+    )
+    equal(
+        old["moderation"]("roi", da, db, np.random.default_rng(2)),
+        new["moderation"]("roi", da, db, np.random.default_rng(2)),
+    )
+    results.append(repo + ":rank_moderation_full")
+    path = gp + "/field_orientation_global_density_dkatlas.py"
+    names = {"_residualize", "_rank", "_partial_r", "_partial_p", "_bh_fdr"}
+    old, new = load(snap / repo / path, names), load(root / path, names)
+    vals = stats.rankdata(rng.normal(size=(20, 4)), axis=0)
+    equal(
+        old["_partial_r"](vals[:, 0], vals[:, 1], vals[:, 2:]),
+        new["_partial_r"](vals[:, 0], vals[:, 1], vals[:, 2:]),
+    )
+    results.append(repo + ":partial_ranked")
+    equal(
+        old["_bh_fdr"](np.array([0.01, 0.04, np.nan, 0.2])),
+        new["_bh_fdr"](np.array([0.01, 0.04, np.nan, 0.2])),
+    )
+    results.append(repo + ":bh_fdr")
+    # Supporting interaction / jackknife use the same residual permutations.
+    for fn, symbol in [
+        ("hfmax_perparcel_interaction.py", "_interaction"),
+        ("hfmax_sham_jackknife.py", "moderation_fit"),
+    ]:
+        path = gp + "/" + fn
+        names = {"_rank", "_design", "_ols_coef", symbol, "_bh_fdr"}
+        old, new = load(snap / repo / path, names), load(root / path, names)
+        inputs = (
+            rng.normal(size=9),
+            rng.normal(size=9),
+            rng.normal(size=7),
+            rng.normal(size=7),
+        )
+        equal(
+            old[symbol](*inputs, np.random.default_rng(77)),
+            new[symbol](*inputs, np.random.default_rng(77)),
+        )
+        results.append(repo + ":" + symbol)
+        if fn == "hfmax_perparcel_interaction.py":
+            equal(
+                old["_bh_fdr"](np.array([0.01, 0.04, np.nan, 0.2])),
+                new["_bh_fdr"](np.array([0.01, 0.04, np.nan, 0.2])),
+            )
+            results.append(repo + ":bh_propagate")
+report = {"passed": len(results), "checks": results, "dataset_rerun": False}
+print(json.dumps(report, indent=2))

--- a/tests/numerical/test_eeg_array_stats.py
+++ b/tests/numerical/test_eeg_array_stats.py
@@ -1,0 +1,350 @@
+"""2026-09-13: EEG array statistics against independent SciPy/MNE oracles.
+
+Run: python -m pytest tests/numerical/test_eeg_array_stats.py -q
+Fixtures are authored small arrays; expectations are recomputed with SciPy,
+MNE, direct rank identities or exhaustive sign enumerations. Participant-data
+reproduction is separate and no dataset is downloaded by these tests.
+"""
+
+import itertools
+import numpy as np
+import pytest
+
+
+def test_sign_policy_is_explicit():
+    from scipy import sparse
+    from tit.stats.graph import find_clusters, cluster_mass
+
+    # A chain of two positive and two negative nodes is an authored topology.
+    graph = sparse.diags([np.ones(3), np.ones(3)], [-1, 1], shape=(4, 4)).tocsr()
+    z = np.array([3.0, 3.0, -3.0, -3.0])
+    cs = find_clusters(z, graph, 1.96, 0)
+    assert [c.tolist() for c in cs] == [[0, 1], [2, 3]]
+    legacy = find_clusters(z, graph, 1.96, 0, sign_policy="absolute_connected")
+    assert len(legacy) == 1
+    assert cluster_mass(z, legacy[0], 0) == np.abs(z).sum()
+
+
+@pytest.mark.parametrize("statistic", ["t", "rank"])
+def test_sampled_sign_null_matches_independent_one_node_oracle(statistic):
+    from scipy import sparse, stats
+    from tit.stats.graph import cluster_permutation
+
+    x = np.array([1.0, 2.0, 4.0, 5.0, -3.0, 7.0])
+    count, seed = 97, 11
+    result = cluster_permutation(
+        x[:, None], sparse.eye(1), statistic=statistic, n_permutations=count, seed=seed
+    )
+
+    def score(v):
+        if statistic == "t":
+            return stats.ttest_1samp(v, 0).statistic
+        ranks = stats.rankdata(abs(v))
+        n = len(v)
+        return (ranks[v > 0].sum() - n * (n + 1) / 4) / np.sqrt(
+            n * (n + 1) * (2 * n + 1) / 24
+        )
+
+    threshold = (
+        stats.t.ppf(0.975, len(x) - 1) if statistic == "t" else stats.norm.ppf(0.975)
+    )
+    generator = np.random.default_rng(seed)
+    expected = []
+    for _ in range(count):
+        z = score(x * generator.choice([-1.0, 1.0], len(x)))
+        expected.append(abs(z) if abs(z) > threshold else 0.0)
+    np.testing.assert_allclose(result.statistic, [score(x)])
+    np.testing.assert_allclose(result.null_distribution, expected)
+    assert np.all(result.pvalues >= 1 / (count + 1))
+
+
+def test_independent_rank_scores_match_u_identity():
+    from scipy import stats
+    from tit.stats.graph import mannwhitney_z, wilcoxon_z
+
+    a, b = np.array([1.0, 3.0, 6.0, 8.0]), np.array([2.0, 4.0, 5.0, 7.0, 9.0])
+    u = stats.mannwhitneyu(a, b).statistic
+    n, m = len(a), len(b)
+    expected = (u - n * m / 2) / np.sqrt(n * m * (n + m + 1) / 12)
+    np.testing.assert_allclose(mannwhitney_z(a[:, None], b[:, None]), [expected])
+    # Only this case pins the published omission of zero and NaN differences.
+    np.testing.assert_allclose(
+        wilcoxon_z(np.array([0.0, np.nan, 1.0, -3.0, 5.0])[:, None]),
+        wilcoxon_z(np.array([1.0, -3.0, 5.0])[:, None]),
+    )
+
+
+def test_source_adapter_matches_real_mne_exhaustive_null():
+    # A clean child interpreter keeps host-suite MNE/joblib mocks out of the oracle.
+    import subprocess
+    import sys
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import numpy as np\nfrom scipy import sparse\nfrom mne.stats import spatio_temporal_cluster_1samp_test\nfrom tit.stats.graph import mne_cluster_test\nrng = np.random.default_rng(2)\nx = rng.normal(size=(5, 3)) + 1.4\ngraph = sparse.diags([np.ones(2), np.ones(2)], [-1, 1], shape=(3, 3)).tocsr()\nactual = mne_cluster_test(x, graph, n_permutations=5000)\nreference = spatio_temporal_cluster_1samp_test(x[:, None, :], adjacency=graph, n_permutations=5000, seed=42, tail=0, threshold=None, buffer_size=None, verbose=False)\nnp.testing.assert_allclose(actual[0], reference[0])\nnp.testing.assert_array_equal(actual[2], reference[2])\nnp.testing.assert_array_equal(actual[3], reference[3])\nassert len(actual[3]) == 2 ** (len(x) - 1)\n",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_source_f_adapter_matches_real_mne():
+    # A clean child interpreter keeps host-suite MNE/joblib mocks out of the oracle.
+    import subprocess
+    import sys
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import numpy as np\nfrom scipy import sparse\nfrom mne.stats import spatio_temporal_cluster_test\nfrom tit.stats.graph import mne_cluster_test\nrng = np.random.default_rng(6)\na, b = rng.normal(size=(6, 2)) + 2, rng.normal(size=(5, 2))\ngraph = sparse.csr_matrix([[0, 1], [1, 0]])\nactual = mne_cluster_test(a, graph, other=b, n_permutations=29)\nreference = spatio_temporal_cluster_test([a[:, None, :], b[:, None, :]], adjacency=graph, n_permutations=29, seed=42, tail=0, threshold=None, buffer_size=None, verbose=False)\nnp.testing.assert_allclose(actual[0], reference[0])\nnp.testing.assert_array_equal(actual[2], reference[2])\nnp.testing.assert_array_equal(actual[3], reference[3])\n",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_map_correlations_match_scipy_and_perfect_policy():
+    from scipy import stats
+    from tit.stats.graph import pearson_columns
+
+    rng = np.random.default_rng(8)
+    x, y = rng.normal(size=(9, 4)), rng.normal(size=(9, 4))
+    y[:, 0] = x[:, 0]
+    x[1, 2] = np.nan
+    r, p = pearson_columns(x, y)
+    for col in range(x.shape[1]):
+        mask = np.isfinite(x[:, col]) & np.isfinite(y[:, col])
+        oracle = stats.pearsonr(x[mask, col], y[mask, col])
+        np.testing.assert_allclose(r[col], oracle.statistic, atol=1e-14)
+        np.testing.assert_allclose(p[col], oracle.pvalue, atol=1e-14)
+    assert pearson_columns(x, x, published_policy=True)[1][0] == 1.0
+    assert p[0] == 0.0
+
+
+def test_map_permutation_is_seeded_and_subjectwise():
+    from scipy import sparse, stats
+    from tit.stats.graph import correlation_cluster_permutation
+
+    rng = np.random.default_rng(8)
+    x = rng.normal(size=(10, 2))
+    y = x + rng.normal(size=x.shape) * 0.3
+    result = correlation_cluster_permutation(
+        x, y, sparse.csr_matrix([[0, 1], [1, 0]]), n_permutations=19, seed=7
+    )
+    np.testing.assert_allclose(
+        result.statistic,
+        [stats.spearmanr(x[:, j], y[:, j]).statistic for j in range(2)],
+    )
+    repeated = correlation_cluster_permutation(
+        x, y, sparse.csr_matrix([[0, 1], [1, 0]]), n_permutations=19, seed=7
+    )
+    np.testing.assert_array_equal(result.null_distribution, repeated.null_distribution)
+
+
+def test_effects_match_scipy_rank_identity_and_mean_population():
+    from scipy import stats
+    from tit.stats.effects import rank_biserial, bootstrap_effects
+
+    a, b = np.array([0.0, 1.0, 3.0, 5.0]), np.array([1.0, 2.0, 7.0])
+    assert rank_biserial(a, b) == pytest.approx(
+        2 * stats.mannwhitneyu(a, b).statistic / (len(a) * len(b)) - 1
+    )
+    _, means = bootstrap_effects(a, n_bootstrap=101, seed=12)
+    generator = np.random.default_rng(12)
+    expected = [np.mean(generator.choice(a, len(a), replace=True)) for _ in range(101)]
+    np.testing.assert_array_equal(means, expected)
+    _, legacy = bootstrap_effects(a, n_bootstrap=101, seed=12, exclude_zero_draws=True)
+    assert not np.array_equal(means, legacy)
+
+
+def test_fdr_matches_scipy_and_keeps_families_separate():
+    from scipy.stats import false_discovery_control
+    from tit.stats.associations import bh_fdr, fdr_by_family
+
+    p = np.array([0.001, 0.07, np.nan, 0.02, 0.8])
+    expected = false_discovery_control(p[np.isfinite(p)])
+    np.testing.assert_allclose(bh_fdr(p)[np.isfinite(p)], expected)
+    q = fdr_by_family(np.array([0.01, 0.08, 0.03, 0.9]), ["a", "a", "b", "b"])
+    np.testing.assert_allclose(q[:2], false_discovery_control([0.01, 0.08]))
+    np.testing.assert_allclose(q[2:], false_discovery_control([0.03, 0.9]))
+
+
+def test_partial_spearman_matches_three_correlation_identity():
+    from scipy import stats
+    from tit.stats.associations import partial_spearman
+
+    rng = np.random.default_rng(12)
+    y, x, z = rng.normal(size=(3, 17))
+    a, b, c = (
+        stats.spearmanr(x, y).statistic,
+        stats.spearmanr(x, z).statistic,
+        stats.spearmanr(y, z).statistic,
+    )
+    expected = (a - b * c) / np.sqrt((1 - b * b) * (1 - c * c))
+    assert partial_spearman(y, x, z)[0] == pytest.approx(expected)
+
+
+def test_rank_moderation_matches_direct_design_and_residual_null():
+    from scipy import stats
+    from tit.stats.associations import rank_moderation
+
+    rng = np.random.default_rng(5)
+    a, b = rng.normal(size=9), rng.normal(size=7)
+    ya, yb = 0.7 * a + rng.normal(size=9), -0.4 * b + rng.normal(size=7)
+    count, seed = 29, 4
+    actual = rank_moderation(
+        a, ya, b, yb, n_permutations=count, n_bootstrap=21, seed=seed
+    )
+    x = stats.rankdata(np.r_[a, b])
+    x -= np.mean(x)
+    y = stats.rankdata(np.r_[ya, yb])
+    g = np.r_[np.ones(len(a)), np.zeros(len(b))]
+    full = np.c_[np.ones(len(x)), x, g, x * g]
+    red = full[:, :3]
+    # pinv is an independent OLS path, with tolerance for SVD roundoff only.
+    beta = np.linalg.pinv(full) @ y
+    np.testing.assert_allclose(
+        [actual.interaction, actual.slope_a, actual.slope_b],
+        [beta[3], beta[1] + beta[3], beta[1]],
+        atol=1e-13,
+    )
+    fitted = red @ (np.linalg.pinv(red) @ y)
+    resid = y - fitted
+    rg = np.random.default_rng(seed)
+    null = [
+        (np.linalg.pinv(full) @ (fitted + resid[rg.permutation(len(y))]))[3]
+        for _ in range(count)
+    ]
+    np.testing.assert_allclose(actual.permutation_null, null, atol=1e-13)
+
+
+def test_loso_is_subject_axis_and_rejects_ambiguous_ids():
+    from tit.stats.robustness import leave_one_out
+
+    x = np.arange(12).reshape(4, 3)
+    rows = leave_one_out(x, lambda v: v[:, 1].mean(), subject_ids=list("abcd"))
+    np.testing.assert_allclose(
+        [r["estimate"] for r in rows], [(x[:, 1].sum() - v) / 3 for v in x[:, 1]]
+    )
+    with pytest.raises(ValueError, match="unique"):
+        leave_one_out(x, np.mean, subject_ids=["a"] * 4)
+
+
+def test_invalid_graph_rejected():
+    from tit.stats.graph import cluster_permutation
+
+    with pytest.raises(ValueError, match="symmetric"):
+        cluster_permutation(np.ones((4, 2)), [[0, 1], [0, 0]])
+
+
+def test_published_rank_score_ties_are_an_explicit_convention():
+    from scipy import stats
+    from tit.stats.graph import wilcoxon_z, mannwhitney_z
+
+    # Midranks are SciPy's oracle; variance intentionally excludes tie correction.
+    values = np.array([0.0, 1.0, 1.0, -2.0, 2.0, np.nan])
+    finite = values[np.isfinite(values) & (values != 0)]
+    ranks = stats.rankdata(np.abs(finite))
+    n = len(finite)
+    expected = (ranks[finite > 0].sum() - n * (n + 1) / 4) / np.sqrt(
+        n * (n + 1) * (2 * n + 1) / 24
+    )
+    np.testing.assert_allclose(wilcoxon_z(values[:, None]), [expected])
+    a, b = np.array([1.0, 1.0, 3.0]), np.array([1.0, 2.0, 3.0])
+    u = stats.mannwhitneyu(a, b).statistic
+    expected = (u - len(a) * len(b) / 2) / np.sqrt(
+        len(a) * len(b) * (len(a) + len(b) + 1) / 12
+    )
+    np.testing.assert_allclose(mannwhitney_z(a[:, None], b[:, None]), [expected])
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_partial_spearman_fully_explained_ranks_are_undefined(reverse):
+    from tit.stats.associations import partial_spearman
+
+    z = np.arange(1.0, 11.0)
+    y = z[::-1] if reverse else z
+    r, p = partial_spearman(y, z, z[:, None])
+    assert np.isnan(r) and np.isnan(p)
+
+
+@pytest.mark.parametrize("scale", [1.0, 1e-20])
+def test_partial_ranked_preserves_small_scale_residual_signal(scale):
+    from tit.stats.associations import partial_ranked
+
+    # Authored orthogonal centered vectors: removing z leaves independent u/v.
+    z = np.array([-3.0, -1.0, 1.0, 3.0])
+    u = np.array([1.0, -1.0, -1.0, 1.0])
+    v = np.array([-1.0, 3.0, -3.0, 1.0])
+    x, y = scale * (z + u), scale * (2 * z + u + v)
+    expected = np.corrcoef(u, u + v)[0, 1]
+    assert partial_ranked(y, x, z[:, None]) == pytest.approx(expected, abs=1e-14)
+    assert np.isnan(partial_ranked(np.ones(4) * scale, x, z[:, None]))
+
+
+def test_stored_zero_edges_do_not_connect_clusters_or_mutate_input():
+    from scipy import sparse
+    from tit.stats.graph import find_clusters, correlation_clusters, cluster_permutation
+
+    graph = sparse.csr_matrix(np.ones((2, 2), dtype=bool))
+    graph[0, 1] = False
+    graph[1, 0] = False
+    original_data, original_indices, original_indptr = (
+        graph.data.copy(),
+        graph.indices.copy(),
+        graph.indptr.copy(),
+    )
+    # Explicitly stored False cells are not edges: dense oracle is identity.
+    np.testing.assert_array_equal(graph.toarray(), np.eye(2, dtype=bool))
+    assert [
+        c.tolist() for c in find_clusters(np.array([3.0, 3.0]), graph, 1.96, 0)
+    ] == [[0], [1]]
+    clusters = correlation_clusters(
+        np.array([0.8, 0.8]), np.array([0.001, 0.001]), graph
+    )
+    assert [c["nodes"].tolist() for c in clusters] == [[0], [1]]
+    values = np.column_stack([np.arange(1.0, 7.0), np.arange(2.0, 8.0)])
+    result = cluster_permutation(values, graph, n_permutations=19)
+    assert [c.tolist() for c in result.clusters] == [[0], [1]]
+    np.testing.assert_array_equal(graph.data, original_data)
+    np.testing.assert_array_equal(graph.indices, original_indices)
+    np.testing.assert_array_equal(graph.indptr, original_indptr)
+
+
+def test_moderation_singular_bootstrap_draws_are_discarded_and_counted():
+    from tit.stats.associations import rank_moderation
+
+    a, b = np.array([0.0, 1.0]), np.array([2.0, 3.0])
+    n_perm, n_boot, seed = 10, 100, 42
+    result = rank_moderation(
+        a, a, b, b[::-1], n_permutations=n_perm, n_bootstrap=n_boot, seed=seed
+    )
+    # For two distinct observations per group, a full-rank draw must retain
+    # both observations in each group; unique sampled IDs are an independent oracle.
+    rng = np.random.default_rng(seed)
+    for _ in range(n_perm):
+        rng.permutation(4)
+    valid = []
+    for _ in range(n_boot):
+        ia, ib = rng.integers(0, 2, 2), rng.integers(0, 2, 2)
+        valid.append(len(set(ia)) == 2 and len(set(ib)) == 2)
+    np.testing.assert_array_equal(np.isfinite(result.bootstrap_interaction), valid)
+    assert result.bootstrap_valid_count == sum(valid)
+    assert result.bootstrap_valid_fraction == sum(valid) / n_boot
+    legacy = rank_moderation(
+        a,
+        a,
+        b,
+        b[::-1],
+        n_permutations=n_perm,
+        n_bootstrap=n_boot,
+        seed=seed,
+        singular_bootstrap="legacy",
+    )
+    assert np.isfinite(legacy.bootstrap_interaction).all()
+    assert legacy.bootstrap_valid_count == sum(valid)

--- a/tests/numerical/test_eeg_fields.py
+++ b/tests/numerical/test_eeg_fields.py
@@ -1,0 +1,205 @@
+"""Independent small-array checks; no participant data or FEM reproduction."""
+
+from __future__ import annotations
+import numpy as np
+import pytest
+
+
+def test_carrier_metrics_manual_vectors():
+    from tit.fields import carrier_metrics
+
+    a = np.array([[3.0, 0, 0], [3, 0, 0], [3, 0, 0]])
+    b = np.array([[2.0, 0, 0], [0, 4, 0], [-2, 0, 0]])
+    normals = np.array([[1.0, 0, 0], [1, 0, 0], [1, 0, 0]])
+    result = carrier_metrics([a, b], normals)
+    np.testing.assert_allclose(result["hf_peak"], [5, 5, 5])
+    np.testing.assert_allclose(result["hf_sar"], [13, 25, 13])
+    np.testing.assert_allclose(result["carrier_sum"], [5, 7, 5])
+    np.testing.assert_allclose(result["TI_normal"], [4, 0, 4])
+    np.testing.assert_allclose(result["carrier_normal_sum"], [5, 3, 1])
+    with pytest.raises(ValueError):
+        carrier_metrics([a, b], normals * 2)
+    with pytest.raises(ValueError):
+        carrier_metrics([a, b * np.nan])
+
+
+def test_nonlinear_scalar_precedes_surface_morph():
+    from tit.fields import carrier_metrics
+    from tit.source.fsaverage import _morph_split
+
+    class Average:
+        def resample(self, values):
+            return np.array([np.mean(values)])
+
+    a = np.array([[3.0, 0, 0], [-3, 0, 0], [1, 0, 0], [1, 0, 0]])
+    b = np.array([[1.0, 0, 0], [-1, 0, 0], [2, 0, 0], [2, 0, 0]])
+    native = carrier_metrics([a, b])["hf_peak"]
+    actual = _morph_split(native, 2, 2, dict(lh=Average(), rh=Average()), ("lh", "rh"))
+    np.testing.assert_allclose(actual, [4, 3])
+    # Averaging left carrier vectors first would cancel both fields to zero.
+    assert carrier_metrics([a[:2].mean(0), b[:2].mean(0)])["hf_peak"] == 0
+
+
+def test_parcel_reduction_order_weights_missing_and_nans():
+    from tit.atlas.surface import parcel_means
+
+    labels = np.array([1, 1, 5, -1])
+    values = np.array([[2.0, 8.0, 9.0, 100.0], [4.0, np.nan, 6.0, 100.0]])
+    means, ids = parcel_means(values, labels, region_ids=np.array([5, 1, 3]))
+    np.testing.assert_equal(ids, [5, 1, 3])
+    np.testing.assert_allclose(
+        means, [[9, 5, np.nan], [6, np.nan, np.nan]], equal_nan=True
+    )
+    weighted, _ = parcel_means(
+        values, labels, weights=np.array([1.0, 3.0, 2.0, 1.0]), nan_policy="omit"
+    )
+    np.testing.assert_allclose(weighted, [[6.5, 9], [4, 6]])
+    vector, _ = parcel_means(values[0], labels, weights=np.array([1.0, 3.0, 2.0, 1.0]))
+    np.testing.assert_allclose(vector, [6.5, 9])
+    with pytest.raises(ValueError):
+        parcel_means(values, labels, nan_policy="raise")
+
+
+def test_nearest_vertices_enforces_coordinate_tolerance():
+    from tit.atlas.surface import nearest_vertex_ids
+
+    reference = np.array([[0.0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    np.testing.assert_array_equal(
+        nearest_vertex_ids(reference, reference[[2, 0]], max_distance=0), [2, 0]
+    )
+    with pytest.raises(ValueError):
+        nearest_vertex_ids(reference, [[8, 0, 0]], max_distance=0.1)
+
+
+def test_array_cache_rejects_stale_partial_and_unsafe(tmp_path):
+    from tit.source.cache import input_fingerprints, read_array_cache, write_array_cache
+
+    source = tmp_path / "mesh"
+    source.write_bytes(b"original")
+    metadata = {"version": 1, "inputs": input_fingerprints([source])}
+    cache = tmp_path / "fields.npz"
+    write_array_cache(cache, {"x": np.arange(3)}, metadata)
+    np.testing.assert_array_equal(
+        read_array_cache(cache, metadata, ("x",))["x"], [0, 1, 2]
+    )
+    assert read_array_cache(cache, metadata, ("x", "missing")) is None
+    source.write_bytes(b"modified")
+    assert (
+        read_array_cache(
+            cache, {"version": 1, "inputs": input_fingerprints([source])}, ("x",)
+        )
+        is None
+    )
+    with pytest.raises(ValueError):
+        write_array_cache(cache, {"x": np.array([{}], object)}, metadata)
+    assert read_array_cache(cache, metadata, ("x",)) is not None
+    cache.write_bytes(b"PK\x03\x04interrupted ZIP archive")
+    assert read_array_cache(cache, metadata, ("x",)) is None
+
+
+def test_study_projection_snapshot_parity(monkeypatch):
+    """Optional unpublished study checkout: compare the saved projection scorer."""
+    import ast
+    import os
+    import subprocess
+    from pathlib import Path
+    from types import SimpleNamespace
+    from tit.source import fsaverage as fs
+
+    roots = os.environ.get("TIT_STUDY_CHECKOUTS", "").split(os.pathsep)
+    roots = [Path(p) for p in roots if p]
+    if not roots:
+        pytest.skip(
+            "set TIT_STUDY_CHECKOUTS to check v1.0-preliminary projection parity"
+        )
+    rng = np.random.default_rng(8)
+    vector = {k: rng.normal(size=(7, 3)) for k in ("a", "b")}
+    normal = rng.normal(size=(7, 3))
+    normal /= np.linalg.norm(normal, axis=1)[:, None]
+    central = {}
+
+    class Morph:
+        def __init__(self, matrix):
+            self.matrix = matrix
+
+        def resample(self, value):
+            return self.matrix @ value
+
+    morph = {
+        "lh": Morph(np.array([[0.5, 0.5, 0], [0, 0, 1.0]])),
+        "rh": Morph(np.array([[0.5, 0.5, 0, 0], [0, 0, 0.5, 0.5]])),
+    }
+    for h, ids in [("lh", slice(0, 3)), ("rh", slice(3, 7))]:
+        n = normal[ids]
+        central[h] = SimpleNamespace(
+            nodes=SimpleNamespace(nr=len(n)),
+            nodes_normals=lambda n=n: SimpleNamespace(value=n),
+        )
+    subject = SimpleNamespace(subpath="m2m_fixture", hemispheres=("lh", "rh"))
+    monkeypatch.setattr(
+        fs, "_subject_geometry", lambda *a: (central, morph, subject.hemispheres)
+    )
+    monkeypatch.setattr(fs, "_load_carrier_mesh", lambda path: (path.name, None))
+    monkeypatch.setattr(fs, "_interp_to_central", lambda mesh, *a: vector[mesh])
+    monkeypatch.setitem(fs._FSAVG_NODES, 5, 4)
+
+    def extract(source, name):
+        tree = ast.parse(source)
+        node = next(
+            n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name
+        )
+        return compile(
+            ast.fix_missing_locations(ast.Module(body=[node], type_ignores=[])),
+            str(name),
+            "exec",
+        )
+
+    for root in roots:
+        path = "src/simulation/scripts/hf_project.py"
+        old = subprocess.check_output(
+            ["git", "show", f"v1.0-preliminary:{path}"], cwd=root, text=True
+        )
+        context = {
+            "np": np,
+            "Path": Path,
+            "SubjectFiles": object,
+            "config": SimpleNamespace(N_FSAVG5_NODES=4),
+            "FSAVERAGE_SUBSAMPLING": 5,
+            "mesh_io": SimpleNamespace(load_subject_surfaces=lambda *a: central),
+            "cross_subject_map": lambda *a, **k: morph,
+            "_surface_vector_field": lambda path, *a: {
+                "lh": vector[str(path)][:3],
+                "rh": vector[str(path)][3:],
+            },
+        }
+        exec(extract(old, "_project_hf_fields"), context)
+        expected = context["_project_hf_fields"](Path("a"), Path("b"), subject)
+        current = {"Path": Path, "SubjectFiles": object, "FSAVERAGE_SUBSAMPLING": 5}
+        exec(extract((root / path).read_text(), "_project_hf_fields"), current)
+        actual = current["_project_hf_fields"](Path("a"), Path("b"), subject)
+        assert actual.keys() == expected.keys()
+        for key in expected:
+            np.testing.assert_allclose(
+                actual[key], expected[key], atol=1e-14, rtol=1e-13
+            )
+
+
+def test_projection_metadata_invalidates_runtime_change(tmp_path, monkeypatch):
+    from importlib import metadata
+    from types import SimpleNamespace
+    from tit.source.fsaverage import _projection_metadata
+    from tit.source.config import FsavgMapConfig
+
+    pm = SimpleNamespace(m2m=lambda subject: tmp_path)
+    cfg = FsavgMapConfig(fields=("hf_peak",))
+    from tit.source import fsaverage as fs
+
+    monkeypatch.setattr(fs, "_carrier_volume_meshes", lambda *a: ())
+    monkeypatch.setattr(metadata, "version", lambda package: "1")
+    before = _projection_metadata(pm, "fixture", "simulation", cfg)
+    monkeypatch.setattr(
+        metadata, "version", lambda package: "2" if package == "simnibs" else "1"
+    )
+    after = _projection_metadata(pm, "fixture", "simulation", cfg)
+    assert before["inputs"] == after["inputs"]
+    assert before != after

--- a/tests/numerical/test_eeg_source.py
+++ b/tests/numerical/test_eeg_source.py
@@ -1,0 +1,403 @@
+"""Real-MNE EEG/source extraction contracts (2026-09-13).
+
+Run: simnibs_python -m pytest tests/numerical/test_eeg_source.py -q
+Set TIT_EEG_TEST_PYTHON to test a different installed MNE interpreter explicitly.
+Numbers come from independently invoked public MNE APIs or analytic graph/time
+invariants, never cached output of the wrappers. Each test uses a fresh Python
+process so the host suite's module mocks cannot masquerade as numerical proof.
+No datasets are downloaded. Real FEM/head-model parity is a separate data test.
+"""
+
+from pathlib import Path
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_real(code: str) -> None:
+    env = dict(
+        os.environ,
+        PYTHONPATH=str(ROOT),
+        MNE_DONTWRITE_HOME="true",
+        MNE_HOME="/tmp/mne-home",
+        MPLBACKEND="Agg",
+        TIT_NO_TELEMETRY="1",
+    )
+    python = os.environ.get("TIT_EEG_TEST_PYTHON", sys.executable)
+    probe = subprocess.run(
+        [python, "-c", "import mne, scipy, numpy"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode:
+        pytest.skip(f"Real MNE/scipy unavailable in {python}: {probe.stderr}")
+    result = subprocess.run(
+        [python, "-c", textwrap.dedent(code)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_noise_epochs_first_sample_exact_fit_and_exclusions():
+    # Only this case catches the raw-relative/absolute offset and terminal-epoch bugs.
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.source.reconstruction import epochs_from_intervals, subtract_intervals
+        info = mne.create_info(['Cz'], 10, 'eeg')
+        raw = mne.io.RawArray(np.arange(100)[None, :] * 1e-6, info, first_samp=50, verbose=False)
+        epochs = epochs_from_intervals(raw, [(0, 10)], exclusions=[(2, 4)], epoch_duration=2)
+        # Authored timeline: [0,2), [4,6), [6,8), [8,10), absolute starts +50.
+        np.testing.assert_array_equal(epochs.events[:, 0], [50, 90, 110, 130])
+        np.testing.assert_allclose(epochs.get_data()[:, 0, 0], np.array([0,40,60,80]) * 1e-6)
+        assert subtract_intervals([(0, 10)], [(2,4), (3,5), (7,8)]) == [(0,2), (5,7), (8,10)]
+        raw_zero = mne.io.RawArray(np.arange(100)[None, :] * 1e-6, info, verbose=False)
+        old = epochs_from_intervals(raw_zero, [(0,10)], epoch_duration=2, legacy_sampling=True)
+        np.testing.assert_array_equal(old.events[:, 0], [0,20,40,60])
+    """)
+
+
+def test_covariance_matches_independent_mne_epochs():
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.source.reconstruction import covariance_from_intervals
+        rng = np.random.default_rng(20)
+        raw = mne.io.RawArray(rng.normal(size=(3, 600)) * 1e-6,
+                             mne.create_info(['C3','Cz','C4'], 100, 'eeg'), verbose=False)
+        expected_epochs = mne.Epochs(raw, np.array([[0,0,1],[200,0,1],[400,0,1]]),
+                                    {'noise':1}, tmin=0, tmax=1.99, baseline=None, preload=True, verbose=False)
+        expected = mne.compute_covariance(expected_epochs, method='empirical', rank=None, verbose=False)
+        actual = covariance_from_intervals(raw, [(0,6)], method='empirical')
+        np.testing.assert_allclose(actual.data, expected.data, rtol=1e-14, atol=0)
+    """)
+
+
+def test_harmonization_preserves_metadata_and_matches_mne_interpolation():
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.eeg import harmonize_channels
+        names = ['Fp1','Fp2','F3','F4','C3','C4','P3','P4','O1','O2']
+        montage = mne.channels.make_standard_montage('standard_1020')
+        raw = mne.io.RawArray(np.random.default_rng(8).normal(size=(len(names), 40)) * 1e-6,
+                             mne.create_info(names, 100, 'eeg'), first_samp=200, verbose=False)
+        raw.set_montage(montage)
+        raw.set_annotations(mne.Annotations([0.1], [0.05], ['event']))
+        raw.info['bads'] = ['C3']
+        expected = raw.copy().interpolate_bads(reset_bads=True, verbose=False)
+        actual = harmonize_channels(raw, names, montage)
+        np.testing.assert_allclose(actual.get_data(), expected.get_data(), rtol=1e-14, atol=0)
+        assert raw.info['bads'] == ['C3'] and actual.info['bads'] == []
+        assert actual.first_samp == raw.first_samp
+        np.testing.assert_array_equal(actual.annotations.onset, raw.annotations.onset)
+        incomplete = raw.copy().drop_channels(['C4'])
+        restored = harmonize_channels(incomplete, names, montage, preserve_bads=False)
+        # Legacy mode interpolates newly missing C4 and retains existing C3 signal.
+        np.testing.assert_array_equal(restored.get_data(picks=['C3']), raw.get_data(picks=['C3']))
+        assert restored.ch_names == names and restored.first_samp == 200
+    """)
+
+
+def test_annotations_and_protocol_window_policies():
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.eeg import annotation_pairs, stimulation_windows
+        raw = mne.io.RawArray(np.zeros((1, 100)), mne.create_info(['Cz'], 10, 'eeg'),
+                             first_samp=50, verbose=False)
+        raw.set_annotations(mne.Annotations([1,3,6,8], [0]*4, ['STIM-start','stim end']*2))
+        assert annotation_pairs(raw,'stim start','stim end') == [(1,3),(6,8)]
+        assert annotation_pairs(raw,'stim start','stim end', relative_to_raw=False) == [(6,8),(11,13)]
+        windows = stimulation_windows([(2,4),(6,8)])
+        assert windows[0].post_end_sec == windows[1].pre_start_sec == 5
+        assert (windows[0].pre_start_sec, windows[1].post_end_sec) == (0,10)
+    """)
+
+
+def test_graph_diffusion_matches_manual_neighbor_averaging():
+    run_real("""
+        import numpy as np
+        from scipy.sparse import csr_matrix
+        from tit.source.reconstruction import diffusion_smoother
+        # Authored chain with one isolated vertex. Average each node with its neighbors.
+        adjacency = csr_matrix([[0,1,0,0],[1,0,1,0],[0,1,0,0],[0,0,0,0]])
+        matrix = diffusion_smoother(adjacency, 2)
+        x = np.array([1.,4.,10.,9.])
+        first = np.array([(1+4)/2, (1+4+10)/3, (4+10)/2, 9])
+        expected = np.array([(first[0]+first[1])/2, first[:3].mean(), (first[1]+first[2])/2, 9])
+        np.testing.assert_allclose(matrix @ x, expected, rtol=1e-14)
+        np.testing.assert_allclose(matrix @ np.ones(4), np.ones(4), rtol=1e-14)
+    """)
+
+
+def test_sensor_adjacency_reordering_matches_public_mne():
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.eeg import sensor_adjacency
+        names=['F3','F4','C3','C4','P3','P4']
+        info=mne.create_info(names,100,'eeg')
+        info.set_montage('standard_1020')
+        wanted=names[::-1]
+        matrix, ordered, index=sensor_adjacency(info,wanted)
+        expected_info=mne.pick_info(info,mne.pick_channels(names,wanted,ordered=True))
+        expected, expected_names=mne.channels.find_ch_adjacency(expected_info,'eeg')
+        assert ordered == expected_names
+        assert [wanted[i] for i in index] == ordered
+        np.testing.assert_array_equal(matrix.toarray(), expected.toarray())
+    """)
+
+
+def test_batched_inverse_matches_independent_mne_epochs():
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.source.reconstruction import prepare_inverse, apply_inverse_windows
+        names=['Fp1','Fp2','F3','F4','C3','C4','P3','P4','O1','O2']
+        info=mne.create_info(names,100,'eeg'); info.set_montage('standard_1020')
+        raw=mne.io.RawArray(np.random.default_rng(2).normal(size=(10,100))*1e-6,info,verbose=False)
+        raw.set_eeg_reference(projection=True,verbose=False)
+        sphere=mne.make_sphere_model(r0=(0,0,0),head_radius=0.09,verbose=False)
+        # Discrete interior dipoles avoid a dataset or a FreeSurfer subject.
+        source=mne.setup_volume_source_space(pos=dict(rr=np.array([[.01,.02,.03],[-.02,.01,.04]]),
+                                            nn=np.array([[0,0,1],[0,1,0]])),verbose=False)
+        forward=mne.make_forward_solution(raw.info,trans=None,src=source,bem=sphere,eeg=True,meg=False,verbose=False)
+        covariance=mne.make_ad_hoc_cov(raw.info,verbose=False)
+        inverse=prepare_inverse(raw.info,forward,covariance,loose=1.,depth=None)
+        offsets=np.array([-2,0,2]); peaks=np.array([10,50,80])
+        event_data=np.stack([raw.get_data()[:,peak+offsets] for peak in peaks])
+        epochs=mne.EpochsArray(event_data,raw.info,baseline=None,verbose=False)
+        for method in ('MNE','sLORETA'):
+            for orientation in (None,'vector'):
+                expected=mne.minimum_norm.apply_inverse_epochs(epochs,inverse,lambda2=1/9,
+                         method=method,pick_ori=orientation,verbose=False)
+                actual=apply_inverse_windows(raw.get_data(),raw.info,inverse,peaks,offsets,
+                         lambda2=1/9,method=method,pick_ori=orientation)
+                independent=np.stack([stc.data for stc in expected], axis=-2)
+                # Same linear algebra reordered in batches: floating reduction roundoff only.
+                np.testing.assert_allclose(actual,independent,rtol=1e-12,atol=1e-20)
+    """)
+
+
+def test_forward_recording_frame_and_explicit_transform():
+    run_real("""
+        import mne
+        import numpy as np
+        from tit.source.forward import _build_montage_info
+        fids={'LPA':np.array([-.08,0,0]),'Nz':np.array([0,.10,0]),'RPA':np.array([.08,0,0])}
+        electrodes={'Cz':np.array([0,0,.09]),'Fpz':np.array([0,.08,.04])}
+        info=mne.create_info(['Cz','Fpz'],100,'eeg')
+        info.set_montage(mne.channels.make_dig_montage(ch_pos=electrodes,lpa=fids['LPA'],
+                         nasion=fids['Nz'],rpa=fids['RPA'],coord_frame='head'))
+        translation=np.array([.01,-.02,.03])
+        mri_fids={key:value+translation for key,value in fids.items()}
+        mri_electrodes={key:value+translation for key,value in electrodes.items()}
+        built, transform=_build_montage_info(mri_electrodes,mri_fids,info=info)
+        # Authored rigid frame: same electrodes translated in MRI. No fit to wrapper output.
+        np.testing.assert_allclose(transform['trans'][:3,3],translation,atol=1e-8)
+        for channel in built['chs']:
+            np.testing.assert_allclose(channel['loc'][:3],electrodes[channel['ch_name']],atol=1e-8)
+        explicit=mne.transforms.Transform('head','mri',transform['trans'])
+        rebuilt, reused=_build_montage_info(mri_electrodes,mri_fids,trans=explicit)
+        np.testing.assert_array_equal(reused['trans'],explicit['trans'])
+    """)
+
+
+def test_external_study_baseline_primitive_parity():
+    """Optional code-baseline comparison; no participant files are accessed."""
+    study = os.environ.get("TIT_EEG_STUDY_ROOT")
+    if not study:
+        pytest.skip(
+            "TIT_EEG_STUDY_ROOT unset: external v1.0-preliminary study code parity not requested"
+        )
+    run_real("""
+        import ast
+        import dataclasses
+        import os
+        from pathlib import Path
+        import subprocess
+        import mne
+        import numpy as np
+        import pandas as pd
+        import scipy.sparse as sp
+        from tit.eeg import harmonize_channels, annotation_pairs, stimulation_windows
+        from tit.source.reconstruction import covariance_from_intervals, diffusion_smoother
+        root=Path(os.environ['TIT_EEG_STUDY_ROOT'])
+        def load_function(path,name,namespace):
+            source=subprocess.check_output(['git','show',f'v1.0-preliminary:{path}'],cwd=root,text=True)
+            node=next(n for n in ast.parse(source).body if isinstance(n,ast.FunctionDef) and n.name==name)
+            future=ast.ImportFrom(module='__future__',names=[ast.alias(name='annotations')],level=0)
+            module=ast.fix_missing_locations(ast.Module(body=[future,node],type_ignores=[]))
+            exec(compile(module,path,'exec'),namespace)
+            return namespace[name]
+        source_path='src/source/source/density.py'
+        namespace=dict(mne=mne,np=np,pd=pd,sp=sp)
+        old_cov=load_function(source_path,'wave_free_noise_cov',namespace)
+        old_smoother=load_function(source_path,'build_diffusion_smoother',namespace)
+        raw=mne.io.RawArray(np.random.default_rng(91).normal(size=(4,2000))*1e-6,
+                mne.create_info(['C3','Cz','C4','Pz'],100,'eeg'),verbose=False)
+        from types import SimpleNamespace
+        protocols=[SimpleNamespace(pre_start_sec=0.,pre_end_sec=20.)]
+        waves=pd.DataFrame({'Start':[2.,2.5,12.],'End':[3.,4.,13.]})
+        before=old_cov(raw,protocols,waves)
+        after=covariance_from_intervals(raw,[(0,20)],exclusions=[(r.Start-.5,r.End+.5) for r in waves.itertuples()],
+                                       legacy_sampling=True)
+        np.testing.assert_allclose(after.data,before.data,rtol=1e-14,atol=0)
+        graph=sp.csr_matrix([[0,1,0],[1,0,1],[0,1,0]])
+        np.testing.assert_array_equal(diffusion_smoother(graph,5).toarray(),old_smoother(graph,5).toarray())
+        # Evaluate the historical interpolation body against the same in-memory recording.
+        names=['Fp1','Fp2','F3','F4','C3','C4','P3','P4','O1','O2']
+        import logging
+        old_io=load_function('src/shared/io.py','load_set',dict(mne=mne,np=np,Path=Path,
+             logger=logging.getLogger('parity'),EXCLUDE_CHANNELS=[],N_WORKING_CHANNELS=len(names),
+             working_channel_names=lambda:names))
+        # Use the actual study montage/channel policy from the baseline, not the small example cap.
+        channel_source=subprocess.check_output(['git','show','v1.0-preliminary:src/shared/channels.py'],cwd=root,text=True)
+        channels={};exec(channel_source,channels)
+        template=channels['working_channel_names']()
+        old_io.__globals__.update(EXCLUDE_CHANNELS=channels['EXCLUDE_CHANNELS'],N_WORKING_CHANNELS=len(template),
+                                  working_channel_names=lambda:template)
+        raw=mne.io.RawArray(np.random.default_rng(9).normal(size=(len(template)-1,50))*1e-6,
+                           mne.create_info(template[:-1],100,'eeg'),verbose=False)
+        raw.info['bads']=[template[3]]
+        reader=mne.io.read_raw_eeglab
+        mne.io.read_raw_eeglab=lambda *a,**k:raw.copy()
+        try:
+            before=old_io(Path('synthetic.set'))
+        finally:
+            mne.io.read_raw_eeglab=reader
+        after=harmonize_channels(raw,template,'GSN-HydroCel-256',exclude=channels['EXCLUDE_CHANNELS'],preserve_bads=False)
+        np.testing.assert_allclose(after.get_data(),before.get_data(),rtol=1e-14,atol=0)
+        assert after.ch_names == before.ch_names and after.info['bads'] == before.info['bads']
+        # Build the old dataclass/module without importing the migrated implementation.
+        import types, sys
+        old_segments=types.ModuleType('baseline_segments');sys.modules[old_segments.__name__]=old_segments
+        text=subprocess.check_output(['git','show','v1.0-preliminary:src/shared/segments.py'],cwd=root,text=True)
+        exec(text,old_segments.__dict__)
+        raw=mne.io.RawArray(np.zeros((1,2000)),mne.create_info(['Cz'],1,'eeg'),verbose=False)
+        raw.set_annotations(mne.Annotations([300,480,650,830],[0]*4,['STIM-start','stim end']*2))
+        old_pairs=old_segments.find_stim_pairs(raw)
+        new_pairs=annotation_pairs(raw,'stim start','stim end',min_duration=170,max_duration=220,relative_to_raw=False)
+        assert old_pairs == new_pairs
+        assert [dataclasses.asdict(w) for w in old_segments.build_protocols(old_pairs)] == [dataclasses.asdict(w) for w in stimulation_windows(new_pairs)]
+    """)
+
+
+def test_external_study_baseline_origin_scoring_parity():
+    """Same synthetic inverse/source signals through frozen and migrated scorers."""
+    if not os.environ.get("TIT_EEG_STUDY_ROOT"):
+        pytest.skip(
+            "TIT_EEG_STUDY_ROOT unset: external v1.0-preliminary scoring parity not requested"
+        )
+    run_real("""
+        import ast
+        import os
+        import subprocess
+        import time
+        from pathlib import Path
+        from types import SimpleNamespace
+        import mne
+        import numpy as np
+        import pandas as pd
+        import scipy.sparse as sp
+        from tit.source.reconstruction import prepare_inverse, apply_inverse_windows, diffusion_smoother
+        root=Path(os.environ['TIT_EEG_STUDY_ROOT'])
+        names=['Fp1','Fp2','F3','F4','C3','C4','P3','P4','O1','O2']
+        raw=mne.io.RawArray(np.random.default_rng(2).normal(size=(10,1200))*1e-6,
+                           mne.create_info(names,250,'eeg'),verbose=False)
+        raw.set_montage('standard_1020');raw.set_eeg_reference(projection=True,verbose=False)
+        sphere=mne.make_sphere_model(r0=(0,0,0),head_radius=0.09,verbose=False)
+        src=mne.setup_volume_source_space(pos=dict(rr=np.array([[.01,.02,.03],[-.02,.01,.04]]),
+                            nn=np.array([[0,0,1],[0,1,0]])),verbose=False)
+        fwd=mne.make_forward_solution(raw.info,trans=None,src=src,bem=sphere,eeg=True,meg=False,verbose=False)
+        inv=prepare_inverse(raw.info,fwd,mne.make_ad_hoc_cov(raw.info,verbose=False),loose=1.,depth=None)
+        class SyntheticMorph:
+            # Authored 2-vertex linear map, independent of cortical mapping implementation.
+            vertices_to=[np.array([0]),np.array([1])]
+            def apply(self, stc, verbose=False):
+                out=stc.copy();out.data=np.array([[.8,.2],[.1,.9]])@stc.data
+                return out
+        morph=SyntheticMorph()
+        waves=pd.DataFrame({'NegPeak':np.arange(100,1000,100)/250,
+                            'seg':['pre']*3+['stim']*3+['post']*3})
+        def setup(paths, depth=None):
+            return raw.get_data(),raw.info,250.,waves,inv,morph,2
+        old_text=subprocess.check_output(['git','show','v1.0-preliminary:src/source/source/origin.py'],cwd=root,text=True)
+        new_text=(root/'src/source/source/origin.py').read_text()
+        def scorer(text):
+            tree=ast.parse(text)
+            keep=[n for n in tree.body if isinstance(n,ast.Assign) or
+                  isinstance(n,ast.FunctionDef) and n.name=='compute_subject']
+            future=ast.ImportFrom(module='__future__',names=[ast.alias(name='annotations')],level=0)
+            module=ast.fix_missing_locations(ast.Module(body=[future,*keep],type_ignores=[]))
+            namespace=dict(time=time,Path=Path,np=np,mne=mne,setup_subject=setup,
+                           CFG_INV=SimpleNamespace(lambda2=1/9,method='sLORETA',pick_ori=None),
+                           build_diffusion_smoother=diffusion_smoother,
+                           apply_inverse_windows=apply_inverse_windows)
+            exec(compile(module,'origin.py','exec'),namespace)
+            return namespace['compute_subject']
+        # Geometry loading alone is replaced with an authored chain; no source data are mocked.
+        mne.datasets.fetch_fsaverage=lambda **kwargs:'/unused/fsaverage'
+        mne.read_source_spaces=lambda *args,**kwargs:None
+        mne.spatial_src_adjacency=lambda *args,**kwargs:sp.csr_matrix([[0,1],[1,0]])
+        old=scorer(old_text)(SimpleNamespace(subject_id='synthetic'))
+        new=scorer(new_text)(SimpleNamespace(subject_id='synthetic'))
+        assert old.keys()==new.keys()
+        for key in old:
+            if key in ('setup_sec','compute_sec'):
+                continue
+            if isinstance(old[key],np.ndarray):
+                np.testing.assert_allclose(new[key],old[key],rtol=1e-14,atol=0,err_msg=key)
+            else:
+                assert new[key]==old[key],key
+    """)
+
+
+def test_explicit_transform_reassembles_cached_forward_without_rerunning_fem():
+    # Filesystem/FEM process boundaries are replaced; MNE transform I/O remains real.
+    run_real("""
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+        import mne
+        import numpy as np
+        import tit.source.forward as forward
+        from tit.source.config import ForwardConfig
+        fids={'LPA':np.array([-.08,0,0]),'Nz':np.array([0,.10,0]),'RPA':np.array([.08,0,0])}
+        electrodes={'Cz':np.array([0,0,.09]),'Fpz':np.array([0,.08,.04])}
+        with TemporaryDirectory() as directory:
+            directory=Path(directory);model=directory/'m2m';model.mkdir()
+            output=directory/'forward';output.mkdir();leadfield=output/'cached.hdf5';leadfield.touch()
+            expected=tuple(output/f'custom{suffix}' for suffix in ('-fwd.fif','-src.fif','-morph.h5'))
+            for path in expected:path.touch()
+            with patch.object(forward,'_check_forward_dependencies'), \
+                 patch.object(forward,'_forward_outputs_valid',return_value=True), \
+                 patch.object(forward,'_read_simnibs_montage',return_value=(electrodes,fids)), \
+                 patch.object(forward,'_find_existing_leadfield',return_value=leadfield), \
+                 patch.object(forward,'_in_leadfield_order',side_effect=lambda positions,path:positions), \
+                 patch.object(forward,'_compute_leadfield',side_effect=AssertionError('FEM rerun')), \
+                 patch.object(forward,'_run') as worker, \
+                 patch.object(forward,'_rename_generated_outputs',return_value=expected):
+                cfg=ForwardConfig()
+                args=dict(head_model_dir=model,output_dir=output,output_stem='custom')
+                assert forward.prepare_forward('synthetic',cfg,**args)==expected
+                assert worker.call_count==0
+                for shift in (0.01,0.02):
+                    matrix=np.eye(4);matrix[0,3]=shift
+                    transform=mne.transforms.Transform('head','mri',matrix)
+                    forward.prepare_forward('synthetic',cfg,trans=transform,**args)
+                    saved=mne.read_trans(output/'custom-trans.fif',verbose=False)
+                    # FIF stores float32 transform values, bounding only serialization error.
+                    np.testing.assert_allclose(saved['trans'],matrix,rtol=0,atol=1e-9)
+                assert worker.call_count==2
+    """)

--- a/tests/numerical/test_eeg_study_parity.py
+++ b/tests/numerical/test_eeg_study_parity.py
@@ -1,0 +1,36 @@
+"""2026-09-13: optional frozen-study compatibility under real libraries.
+
+TIT_STUDY_CHECKOUTS=/path/sleepTI:/path/Dose-response_SW_TI python -m pytest
+ tests/numerical/test_eeg_study_parity.py -q
+
+The oracle is each checkout's v1.0-preliminary Git tag, never the migrated code.
+Only synthetic arrays are used. A clean child avoids host-suite MNE mocks.
+No participant data, downloads or hard-coded maintainer paths are required.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import pytest
+
+
+def test_frozen_study_arrays_match_migrated_adapters():
+    configured = os.environ.get("TIT_STUDY_CHECKOUTS")
+    if not configured:
+        pytest.skip(
+            "set TIT_STUDY_CHECKOUTS to tagged study checkouts for frozen-source compatibility"
+        )
+    roots = configured.split(os.pathsep)
+    if not all(Path(p).is_dir() for p in roots):
+        pytest.skip("a TIT_STUDY_CHECKOUTS path is unavailable")
+    probe = Path(__file__).with_name("eeg_study_parity_probe.py")
+    result = subprocess.run(
+        [sys.executable, str(probe), *roots], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    import json
+
+    report = json.loads(result.stdout)
+    assert report["passed"] == 18 * len(roots)
+    assert not report["dataset_rerun"]

--- a/tit/STUDY_CODE_NOTICE.txt
+++ b/tit/STUDY_CODE_NOTICE.txt
@@ -1,0 +1,35 @@
+Portions of tit/eeg.py, tit/source/reconstruction.py, tit/source/forward.py,
+tit/source/fsaverage.py, tit/atlas/surface.py and tit/stats/{graph,effects,
+associations,robustness}.py derive from Dose-response_SW_TI / sleepTI.
+Original study copyright and redistribution notice follow. The containing
+TI-Toolbox distribution retains its existing LICENSE.
+
+BSD 3-Clause License
+
+Copyright (c) 2026, Ido Haber and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tit/atlas/__init__.py
+++ b/tit/atlas/__init__.py
@@ -14,7 +14,16 @@ from tit.atlas.constants import (
     VOXEL_ATLAS_FILES,
 )
 from tit.atlas.mesh import MeshAtlasManager
-from tit.atlas.overlap import atlas_overlap_analysis, check_and_resample_atlas
+
+
+def __getattr__(name: str):
+    if name in {"atlas_overlap_analysis", "check_and_resample_atlas"}:
+        from tit.atlas import overlap
+
+        return getattr(overlap, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 from tit.atlas.voxel import VoxelAtlasManager
 
 __all__ = [

--- a/tit/atlas/surface.py
+++ b/tit/atlas/surface.py
@@ -1,0 +1,110 @@
+"""Surface label alignment and parcel reduction without study-specific atlases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+
+def labels_for_vertices(
+    annotation_path: str | Path, vertex_ids: np.ndarray
+) -> tuple[np.ndarray, list[str]]:
+    """Read FreeSurfer annotation labels at explicit native vertex identities."""
+    from nibabel.freesurfer.io import read_annot
+
+    labels, _, names = read_annot(str(annotation_path))
+    vertices = np.asarray(vertex_ids)
+    if vertices.ndim != 1 or not np.issubdtype(vertices.dtype, np.integer):
+        raise ValueError("vertex_ids must be a one-dimensional integer array")
+    if vertices.size and (vertices.min() < 0 or vertices.max() >= len(labels)):
+        raise ValueError("Vertex identity lies outside the annotation")
+    return labels[vertices].astype(int), [
+        n.decode() if isinstance(n, bytes) else str(n) for n in names
+    ]
+
+
+def nearest_vertex_ids(
+    reference_coordinates: np.ndarray,
+    query_coordinates: np.ndarray,
+    *,
+    max_distance: float | None = None,
+) -> np.ndarray:
+    """Align explicit coordinates in a common frame, optionally bounding distance."""
+    from scipy.spatial import cKDTree
+
+    ref, query = np.asarray(reference_coordinates, float), np.asarray(
+        query_coordinates, float
+    )
+    if any(
+        a.ndim != 2 or a.shape[1] != 3 or not np.isfinite(a).all() for a in (ref, query)
+    ) or not len(ref):
+        raise ValueError(
+            "Coordinate arrays must be finite N-by-3, with a nonempty reference"
+        )
+    distances, vertices = cKDTree(ref).query(query, k=1)
+    if max_distance is not None and (
+        max_distance < 0 or np.any(distances > max_distance)
+    ):
+        raise ValueError("Surface coordinates exceed the requested alignment tolerance")
+    return vertices
+
+
+def parcel_means(
+    values: np.ndarray,
+    labels: np.ndarray,
+    *,
+    region_ids: np.ndarray | None = None,
+    weights: np.ndarray | None = None,
+    nan_policy: str = "propagate",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reduce the final vertex axis to parcels, preserving all preceding axes.
+
+    Unweighted means are the default. Supply vertex areas explicitly for area
+    weighting. Negative label IDs are unassigned and omitted by default. Empty
+    regions return NaN. Returns (means, region_ids), retaining requested order.
+    """
+    values, labels = np.asarray(values, float), np.asarray(labels)
+    if values.ndim < 1 or labels.ndim != 1 or values.shape[-1] != labels.size:
+        raise ValueError("Last values axis must align with the label vector")
+    if not np.issubdtype(labels.dtype, np.integer):
+        raise ValueError("Labels must be integer region IDs")
+    if nan_policy not in {"propagate", "omit", "raise"}:
+        raise ValueError("nan_policy must be propagate, omit or raise")
+    if nan_policy == "raise" and not np.isfinite(values).all():
+        raise ValueError("Values contain nonfinite entries")
+    regions = (
+        np.unique(labels[labels >= 0]) if region_ids is None else np.asarray(region_ids)
+    )
+    if regions.ndim != 1 or not np.issubdtype(regions.dtype, np.integer):
+        raise ValueError("region_ids must be a one-dimensional integer array")
+    if weights is not None:
+        weights = np.asarray(weights, float)
+        if (
+            weights.shape != labels.shape
+            or not np.isfinite(weights).all()
+            or np.any(weights < 0)
+        ):
+            raise ValueError(
+                "Weights must be finite, nonnegative and aligned with vertices"
+            )
+    out = np.full(values.shape[:-1] + (regions.size,), np.nan)
+    for index, region in enumerate(regions):
+        mask = labels == region
+        if not mask.any():
+            continue
+        selected = values[..., mask]
+        if weights is None and nan_policy != "omit":
+            out[..., index] = selected.mean(axis=-1)
+            continue
+        w = np.ones(mask.sum()) if weights is None else weights[mask]
+        finite = (
+            np.isfinite(selected)
+            if nan_policy == "omit"
+            else np.ones(selected.shape, bool)
+        )
+        denom = np.sum(w * finite, axis=-1)
+        numerator = np.sum(np.where(finite, selected, 0) * w, axis=-1)
+        out[..., index] = np.divide(
+            numerator, denom, out=np.full(np.shape(numerator), np.nan), where=denom > 0
+        )
+    return out, regions

--- a/tit/eeg.py
+++ b/tit/eeg.py
@@ -1,0 +1,201 @@
+"""MNE-preserving EEG channel, annotation and interval utilities.
+
+These helpers accept recording metadata and study-defined choices; no EEG cap,
+stimulation duration, frequency band or condition names are selected implicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import re
+from collections.abc import Sequence
+
+import mne
+import numpy as np
+
+
+def harmonize_channels(
+    raw: mne.io.BaseRaw,
+    target_channels: Sequence[str],
+    montage: str | mne.channels.DigMontage,
+    *,
+    exclude: Sequence[str] = (),
+    preserve_bads: bool = True,
+    copy: bool = True,
+) -> mne.io.BaseRaw:
+    """Interpolate missing EEG channels and return the requested channel order.
+
+    Existing bad channels are included in interpolation by default. Set
+    ``preserve_bads=False`` only to reproduce an analysis that interpolated newly
+    absent channels alone. Input annotations, first sample and non-EEG metadata
+    are retained; channels outside ``target_channels`` are removed explicitly.
+    The supplied montage is applied only when interpolation is necessary.
+    """
+    names = list(target_channels)
+    if not names or len(set(names)) != len(names):
+        raise ValueError("target_channels must be a nonempty sequence of unique names")
+    if set(names) & set(exclude):
+        raise ValueError("target channels must not also be excluded")
+    result = raw.copy() if copy else raw
+    drops = [name for name in result.ch_names if name in exclude]
+    if drops:
+        result.drop_channels(drops)
+    missing = [name for name in names if name not in result.ch_names]
+    existing_bads = [name for name in result.info["bads"] if name in names]
+    interpolate = missing or (preserve_bads and existing_bads)
+    if interpolate:
+        dig = (
+            mne.channels.make_standard_montage(montage)
+            if isinstance(montage, str)
+            else montage
+        )
+        positions = dig.get_positions()["ch_pos"]
+        absent = [name for name in names if name not in positions]
+        if absent:
+            raise ValueError(f"Montage has no positions for target channels: {absent}")
+        result.set_montage(dig, on_missing="ignore")
+        if missing:
+            info = mne.create_info(missing, result.info["sfreq"], ch_types="eeg")
+            added = mne.io.RawArray(
+                np.zeros((len(missing), result.n_times)),
+                info,
+                first_samp=result.first_samp,
+                verbose=False,
+            )
+            added.set_montage(dig, on_missing="raise")
+            result.add_channels([added], force_update_info=True)
+        result.info["bads"] = (
+            list(dict.fromkeys(existing_bads + missing)) if preserve_bads else missing
+        )
+        result.interpolate_bads(reset_bads=True, verbose=False)
+    result.reorder_channels(names)
+    return result
+
+
+def annotation_pairs(
+    raw: mne.io.BaseRaw,
+    start_marker: str,
+    end_marker: str,
+    *,
+    min_duration: float = 0.0,
+    max_duration: float = float("inf"),
+    relative_to_raw: bool = True,
+) -> list[tuple[float, float]]:
+    """Pair normalized annotation labels, returning start/end times in seconds.
+
+    Times are relative to the first stored sample by default. The legacy option
+    ``relative_to_raw=False`` returns MNE annotation onsets unchanged. Pairing
+    uses the first subsequent end marker; invalid-duration pairs are omitted.
+    """
+    if min_duration < 0 or max_duration < min_duration:
+        raise ValueError("Require 0 <= min_duration <= max_duration")
+
+    def normalize(text: str) -> str:
+        return re.sub(r"[^a-z0-9]", "", str(text).lower())
+
+    start_label, end_label = normalize(start_marker), normalize(end_marker)
+    if not start_label or not end_label or start_label == end_label:
+        raise ValueError("Start and end markers must be distinct nonempty labels")
+    shift = raw.first_time if relative_to_raw else 0.0
+    starts = sorted(
+        float(a["onset"]) - shift
+        for a in raw.annotations
+        if normalize(a["description"]) == start_label
+    )
+    ends = sorted(
+        float(a["onset"]) - shift
+        for a in raw.annotations
+        if normalize(a["description"]) == end_label
+    )
+    pairs = []
+    end_idx = 0
+    for start in starts:
+        while end_idx < len(ends) and ends[end_idx] <= start:
+            end_idx += 1
+        if end_idx < len(ends):
+            end = ends[end_idx]
+            if min_duration <= end - start <= max_duration:
+                pairs.append((start, end))
+                end_idx += 1
+    return pairs
+
+
+@dataclass(frozen=True)
+class StimulationWindow:
+    """One stimulation interval and its explicitly constructed comparison windows."""
+
+    protocol_idx: int
+    stim_start_sec: float
+    stim_end_sec: float
+    pre_start_sec: float
+    pre_end_sec: float
+    post_start_sec: float
+    post_end_sec: float
+
+
+def stimulation_windows(
+    pairs: Sequence[tuple[float, float]],
+    *,
+    pre_duration: float | None = None,
+    post_duration: float | None = None,
+    split_overlaps: bool = True,
+) -> list[StimulationWindow]:
+    """Construct comparison windows; None uses each stimulation interval's length.
+
+    With ``split_overlaps=True``, adjacent POST/PRE overlaps are split at their
+    midpoint. Intervals are not clipped to a recording; callers must explicitly
+    decide recording boundaries and treatment of excluded/discontinuous time.
+    """
+    if any(end <= start for start, end in pairs):
+        raise ValueError("Stimulation intervals must have positive duration")
+    if any(pairs[i][0] > pairs[i + 1][0] for i in range(len(pairs) - 1)):
+        raise ValueError("Stimulation intervals must be ordered by start time")
+    if any(value is not None and value < 0 for value in (pre_duration, post_duration)):
+        raise ValueError("Comparison durations must be nonnegative")
+    result = []
+    for i, (start, end) in enumerate(pairs):
+        duration = end - start
+        result.append(
+            StimulationWindow(
+                i,
+                start,
+                end,
+                start - (duration if pre_duration is None else pre_duration),
+                start,
+                end,
+                end + (duration if post_duration is None else post_duration),
+            )
+        )
+    if split_overlaps:
+        for i in range(len(result) - 1):
+            current, following = result[i], result[i + 1]
+            overlap = current.post_end_sec - following.pre_start_sec
+            if overlap > 0:
+                result[i] = replace(
+                    current, post_end_sec=current.post_end_sec - overlap / 2
+                )
+                result[i + 1] = replace(
+                    following, pre_start_sec=following.pre_start_sec + overlap / 2
+                )
+    return result
+
+
+def sensor_adjacency(
+    info: mne.Info,
+    channel_names: Sequence[str] | None = None,
+) -> tuple[object, list[str], list[int]]:
+    """Return EEG adjacency with an explicit permutation of the input channel axis.
+
+    ``info`` must already carry the caller's intended montage. The returned
+    indices reorder ``channel_names`` (or info's names) into adjacency order.
+    """
+    names = list(info.ch_names if channel_names is None else channel_names)
+    if len(set(names)) != len(names):
+        raise ValueError("channel_names must be unique")
+    if any(name not in info.ch_names for name in names):
+        raise ValueError("All requested channels must be present in info")
+    selected = mne.pick_info(
+        info, mne.pick_channels(info.ch_names, names, ordered=True)
+    )
+    adjacency, ordered = mne.channels.find_ch_adjacency(selected, ch_type="eeg")
+    return adjacency, ordered, [names.index(name) for name in ordered]

--- a/tit/fields.py
+++ b/tit/fields.py
@@ -265,3 +265,41 @@ def hf_sar(*fields) -> np.ndarray:
     stack, shape = _stack_fields(fields)
     flat = np.sum(np.linalg.norm(stack, axis=-1) ** 2, axis=0)
     return flat.reshape(shape[:-1])
+
+
+def carrier_metrics(
+    fields: list[np.ndarray], normals: np.ndarray | None = None
+) -> dict[str, np.ndarray]:
+    """Summarize carrier vectors on one common geometry before interpolation.
+
+    Returns peak exposure, heating driver, carrier magnitudes and their loose
+    sum bound. With unit normals, also returns absolute normal components and
+    the absolute normal vector sum. Two fields additionally define TI_normal.
+    Units are V/m, except hf_sar (V²/m²). Normal components are sign-invariant.
+    """
+    _stack_fields(tuple(fields))  # validates shared vector shape
+    arrays = [np.asarray(value, dtype=float) for value in fields]
+    if not all(np.isfinite(value).all() for value in arrays):
+        raise ValueError("Carrier vectors must be finite")
+    out = {"hf_peak": hf_peak(*arrays), "hf_sar": hf_sar(*arrays)}
+    magnitudes = [np.linalg.norm(value, axis=-1) for value in arrays]
+    out["carrier_sum"] = np.sum(magnitudes, axis=0)
+    for index, value in enumerate(magnitudes, 1):
+        out[f"carrier_{index}"] = value
+    if normals is not None:
+        normals = np.asarray(normals, dtype=float)
+        if normals.shape != arrays[0].shape or not np.isfinite(normals).all():
+            raise ValueError("Normals must be finite and match the vector field shape")
+        if not np.allclose(np.linalg.norm(normals, axis=-1), 1.0, atol=1e-6, rtol=0):
+            raise ValueError(
+                "Supply unit normals in the same coordinate frame as fields"
+            )
+        projected = [np.sum(value * normals, axis=-1) for value in arrays]
+        for index, value in enumerate(projected, 1):
+            out[f"carrier_normal_{index}"] = np.abs(value)
+        out["carrier_normal_sum"] = np.abs(np.sum(projected, axis=0))
+        if len(arrays) == 2:
+            out["TI_normal"] = 2.0 * np.minimum(
+                np.abs(projected[0]), np.abs(projected[1])
+            )
+    return out

--- a/tit/source/__init__.py
+++ b/tit/source/__init__.py
@@ -18,8 +18,25 @@ tit.source.config : ``ForwardConfig`` and ``FsavgMapConfig`` dataclasses.
 """
 
 from tit.source.config import ForwardConfig, FsavgMapConfig
-from tit.source.fsaverage import project_fields_to_fsaverage, project_subject
-from tit.source.forward import prepare_forward
+
+
+def __getattr__(name: str):
+    # Loading inverse/array utilities must not import the SimNIBS forward stack.
+    if name == "prepare_forward":
+        from tit.source.forward import prepare_forward
+
+        return prepare_forward
+    if name in {
+        "project_fields_to_fsaverage",
+        "project_subject",
+        "project_carrier_fields",
+        "project_scalar_field",
+    }:
+        from tit.source import fsaverage
+
+        return getattr(fsaverage, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ForwardConfig",
@@ -27,4 +44,6 @@ __all__ = [
     "prepare_forward",
     "project_fields_to_fsaverage",
     "project_subject",
+    "project_carrier_fields",
+    "project_scalar_field",
 ]

--- a/tit/source/_forward_inputs.py
+++ b/tit/source/_forward_inputs.py
@@ -1,0 +1,52 @@
+"""SimNIBS worker for explicit EEG forward inputs from an external study layout.
+
+Run ``simnibs_python -m tit.source._forward_inputs --help``. Scientific logic
+lives in ``prepare_forward``; this worker only loads MNE metadata and arguments.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import mne
+
+from tit.source.config import ForwardConfig
+from tit.source.forward import prepare_forward
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("subject_id")
+    parser.add_argument("head_model_dir")
+    parser.add_argument("output_dir")
+    parser.add_argument("--info", help="FIF recording/Info with digitized fiducials")
+    parser.add_argument("--trans", help="FIF head-to-MRI transform")
+    parser.add_argument("--eeg-net", required=True)
+    parser.add_argument("--spacing", type=int, default=5)
+    parser.add_argument("--cpus", type=int, default=1)
+    parser.add_argument("--output-stem")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+    config = ForwardConfig(
+        eeg_net=args.eeg_net,
+        fsaverage_spacing=args.spacing,
+        cpus=args.cpus,
+        overwrite=args.overwrite,
+    )
+    info = mne.io.read_info(args.info, verbose=False) if args.info else None
+    trans = mne.read_trans(args.trans, verbose=False) if args.trans else None
+    outputs = prepare_forward(
+        args.subject_id,
+        config,
+        output_dir=args.output_dir,
+        head_model_dir=args.head_model_dir,
+        info=info,
+        trans=trans,
+        output_stem=args.output_stem,
+    )
+    for output in outputs:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tit/source/cache.py
+++ b/tit/source/cache.py
@@ -1,0 +1,71 @@
+"""Versioned array caches for derived fields, with explicit input provenance."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import zipfile
+import numpy as np
+
+
+def input_fingerprints(paths: list[str | Path]) -> list[dict[str, object]]:
+    """Hash input bytes so edited files cannot silently reuse old projections."""
+    records = []
+    for raw in paths:
+        path = Path(raw).resolve()
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        records.append(
+            {
+                "path": str(path),
+                "sha256": digest.hexdigest(),
+                "bytes": path.stat().st_size,
+            }
+        )
+    return records
+
+
+def read_array_cache(
+    path: str | Path, metadata: dict, required_fields: tuple[str, ...]
+) -> dict[str, np.ndarray] | None:
+    """Return a cache only when provenance and every requested field match."""
+    try:
+        with np.load(path, allow_pickle=False) as cache:
+            if "_metadata_json" not in cache or not set(required_fields).issubset(
+                cache.files
+            ):
+                return None
+            if json.loads(str(cache["_metadata_json"].item())) != metadata:
+                return None
+            return {name: np.asarray(cache[name]) for name in required_fields}
+    except (OSError, ValueError, KeyError, EOFError, zipfile.BadZipFile):
+        return None
+
+
+def write_array_cache(
+    path: str | Path, arrays: dict[str, np.ndarray], metadata: dict
+) -> None:
+    """Atomically write arrays and JSON provenance without pickle objects."""
+    target = Path(path)
+    if "_metadata_json" in arrays:
+        raise ValueError("_metadata_json is reserved for cache provenance")
+    converted = {name: np.asarray(value) for name, value in arrays.items()}
+    if any(value.dtype.hasobject for value in converted.values()):
+        raise ValueError("Object arrays are not permitted in scientific caches")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=target.stem + "-", suffix=".npz", dir=target.parent
+    )
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            np.savez_compressed(
+                stream, **converted, _metadata_json=json.dumps(metadata, sort_keys=True)
+            )
+        os.replace(temporary, target)
+    finally:
+        Path(temporary).unlink(missing_ok=True)

--- a/tit/source/forward.py
+++ b/tit/source/forward.py
@@ -39,6 +39,8 @@ import sys
 from pathlib import Path
 
 import mne
+import mne.coreg
+import mne.transforms
 import numpy as np
 
 from tit.paths import get_path_manager
@@ -95,6 +97,9 @@ def _read_simnibs_montage(
 def _build_montage_info(
     electrodes: dict[str, np.ndarray],
     fiducials: dict[str, np.ndarray],
+    *,
+    info: mne.Info | None = None,
+    trans: mne.transforms.Transform | None = None,
 ) -> tuple[mne.Info, mne.transforms.Transform]:
     """Build an MNE ``Info`` + head<->MRI ``trans`` from net positions.
 
@@ -102,7 +107,9 @@ def _build_montage_info(
     define the MNE *head* frame directly from the same fiducials.  The resulting
     head<->MRI transform is therefore (near-)identity: the forward is built with
     electrodes at their true subject-space locations, with no dependency on an
-    actual EEG recording.
+    actual EEG recording. Supplying ``info`` instead uses the recording's
+    fiducials, preserving its head frame. An explicit head-to-MRI ``trans``
+    takes precedence and is never re-estimated.
     """
     # An Info whose montage carries the net's own fiducials, used only to derive
     # the head frame that coregister_fiducials aligns to the MRI fiducials.
@@ -121,7 +128,12 @@ def _build_montage_info(
         {"ident": 2, "kind": 1, "r": fiducials["Nz"], "coord_frame": 5},
         {"ident": 3, "kind": 1, "r": fiducials["RPA"], "coord_frame": 5},
     ]
-    trans = mne.coreg.coregister_fiducials(seed_info, fid_list, tol=1e-1)
+    if trans is None:
+        trans = mne.coreg.coregister_fiducials(
+            seed_info if info is None else info, fid_list, tol=1e-1
+        )
+    elif trans["from"] != 4 or trans["to"] != 5:
+        raise ValueError("trans must map MNE head coordinates to MRI coordinates")
     mri_to_head = mne.transforms.invert_transform(trans)
 
     ch_names = list(electrodes)
@@ -300,6 +312,10 @@ def prepare_forward(
     cfg: ForwardConfig,
     *,
     output_dir: str | Path | None = None,
+    head_model_dir: str | Path | None = None,
+    info: mne.Info | None = None,
+    trans: mne.transforms.Transform | None = None,
+    output_stem: str | None = None,
 ) -> tuple[Path, Path, Path]:
     """Rebuild one subject's forward, source-space, and fsaverage morph files.
 
@@ -312,14 +328,23 @@ def prepare_forward(
     output_dir : str or pathlib.Path or None
         Destination directory.  Defaults to ``pm.forward(subject_id)``
         (``derivatives/SimNIBS/sub-<id>/forward/``).
+    head_model_dir : str or pathlib.Path or None
+        Explicit SimNIBS m2m directory; bypasses project discovery when supplied
+        together with output_dir (for external study layouts).
+    info : mne.Info or None
+        Recording Info whose digitized fiducials define the EEG head frame.
+    trans : mne.transforms.Transform or None
+        Explicit head-to-MRI transform; takes precedence over Info fiducials.
+    output_stem : str or None
+        Existing study cache prefix to preserve; must be a filename, not a path.
 
     Returns
     -------
     tuple of pathlib.Path
         ``(fwd_path, src_path, morph_path)``.
     """
-    pm = get_path_manager()
-    m2m_dir = Path(pm.m2m(subject_id))
+    pm = get_path_manager() if head_model_dir is None or output_dir is None else None
+    m2m_dir = Path(pm.m2m(subject_id) if head_model_dir is None else head_model_dir)
     if not m2m_dir.is_dir():
         raise FileNotFoundError(f"m2m directory not found: {m2m_dir}")
 
@@ -330,13 +355,23 @@ def prepare_forward(
     )
     forward_dir.mkdir(parents=True, exist_ok=True)
 
-    stem = f"sub-{subject_id}_net-{cfg.eeg_net}"
+    stem = output_stem or f"sub-{subject_id}_net-{cfg.eeg_net}"
+    if Path(stem).name != stem or stem in (".", ".."):
+        raise ValueError("output_stem must be a filename prefix, not a path")
     expected = (
         forward_dir / f"{stem}-fwd.fif",
         forward_dir / f"{stem}-src.fif",
         forward_dir / f"{stem}-morph.h5",
     )
-    if not cfg.overwrite and _forward_outputs_valid(*expected):
+    # Explicit recording geometry must reach assembly even when a readable cache
+    # exists: the old transform may describe different fiducials. The FEM
+    # leadfield is still reused below; only the MNE coordinate metadata is rebuilt.
+    if (
+        info is None
+        and trans is None
+        and not cfg.overwrite
+        and _forward_outputs_valid(*expected)
+    ):
         logger.info("Forward outputs already present for %s; skipping.", subject_id)
         return expected
 
@@ -354,7 +389,12 @@ def prepare_forward(
     # SimNIBS's assembly asserts `info["ch_names"] == forward["ch_names"]` element by
     # element, and the leadfield does not use the net CSV's order (below).
     electrodes = _in_leadfield_order(electrodes, leadfield_hdf5)
-    montage_info, trans = _build_montage_info(electrodes, fiducials)
+    if info is None and trans is None:
+        montage_info, trans = _build_montage_info(electrodes, fiducials)
+    else:
+        montage_info, trans = _build_montage_info(
+            electrodes, fiducials, info=info, trans=trans
+        )
 
     info_path = forward_dir / f"{stem}-info.fif"
     trans_path = forward_dir / f"{stem}-trans.fif"

--- a/tit/source/fsaverage.py
+++ b/tit/source/fsaverage.py
@@ -278,14 +278,27 @@ def project_subject(
     """
     pm = get_path_manager()
     out_path = _output_path(pm, subject_id, sim, cfg.fsaverage_spacing)
-    if out_path.exists() and not cfg.overwrite:
+    from tit.source.cache import read_array_cache, write_array_cache
+
+    try:
+        metadata = _projection_metadata(pm, subject_id, sim, cfg)
+    except (OSError, ValueError) as exc:
+        return subject_id, "failed", repr(exc)
+    if (
+        not cfg.overwrite
+        and read_array_cache(out_path, metadata, cfg.fields) is not None
+    ):
         return subject_id, "cached", out_path.name
     try:
         maps = _compute_fields(pm, subject_id, sim, cfg)
     except Exception as exc:  # noqa: BLE001 - record per-subject and continue
         return subject_id, "failed", repr(exc)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(out_path, subject_id=subject_id, simulation=sim, **maps)
+    write_array_cache(
+        out_path,
+        dict(subject_id=np.asarray(subject_id), simulation=np.asarray(sim), **maps),
+        metadata,
+    )
     medians = ", ".join(f"{k} med={np.median(v):.3f}" for k, v in maps.items())
     return subject_id, "ok", f"{medians} -> {out_path.name}"
 
@@ -334,3 +347,120 @@ def _log_result(result: tuple[str, str, str]) -> None:
     subject_id, status, msg = result
     tag = {"ok": "✓", "cached": "CACHED", "failed": "✗ FAILED"}.get(status, status)
     print(f"[{tag}] {subject_id}: {msg}", flush=True)
+
+
+def _subject_geometry(head_model_dir: str | Path, spacing: int):
+    from simnibs.mesh_tools import mesh_io
+    from simnibs.utils.file_finder import SubjectFiles
+    from simnibs.utils.transformations import cross_subject_map
+
+    if spacing not in _FSAVG_NODES:
+        raise ValueError(f"Unsupported fsaverage spacing: {spacing}")
+    subject = SubjectFiles(subpath=str(head_model_dir))
+    central = mesh_io.load_subject_surfaces(subject, "central")
+    hemispheres = ("lh", "rh")
+    morph = cross_subject_map(subject, "fsaverage", subsampling_to=spacing)
+    return central, morph, hemispheres
+
+
+def project_carrier_fields(
+    carrier_meshes: list[str | Path], head_model_dir: str | Path, *, spacing: int = 5
+) -> dict[str, np.ndarray]:
+    """Project carrier summaries from explicit FEM inputs onto fsaverage.
+
+    Each carrier is first interpolated onto the same native central surface.
+    Vector operations and normal projections happen there, before scalar maps
+    are morphed. Outputs follow left-then-right hemisphere vertex order. This
+    accepts arbitrary dataset layouts and writes no files.
+    """
+    from tit.fields import carrier_metrics
+
+    if len(carrier_meshes) < 2:
+        raise ValueError("At least two carrier meshes are required")
+    central, morph, hemispheres = _subject_geometry(head_model_dir, spacing)
+    n_lh, n_rh = central["lh"].nodes.nr, central["rh"].nodes.nr
+    vectors = []
+    for path in carrier_meshes:
+        mesh, gm = _load_carrier_mesh(Path(path))
+        vectors.append(_interp_to_central(mesh, gm, "E", central, hemispheres))
+    normals = np.concatenate(
+        [
+            np.asarray(central[hemi].nodes_normals().value, dtype=float)
+            for hemi in hemispheres
+        ]
+    )
+    result = {
+        name: _morph_split(value, n_lh, n_rh, morph, hemispheres)
+        for name, value in carrier_metrics(vectors, normals).items()
+    }
+    for name, value in result.items():
+        if value.shape != (_FSAVG_NODES[spacing],):
+            raise ValueError(f"{name}: unexpected fsaverage shape {value.shape}")
+    return result
+
+
+def project_scalar_field(
+    mesh_path: str | Path,
+    head_model_dir: str | Path,
+    field_name: str,
+    *,
+    spacing: int = 5,
+) -> np.ndarray:
+    """Interpolate a GM scalar field to the central surface and then fsaverage.
+
+    Explicit paths support post-hoc projection of already completed simulations.
+    No participant's mesh is used as an implicit template for another.
+    """
+    central, morph, hemispheres = _subject_geometry(head_model_dir, spacing)
+    mesh, gm = _load_carrier_mesh(Path(mesh_path))
+    native = _interp_to_central(mesh, gm, field_name, central, hemispheres)
+    if native.ndim != 1:
+        raise ValueError("project_scalar_field requires a scalar mesh field")
+    result = _morph_split(
+        native, central["lh"].nodes.nr, central["rh"].nodes.nr, morph, hemispheres
+    )
+    if result.shape != (_FSAVG_NODES[spacing],):
+        raise ValueError(f"Unexpected fsaverage shape: {result.shape}")
+    return result
+
+
+def _projection_metadata(pm, subject_id: str, sim: str, cfg: FsavgMapConfig) -> dict:
+    from tit.source.cache import input_fingerprints
+    from importlib.metadata import PackageNotFoundError, version
+
+    runtime = {}
+    for package in ("simnibs", "cortech", "numpy", "scipy"):
+        try:
+            runtime[package] = version(package)
+        except PackageNotFoundError:
+            runtime[package] = "unavailable"
+
+    inputs: list[Path] = []
+    missing: list[str] = []
+    resolvers = []
+    if "TI_max" in cfg.fields:
+        resolvers.append(lambda: [_ti_max_overlay(pm, subject_id, sim)[0]])
+    if "TI_normal" in cfg.fields:
+        resolvers.append(lambda: [_ti_normal_overlay(pm, subject_id, sim)])
+    if {"hf_peak", "hf_sar"}.intersection(cfg.fields):
+        resolvers.append(lambda: list(_carrier_volume_meshes(pm, subject_id, sim)))
+    for resolve in resolvers:
+        try:
+            inputs.extend(resolve())
+        except FileNotFoundError as exc:
+            missing.append(str(exc))
+    surface_dir = Path(pm.m2m(subject_id)) / "surfaces"
+    inputs.extend(sorted(surface_dir.glob("*central*.gii")))
+    inputs.extend(sorted(surface_dir.glob("*sphere*.gii")))
+    return {
+        "schema": 1,
+        "runtime": runtime,
+        "calculation": "native-scalar-then-morph-v1",
+        "subject": subject_id,
+        "simulation": sim,
+        "spacing": cfg.fsaverage_spacing,
+        "fields": list(cfg.fields),
+        "vertex_order": "hemisphere-native-morph",
+        "inputs": input_fingerprints(sorted(set(inputs))),
+        "missing_inputs": missing,
+    }

--- a/tit/source/reconstruction.py
+++ b/tit/source/reconstruction.py
@@ -1,0 +1,226 @@
+"""Generic MNE covariance, inverse and source-map operations.
+
+Frequency bands, reference, noise definition and inverse parameters belong to
+study configuration. These operations do not detect events or select outcomes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import mne
+import numpy as np
+from scipy import sparse
+
+
+def subtract_intervals(
+    intervals: Sequence[tuple[float, float]],
+    exclusions: Sequence[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """Subtract the union of exclusions, preserving interval order and boundaries."""
+    if any(
+        not np.isfinite((start, end)).all() or end < start
+        for start, end in (*intervals, *exclusions)
+    ):
+        raise ValueError("Intervals must have finite ordered endpoints")
+    merged = []
+    for start, end in sorted(exclusions):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    clean = []
+    for start, end in intervals:
+        cursor = start
+        for left, right in merged:
+            if right <= cursor or left >= end:
+                continue
+            if left > cursor:
+                clean.append((cursor, min(left, end)))
+            cursor = max(cursor, right)
+        if cursor < end:
+            clean.append((cursor, end))
+    return clean
+
+
+def epochs_from_intervals(
+    raw: mne.io.BaseRaw,
+    intervals: Sequence[tuple[float, float]],
+    *,
+    exclusions: Sequence[tuple[float, float]] = (),
+    epoch_duration: float = 2.0,
+    legacy_sampling: bool = False,
+    reject_by_annotation: bool = True,
+    picks: object = None,
+) -> mne.Epochs:
+    """Construct non-overlapping noise epochs from raw-relative second intervals.
+
+    Modern sampling includes exactly fitting epochs and accounts for first_samp.
+    ``legacy_sampling=True`` reproduces older analyses using truncated sample
+    bounds, omitting exactly fitting terminal epochs and treating event samples
+    as absolute without adding first_samp. This mode is for reproducibility only.
+    Intervals are half-open; default bounds round inward to avoid excluded data.
+    """
+    sfreq = raw.info["sfreq"]
+    if not np.isfinite(epoch_duration) or epoch_duration <= 0:
+        raise ValueError("epoch_duration must be positive and finite")
+    step = (
+        int(epoch_duration * sfreq)
+        if legacy_sampling
+        else int(round(epoch_duration * sfreq))
+    )
+    if step < 1:
+        raise ValueError("epoch_duration must span at least one sample")
+    events = []
+    for start_sec, end_sec in subtract_intervals(intervals, exclusions):
+        start = max(
+            0,
+            (
+                int(start_sec * sfreq)
+                if legacy_sampling
+                else int(np.ceil(start_sec * sfreq))
+            ),
+        )
+        end = min(
+            raw.n_times,
+            int(end_sec * sfreq) if legacy_sampling else int(np.floor(end_sec * sfreq)),
+        )
+        stop = end - step if legacy_sampling else end - step + 1
+        shift = 0 if legacy_sampling else raw.first_samp
+        events.extend([sample + shift, 0, 1] for sample in range(start, stop, step))
+    if not events:
+        raise ValueError("No complete noise epochs remain in the requested intervals")
+    # Keep the historical floating-duration tmax in compatibility mode.
+    tmax = epoch_duration - 1 / sfreq if legacy_sampling else (step - 1) / sfreq
+    return mne.Epochs(
+        raw,
+        np.asarray(events, dtype=int),
+        event_id={"noise": 1},
+        tmin=0.0,
+        tmax=tmax,
+        baseline=None,
+        preload=True,
+        picks=picks,
+        reject_by_annotation=reject_by_annotation,
+        verbose=False,
+    )
+
+
+def covariance_from_intervals(
+    raw: mne.io.BaseRaw,
+    intervals: Sequence[tuple[float, float]],
+    *,
+    exclusions: Sequence[tuple[float, float]] = (),
+    epoch_duration: float = 2.0,
+    method: str | Sequence[str] = "auto",
+    rank: object = None,
+    legacy_sampling: bool = False,
+    reject_by_annotation: bool = True,
+    picks: object = None,
+) -> mne.Covariance:
+    """Estimate MNE noise covariance from explicitly selected event-free intervals."""
+    epochs = epochs_from_intervals(
+        raw,
+        intervals,
+        exclusions=exclusions,
+        epoch_duration=epoch_duration,
+        legacy_sampling=legacy_sampling,
+        reject_by_annotation=reject_by_annotation,
+        picks=picks,
+    )
+    if len(epochs) == 0:
+        raise ValueError("No noise epochs remain after annotation rejection")
+    return mne.compute_covariance(epochs, method=method, rank=rank, verbose=False)
+
+
+def prepare_inverse(
+    info: mne.Info,
+    forward: mne.Forward,
+    covariance: mne.Covariance,
+    *,
+    loose: object,
+    depth: object,
+    rank: object = None,
+) -> object:
+    """Align forward channels and construct an inverse with caller-selected priors.
+
+    The input Info must already carry its reference/projectors and bad channels.
+    Frequency filtering and covariance selection are deliberately separate.
+    """
+    selected = mne.pick_channels_forward(forward, include=info.ch_names, ordered=True)
+    return mne.minimum_norm.make_inverse_operator(
+        info, selected, covariance, loose=loose, depth=depth, rank=rank, verbose=False
+    )
+
+
+def apply_inverse_windows(
+    data: np.ndarray,
+    info: mne.Info,
+    inverse: object,
+    peak_samples: np.ndarray,
+    offsets: np.ndarray,
+    *,
+    lambda2: float,
+    method: str,
+    pick_ori: str | None = None,
+    morph: object = None,
+) -> np.ndarray:
+    """Apply an inverse to a batch of event windows: vertex[, orientation], event, time.
+
+    Sample indices are relative to ``data``. The caller defines and retains event
+    identities/timing. The linear inverse and optional morph are batched through
+    an EvokedArray without averaging events; scalar magnitude is handled by MNE
+    before morphing, preserving the same operation order as apply_inverse_epochs.
+    Input windows must already be in bounds. Chunking is controlled by the caller.
+    """
+    values = np.asarray(data)
+    peaks = np.asarray(peak_samples)
+    window = np.asarray(offsets)
+    if values.ndim != 2 or values.shape[0] != len(info.ch_names):
+        raise ValueError("data must be channels x samples in Info channel order")
+    if peaks.ndim != 1 or window.ndim != 1 or not peaks.size or not window.size:
+        raise ValueError("peak_samples and offsets must be nonempty 1D arrays")
+    if peaks.dtype.kind not in "iu" or window.dtype.kind not in "iu":
+        raise ValueError("peak_samples and offsets must contain integer sample indices")
+    columns = peaks[:, None] + window[None, :]
+    if columns.min() < 0 or columns.max() >= values.shape[1]:
+        raise ValueError("Requested inverse window extends outside data")
+    block = values[:, columns.ravel()].astype(np.float64, copy=False)
+    evoked = mne.EvokedArray(block, info, tmin=0, verbose=False)
+    stc = mne.minimum_norm.apply_inverse(
+        evoked,
+        inverse,
+        lambda2=lambda2,
+        method=method,
+        pick_ori=pick_ori,
+        verbose=False,
+    )
+    if morph is not None:
+        stc = morph.apply(stc, verbose=False)
+    return stc.data.reshape(*stc.data.shape[:-1], len(peaks), len(window))
+
+
+def diffusion_smoother(adjacency: sparse.spmatrix, n_iters: int) -> sparse.spmatrix:
+    """Return n vertex-and-neighbor averaging steps on an explicit adjacency graph.
+
+    Adds a self-edge exactly once to the supplied graph; pass a zero-diagonal
+    adjacency to obtain equal weights for the vertex and each neighbor.
+    """
+    if (
+        not sparse.issparse(adjacency)
+        or adjacency.ndim != 2
+        or adjacency.shape[0] != adjacency.shape[1]
+    ):
+        raise ValueError("adjacency must be square")
+    if not isinstance(n_iters, (int, np.integer)) or n_iters < 0:
+        raise ValueError("n_iters must be a nonnegative integer")
+    if np.any(~np.isfinite(adjacency.data)) or np.any(adjacency.data < 0):
+        raise ValueError("adjacency weights must be finite and nonnegative")
+    n_vertices = adjacency.shape[0]
+    with_self = adjacency + sparse.eye(n_vertices)
+    degree = np.asarray(with_self.sum(axis=1)).ravel()
+    transition = sparse.diags(1 / np.maximum(degree, 1)) @ with_self
+    smoother = sparse.eye(n_vertices)
+    for _ in range(n_iters):
+        smoother = smoother @ transition
+    return smoother

--- a/tit/stats/__init__.py
+++ b/tit/stats/__init__.py
@@ -32,7 +32,16 @@ from tit.stats.config import (
     GroupComparisonConfig,
     GroupComparisonResult,
 )
-from tit.stats.permutation import run_correlation, run_group_comparison
+
+
+def __getattr__(name: str):
+    # Array statistics should not import NIfTI, plotting or FEM dependencies.
+    if name in {"run_correlation", "run_group_comparison"}:
+        from tit.stats import permutation
+
+        return getattr(permutation, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "run_group_comparison",

--- a/tit/stats/associations.py
+++ b/tit/stats/associations.py
@@ -1,0 +1,306 @@
+"""Array-only associations, explicit-family FDR and rank-dose moderation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+from scipy import stats
+
+
+def residualize(y: np.ndarray, covariates: np.ndarray) -> np.ndarray:
+    """OLS residuals including an intercept; inputs must be finite."""
+    y = np.asarray(y, dtype=float)
+    z = np.asarray(covariates, dtype=float)
+    if z.size == 0:
+        z = np.empty((y.size, 0))
+    elif z.ndim == 1:
+        z = z[:, None]
+    if z.ndim != 2 or y.ndim != 1 or z.shape[0] != y.size:
+        raise ValueError("covariates must have one row per outcome")
+    if not np.isfinite(y).all() or not np.isfinite(z).all():
+        raise ValueError("residualize requires finite inputs")
+    design = np.column_stack([np.ones(y.size), z])
+    return y - design @ np.linalg.lstsq(design, y, rcond=None)[0]
+
+
+def partial_ranked(y: np.ndarray, x: np.ndarray, covariates: np.ndarray) -> float:
+    """Partial Pearson on already ranked finite inputs, for explicit pipelines.
+
+    Fully explained or constant inputs have undefined partial correlation.
+    Residuals below least-squares roundoff are rejected relative to each
+    centered input's own scale, never against an absolute magnitude floor.
+    """
+    y, x = np.asarray(y, dtype=float), np.asarray(x, dtype=float)
+    ey, ex = residualize(y, covariates), residualize(x, covariates)
+
+    def standardized_residual(original, residual):
+        centered = original - original.mean()
+        scale = np.max(np.abs(centered)) if centered.size else 0.0
+        if scale == 0:
+            return None
+        # Scale first to avoid underflow for legitimate small-valued inputs.
+        centered = centered / scale
+        residual = (residual - residual.mean()) / scale
+        z = np.asarray(covariates)
+        columns = z.shape[1] if z.ndim == 2 else 1
+        tolerance = 8 * np.finfo(float).eps * max(original.size, columns + 1)
+        if np.linalg.norm(residual) <= tolerance * np.linalg.norm(centered):
+            return None
+        return residual
+
+    ey, ex = standardized_residual(y, ey), standardized_residual(x, ex)
+    if ey is None or ex is None:
+        return float("nan")
+    return float(np.corrcoef(ey, ex)[0, 1])
+
+
+def partial_pvalue(
+    r: float, n: int, n_covariates: int, *, published_policy: bool = False
+) -> float:
+    """Two-sided t approximation; not a permutation p-value."""
+    df = n - n_covariates - 2
+    if df <= 0 or not np.isfinite(r):
+        return float("nan")
+    if abs(r) >= 1:
+        return float("nan") if published_policy else 0.0
+    return float(2 * stats.t.sf(abs(r) * np.sqrt(df / (1 - r * r)), df))
+
+
+def partial_spearman(
+    y: np.ndarray, x: np.ndarray, covariates: np.ndarray
+) -> tuple[float, float]:
+    """Complete-case partial Spearman rho and approximate two-sided p.
+
+    The same complete participant set is selected before ranking every input.
+    A rank-deficient covariate design raises rather than reporting misleading
+    degrees of freedom. Bootstrap/permutation inference is a separate choice.
+    """
+    y, x, z = np.asarray(y, float), np.asarray(x, float), np.asarray(covariates, float)
+    if z.ndim == 1:
+        z = z[:, None]
+    if y.ndim != 1 or x.shape != y.shape or z.ndim != 2 or z.shape[0] != y.size:
+        raise ValueError("inputs must share participant rows")
+    valid = np.isfinite(y) & np.isfinite(x) & np.isfinite(z).all(axis=1)
+    y, x, z = y[valid], x[valid], z[valid]
+    if y.size <= z.shape[1] + 2:
+        return float("nan"), float("nan")
+    ry, rx, rz = stats.rankdata(y), stats.rankdata(x), stats.rankdata(z, axis=0)
+    if np.linalg.matrix_rank(np.column_stack([np.ones(y.size), rz])) < z.shape[1] + 1:
+        raise ValueError("covariate design is rank deficient")
+    r = partial_ranked(ry, rx, rz)
+    return r, partial_pvalue(r, y.size, z.shape[1])
+
+
+def bh_fdr(pvalues: np.ndarray) -> np.ndarray:
+    """Benjamini-Hochberg q values for one explicitly supplied family.
+
+    NaNs are omitted from this family's denominator and returned as NaNs.
+    """
+    p = np.asarray(pvalues, dtype=float)
+    if p.ndim != 1:
+        raise ValueError("supply a one-dimensional family")
+    finite = np.isfinite(p)
+    if np.any((p[finite] < 0) | (p[finite] > 1)):
+        raise ValueError("p values must lie in [0, 1]")
+    q = np.full_like(p, np.nan)
+    idx = np.flatnonzero(finite)
+    if not idx.size:
+        return q
+    order = idx[np.argsort(p[idx])]
+    prev = 1.0
+    for rank, j in enumerate(order[::-1]):
+        prev = min(prev, p[j] * idx.size / (idx.size - rank))
+        q[j] = prev
+    return q
+
+
+def fdr_by_family(pvalues: np.ndarray, families: list[str]) -> np.ndarray:
+    """Apply BH separately within the supplied family IDs; preserve row order."""
+    p = np.asarray(pvalues, dtype=float)
+    if p.ndim != 1 or len(families) != p.size:
+        raise ValueError("one family ID is required per p value")
+    q = np.full_like(p, np.nan)
+    family = np.asarray(families)
+    for name in dict.fromkeys(families):
+        mask = family == name
+        q[mask] = bh_fdr(p[mask])
+    return q
+
+
+def moderation_design(
+    dose: np.ndarray, group: np.ndarray, *, full: bool = True
+) -> np.ndarray:
+    """Intercept, dose, group and optional dose × group design."""
+    cols = [np.ones(len(dose)), dose, group]
+    if full:
+        cols.append(dose * group)
+    return np.column_stack(cols)
+
+
+def ols_coefficients(design: np.ndarray, response: np.ndarray) -> np.ndarray:
+    """Least-squares coefficients; low-level compatibility helper."""
+    return np.linalg.lstsq(design, response, rcond=None)[0]
+
+
+def freedman_lane(
+    response: np.ndarray,
+    full_design: np.ndarray,
+    reduced_design: np.ndarray,
+    *,
+    coefficient: int,
+    n_permutations: int = 10000,
+    rng: np.random.Generator | None = None,
+    seed: int = 42,
+) -> tuple[float, float, np.ndarray]:
+    """Two-sided residual permutation for a coefficient in nested fixed designs.
+
+    Requires exchangeable reduced-model residuals across supplied rows. This
+    routine does not infer exchangeability blocks or heteroscedastic corrections.
+    The raw coefficient is the test statistic, matching the study's rank model.
+    """
+    y, full, reduced = map(
+        lambda a: np.asarray(a, dtype=float), (response, full_design, reduced_design)
+    )
+    if (
+        y.ndim != 1
+        or full.ndim != 2
+        or reduced.ndim != 2
+        or full.shape[0] != y.size
+        or reduced.shape[0] != y.size
+    ):
+        raise ValueError("designs must share response rows")
+    if not all(np.isfinite(a).all() for a in (y, full, reduced)):
+        raise ValueError("designs and response must be finite")
+    if n_permutations < 1 or not 0 <= coefficient < full.shape[1]:
+        raise ValueError("invalid permutation count or coefficient")
+    if (
+        np.linalg.matrix_rank(full) < full.shape[1]
+        or np.linalg.matrix_rank(reduced) < reduced.shape[1]
+    ):
+        raise ValueError("design is rank deficient")
+    if np.linalg.matrix_rank(np.column_stack([full, reduced])) > full.shape[1]:
+        raise ValueError("reduced design must be nested in full design")
+    rng = np.random.default_rng(seed) if rng is None else rng
+    observed = float(ols_coefficients(full, y)[coefficient])
+    fitted = reduced @ ols_coefficients(reduced, y)
+    residual = y - fitted
+    null = np.empty(n_permutations)
+    for i in range(n_permutations):
+        null[i] = ols_coefficients(full, fitted + residual[rng.permutation(y.size)])[
+            coefficient
+        ]
+    p = float((1 + np.sum(np.abs(null) >= abs(observed))) / (n_permutations + 1))
+    return observed, p, null
+
+
+@dataclass(frozen=True)
+class ModerationResult:
+    """Rank-scale slopes, interaction and participant bootstrap distributions."""
+
+    interaction: float
+    slope_a: float
+    slope_b: float
+    pvalue: float
+    permutation_null: np.ndarray
+    bootstrap_interaction: np.ndarray
+    bootstrap_slope_a: np.ndarray
+    bootstrap_slope_b: np.ndarray
+    bootstrap_valid_count: int
+    bootstrap_valid_fraction: float
+
+
+def rank_moderation(
+    dose_a: np.ndarray,
+    response_a: np.ndarray,
+    dose_b: np.ndarray,
+    response_b: np.ndarray,
+    *,
+    n_permutations: int = 10000,
+    n_bootstrap: int = 5000,
+    rng: np.random.Generator | None = None,
+    seed: int = 42,
+    singular_bootstrap: str = "discard",
+) -> ModerationResult:
+    """Pooled-rank dose × group model with group-stratified subject bootstrap.
+
+    Group A is coded one, B zero. Finite dose/outcome pairs are retained within
+    each group; all quantities are reranked after each bootstrap resample.
+    Singular bootstrap designs return NaN coefficients by default. The returned
+    count/fraction records identifiable draws; intervals should report this
+    coverage. ``singular_bootstrap="legacy"`` reproduces historical least-squares
+    coefficients even for singular draws, while still reporting their count.
+    """
+    if singular_bootstrap not in ("discard", "legacy"):
+        raise ValueError("singular_bootstrap must be discard or legacy")
+    a, ya, b, yb = map(
+        lambda v: np.asarray(v, float), (dose_a, response_a, dose_b, response_b)
+    )
+    if a.ndim != 1 or b.ndim != 1 or ya.shape != a.shape or yb.shape != b.shape:
+        raise ValueError("one response per dose is required")
+    va, vb = np.isfinite(a) & np.isfinite(ya), np.isfinite(b) & np.isfinite(yb)
+    a, ya, b, yb = a[va], ya[va], b[vb], yb[vb]
+    if min(a.size, b.size) < 2 or n_bootstrap < 1:
+        raise ValueError(
+            "at least two participants per group and a positive bootstrap count are required"
+        )
+    rng = np.random.default_rng(seed) if rng is None else rng
+    group = np.concatenate([np.ones(a.size), np.zeros(b.size)])
+    rx = stats.rankdata(np.concatenate([a, b]))
+    rx -= rx.mean()
+    ry = stats.rankdata(np.concatenate([ya, yb]))
+    full, red = moderation_design(rx, group), moderation_design(rx, group, full=False)
+    beta = ols_coefficients(full, ry)
+    interaction, p, null = freedman_lane(
+        ry, full, red, coefficient=3, n_permutations=n_permutations, rng=rng
+    )
+    bi, ba, bb = (
+        np.full(n_bootstrap, np.nan),
+        np.full(n_bootstrap, np.nan),
+        np.full(n_bootstrap, np.nan),
+    )
+    valid_count = 0
+    for j in range(n_bootstrap):
+        ia, ib = rng.integers(0, a.size, a.size), rng.integers(0, b.size, b.size)
+        rx = stats.rankdata(np.concatenate([a[ia], b[ib]]))
+        rx -= rx.mean()
+        draw_design = moderation_design(rx, group)
+        identifiable = np.linalg.matrix_rank(draw_design) == draw_design.shape[1]
+        valid_count += int(identifiable)
+        if not identifiable and singular_bootstrap == "discard":
+            continue
+        beta_draw = ols_coefficients(
+            draw_design,
+            stats.rankdata(np.concatenate([ya[ia], yb[ib]])),
+        )
+        bi[j], ba[j], bb[j] = beta_draw[3], beta_draw[1] + beta_draw[3], beta_draw[1]
+    return ModerationResult(
+        interaction,
+        float(beta[1] + beta[3]),
+        float(beta[1]),
+        p,
+        null,
+        bi,
+        ba,
+        bb,
+        valid_count,
+        valid_count / n_bootstrap,
+    )
+
+
+def bh_fdr_propagate(pvalues: np.ndarray) -> np.ndarray:
+    """Published per-parcel compatibility: NaNs propagate through BH sorting.
+
+    Prefer ``bh_fdr`` with a deliberate finite-value family for new analyses.
+    This exact legacy rule is separate so untestable parcels cannot silently
+    change the size of a published family during migration.
+    """
+    p = np.asarray(pvalues, dtype=float)
+    if p.ndim != 1:
+        raise ValueError("supply a one-dimensional family")
+    n = p.size
+    order = np.argsort(p)
+    ranked = p[order] * n / (np.arange(n) + 1)
+    q = np.minimum.accumulate(ranked[::-1])[::-1]
+    out = np.empty(n)
+    out[order] = np.clip(q, 0, 1)
+    return out

--- a/tit/stats/effects.py
+++ b/tit/stats/effects.py
@@ -1,0 +1,148 @@
+"""Array-only effect sizes and participant bootstrap confidence intervals.
+
+Finite participants remain in the mean bootstrap, including exact zeros.
+``exclude_zero_draws=True`` reproduces the published sleepTI bootstrap policy;
+it should be requested only to reproduce that analysis, not selected implicitly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import stats
+
+
+def rank_biserial(values: np.ndarray, other: np.ndarray | None = None) -> float:
+    """Signed matched-pairs or independent-samples rank-biserial effect.
+
+    Positive values favor ``values``. Paired input is already a difference;
+    zero differences are omitted from signed ranking (Wilcox convention).
+    """
+    a = np.asarray(values, dtype=float)
+    a = a[np.isfinite(a)]
+    if other is None:
+        a = a[a != 0]
+        if a.size < 2:
+            return float("nan")
+        ranks = stats.rankdata(np.abs(a))
+        plus, minus = ranks[a > 0].sum(), ranks[a < 0].sum()
+        return float((plus - minus) / (plus + minus))
+    b = np.asarray(other, dtype=float)
+    b = b[np.isfinite(b)]
+    if min(a.size, b.size) < 2:
+        return float("nan")
+    ranks = stats.rankdata(np.concatenate([a, b]))
+    u = float(ranks[: a.size].sum()) - a.size * (a.size + 1.0) / 2.0
+    return 2.0 * u / (a.size * b.size) - 1.0
+
+
+def percentile_ci(samples: np.ndarray, alpha: float = 0.05) -> tuple[float, float]:
+    """Finite-sample percentile interval; all-invalid input returns NaN bounds."""
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be between zero and one")
+    v = np.asarray(samples, dtype=float)
+    v = v[np.isfinite(v)]
+    if not v.size:
+        return float("nan"), float("nan")
+    return float(np.percentile(v, 100 * alpha / 2)), float(
+        np.percentile(v, 100 * (1 - alpha / 2))
+    )
+
+
+def bootstrap_effects(
+    values: np.ndarray,
+    other: np.ndarray | None = None,
+    *,
+    n_bootstrap: int = 5000,
+    rng: np.random.Generator | None = None,
+    seed: int = 42,
+    exclude_zero_draws: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return bootstrap rank-biserial effects and means / mean differences.
+
+    Resampling is across participants and independently within each group.
+    Paired data must be participant differences. Ranks are recomputed in each
+    draw; zeros affect the mean but not signed ranks unless the explicit
+    published compatibility option removes them before sampling.
+    """
+    if n_bootstrap < 1:
+        raise ValueError("n_bootstrap must be positive")
+    rng = np.random.default_rng(seed) if rng is None else rng
+    a = np.asarray(values, dtype=float)
+    a = a[np.isfinite(a)]
+    if other is None:
+        if exclude_zero_draws:
+            a = a[a != 0]
+        if a.size < 2:
+            return np.full(n_bootstrap, np.nan), np.full(n_bootstrap, np.nan)
+        draws = a[rng.integers(0, a.size, size=(n_bootstrap, a.size))]
+        if exclude_zero_draws:
+            ranks = stats.rankdata(np.abs(draws), axis=1)
+        else:
+            ranks = stats.rankdata(
+                np.where(draws != 0, np.abs(draws), np.nan), axis=1, nan_policy="omit"
+            )
+            ranks = np.nan_to_num(ranks)
+        plus = np.sum(ranks * (draws > 0), axis=1)
+        minus = np.sum(ranks * (draws < 0), axis=1)
+        total = plus + minus
+        r = np.divide(
+            plus - minus, total, out=np.full(n_bootstrap, np.nan), where=total > 0
+        )
+        return r, draws.mean(axis=1)
+    b = np.asarray(other, dtype=float)
+    b = b[np.isfinite(b)]
+    if min(a.size, b.size) < 2:
+        return np.full(n_bootstrap, np.nan), np.full(n_bootstrap, np.nan)
+    da = a[rng.integers(0, a.size, size=(n_bootstrap, a.size))]
+    db = b[rng.integers(0, b.size, size=(n_bootstrap, b.size))]
+    ranks = stats.rankdata(np.concatenate([da, db], axis=1), axis=1)
+    u = np.sum(ranks[:, : a.size], axis=1) - a.size * (a.size + 1.0) / 2.0
+    return 2.0 * u / (a.size * b.size) - 1.0, da.mean(axis=1) - db.mean(axis=1)
+
+
+def cluster_mean_r_along_subjects(
+    field: np.ndarray, response: np.ndarray
+) -> np.ndarray:
+    """Per-bootstrap cluster mean correlation. field/response: (n_boot, n_subjects, k)."""
+    valid = np.isfinite(field) & np.isfinite(response)
+    x = np.where(valid, field, np.nan)
+    y = np.where(valid, response, np.nan)
+    x_centered = x - np.nanmean(x, axis=1, keepdims=True)
+    y_centered = y - np.nanmean(y, axis=1, keepdims=True)
+    numerator = np.nansum(x_centered * y_centered, axis=1)
+    denominator = np.sqrt(
+        np.nansum(x_centered**2, axis=1) * np.nansum(y_centered**2, axis=1)
+    )
+    r = np.divide(
+        numerator,
+        denominator,
+        out=np.full_like(numerator, np.nan),
+        where=denominator > 0,
+    )
+    r[valid.sum(axis=1) < 4] = np.nan
+    return np.nanmean(r, axis=1)
+
+
+def bootstrap_cluster_mean_r_ci(
+    field_cluster: np.ndarray,
+    response_cluster: np.ndarray,
+    *,
+    statistic: str,
+    n_bootstrap: int,
+    ci_alpha: float,
+    rng: np.random.Generator,
+) -> tuple[float, float]:
+    """Subject-level bootstrap CI on the cluster mean correlation.
+
+    field_cluster/response_cluster are raw (unranked) subject-by-cluster-vertex
+    matrices; for Spearman each resample is re-ranked across subjects.
+    """
+    n_subjects = field_cluster.shape[0]
+    idx = rng.integers(0, n_subjects, size=(n_bootstrap, n_subjects))
+    field_draws = field_cluster[idx]
+    response_draws = response_cluster[idx]
+    if statistic == "spearman":
+        field_draws = stats.rankdata(field_draws, axis=1, nan_policy="omit")
+        response_draws = stats.rankdata(response_draws, axis=1, nan_policy="omit")
+    boot_means = cluster_mean_r_along_subjects(field_draws, response_draws)
+    return percentile_ci(boot_means, ci_alpha)

--- a/tit/stats/graph.py
+++ b/tit/stats/graph.py
@@ -1,0 +1,478 @@
+"""Seeded graph cluster inference over participant-by-feature arrays.
+
+Sensors, source vertices and other features share the same sparse graph API.
+No file formats, cohort labels, FEM libraries or plotting dependencies enter
+this module. Safe defaults separate opposite signs. ``absolute_connected``
+is an explicit compatibility policy for the published sleepTI sensor test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+from scipy import sparse, stats
+
+
+def mannwhitney_z(group_a: np.ndarray, group_b: np.ndarray) -> np.ndarray:
+    """NaN-aware U normal score without tie or continuity correction.
+
+    This is the published permutation cluster-forming score, not a SciPy
+    tie-corrected asymptotic p-value. Prefer the explicit permutation result."""
+    n_group_a = group_a.shape[0]
+    combined = np.vstack([group_a, group_b]).astype(
+        float
+    )  # (n_group_a+n_group_b, n_ch)
+    finite = np.isfinite(combined)
+    masked = np.where(finite, combined, np.nan)
+    ranks = stats.rankdata(masked, axis=0, nan_policy="omit")
+    group_a_finite = finite[:n_group_a]
+    na = group_a_finite.sum(axis=0).astype(float)
+    ns = finite[n_group_a:].sum(axis=0).astype(float)
+    rank_sum = np.nansum(np.where(group_a_finite, ranks[:n_group_a], 0.0), axis=0)
+    u_value = rank_sum - na * (na + 1.0) / 2.0
+    mean_u = na * ns / 2.0
+    std_u = np.sqrt(na * ns * (na + ns + 1.0) / 12.0)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        z_values = np.where(std_u > 0, (u_value - mean_u) / std_u, 0.0)
+    z_values[(na < 2) | (ns < 2)] = np.nan
+    return z_values
+
+
+def wilcoxon_z(values: np.ndarray) -> np.ndarray:
+    """NaN-aware signed-rank normal score without tie/continuity correction.
+
+    Zeros are excluded (Wilcox rule). The normal score defines permutation
+    clusters; it is not a SciPy tie-corrected asymptotic p-value."""
+    values = values.astype(float)
+    valid = np.isfinite(values) & (values != 0)
+    abs_masked = np.where(valid, np.abs(values), np.nan)
+    ranks = stats.rankdata(abs_masked, axis=0, nan_policy="omit")
+    n_obs = valid.sum(axis=0).astype(float)
+    t_plus = np.nansum(np.where(valid & (values > 0), ranks, 0.0), axis=0)
+    mean_t = n_obs * (n_obs + 1.0) / 4.0
+    std_t = np.sqrt(n_obs * (n_obs + 1.0) * (2.0 * n_obs + 1.0) / 24.0)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        z_values = np.where(std_t > 0, (t_plus - mean_t) / std_t, 0.0)
+    z_values[n_obs < 2] = np.nan
+    return z_values
+
+
+def threshold_mask(z_values: np.ndarray, threshold: float, tail: int) -> np.ndarray:
+    finite_z = np.nan_to_num(z_values, nan=0.0)
+    if tail > 0:
+        return finite_z > threshold
+    if tail < 0:
+        return finite_z < -threshold
+    return np.abs(finite_z) > threshold
+
+
+def _canonical_graph(adjacency, n_features: int) -> sparse.csr_matrix:
+    """Copy connectivity, discarding explicitly stored zero-valued non-edges."""
+    graph = sparse.csr_matrix(adjacency, dtype=bool, copy=True)
+    graph.sum_duplicates()
+    graph.eliminate_zeros()
+    graph.sort_indices()
+    if graph.shape != (n_features, n_features):
+        raise ValueError("adjacency must match the feature dimension")
+    if (graph != graph.T).nnz:
+        raise ValueError("adjacency must be symmetric")
+    return graph
+
+
+def find_clusters(
+    z_values: np.ndarray,
+    adjacency: sparse.csr_matrix,
+    threshold: float,
+    tail: int,
+    *,
+    sign_policy: str = "separate",
+    min_cluster_size: int = 1,
+) -> list[np.ndarray]:
+    if sign_policy not in ("separate", "absolute_connected") or min_cluster_size < 1:
+        raise ValueError("invalid sign policy or minimum cluster size")
+    z_values = np.asarray(z_values, dtype=float)
+    if z_values.ndim != 1:
+        raise ValueError("statistics must be a feature vector")
+    adjacency = _canonical_graph(adjacency, z_values.size)
+    supra = threshold_mask(z_values, threshold, tail)
+    visited: set[int] = set()
+    clusters: list[np.ndarray] = []
+
+    for seed in np.where(supra)[0]:
+        if int(seed) in visited:
+            continue
+        queue = [int(seed)]
+        visited.add(int(seed))
+        cluster: list[int] = []
+        while queue:
+            node = queue.pop(0)
+            cluster.append(node)
+            neighbors = adjacency.indices[
+                adjacency.indptr[node] : adjacency.indptr[node + 1]
+            ]
+            for neighbor in neighbors:
+                neighbor = int(neighbor)
+                if (
+                    supra[neighbor]
+                    and neighbor not in visited
+                    and (
+                        sign_policy == "absolute_connected"
+                        or np.sign(z_values[neighbor]) == np.sign(z_values[node])
+                    )
+                ):
+                    visited.add(neighbor)
+                    queue.append(neighbor)
+        if len(cluster) >= min_cluster_size:
+            clusters.append(np.asarray(sorted(cluster), dtype=int))
+    return clusters
+
+
+def cluster_mass(z_values: np.ndarray, cluster: np.ndarray, tail: int) -> float:
+    cluster_values = np.nan_to_num(z_values[cluster], nan=0.0)
+    if tail > 0:
+        return float(cluster_values.sum())
+    if tail < 0:
+        return float(-cluster_values.sum())
+    return float(np.abs(cluster_values).sum())
+
+
+@dataclass(frozen=True)
+class GraphClusterResult:
+    """Observed statistics, feature-index clusters and max-statistic null."""
+
+    statistic: np.ndarray
+    clusters: tuple[np.ndarray, ...]
+    pvalues: np.ndarray
+    null_distribution: np.ndarray
+    significant_mask: np.ndarray
+    exact: bool = False
+
+
+def _validate_graph(data, adjacency):
+    values = np.asarray(data, dtype=float)
+    if values.ndim != 2 or values.shape[0] < 2:
+        raise ValueError("data must contain at least two participant rows")
+    return values, _canonical_graph(adjacency, values.shape[1])
+
+
+def cluster_permutation(
+    data: np.ndarray,
+    adjacency: sparse.spmatrix,
+    *,
+    other: np.ndarray | None = None,
+    statistic: str = "t",
+    n_permutations: int = 5000,
+    seed: int = 42,
+    threshold_p: float = 0.05,
+    alpha: float = 0.05,
+    tail: int = 0,
+    sign_policy: str = "separate",
+    min_cluster_size: int = 1,
+) -> GraphClusterResult:
+    """Paired-change or independent-group graph cluster permutation test.
+
+    ``data`` is participant differences for a paired/one-sample test; supplying
+    ``other`` requests independent groups. ``statistic='rank'`` uses the
+    study's NaN-aware signed-rank or U normal score without tie correction;
+    ``'t'`` uses SciPy t statistics (pooled variance between groups). Whole
+    participant rows are sign-flipped or relabeled together across all features.
+    This samples permutations with replacement; use ``mne_cluster_test`` for
+    the source pipeline's MNE exact-enumeration/TFCE behavior.
+    """
+    data, graph = _validate_graph(data, adjacency)
+    if (
+        n_permutations < 1
+        or not 0 < threshold_p < 1
+        or not 0 < alpha < 1
+        or tail not in (-1, 0, 1)
+    ):
+        raise ValueError("invalid inference parameters")
+    if statistic not in ("t", "rank", "f"):
+        raise ValueError("statistic must be t, rank or f")
+    if other is not None:
+        other, _ = _validate_graph(other, graph)
+    if statistic == "f" and (other is None or tail != 1):
+        raise ValueError("F requires independent groups and tail=1")
+    prob = threshold_p / 2 if tail == 0 else threshold_p
+    if statistic == "rank":
+        threshold = stats.norm.ppf(1 - prob)
+        compute = (
+            (lambda x, y: mannwhitney_z(x, y))
+            if other is not None
+            else (lambda x, y: wilcoxon_z(x))
+        )
+    elif statistic == "f":
+        threshold = stats.f.ppf(1 - prob, 1, data.shape[0] + other.shape[0] - 2)
+        compute = lambda x, y: stats.f_oneway(x, y, axis=0).statistic
+    else:
+        df = data.shape[0] - 1 if other is None else data.shape[0] + other.shape[0] - 2
+        threshold = stats.t.ppf(1 - prob, df)
+        compute = (
+            (lambda x, y: stats.ttest_ind(x, y, axis=0, nan_policy="omit").statistic)
+            if other is not None
+            else (
+                lambda x, y: stats.ttest_1samp(
+                    x, 0, axis=0, nan_policy="omit"
+                ).statistic
+            )
+        )
+
+    def clusters_for(observed):
+        return find_clusters(
+            observed,
+            graph,
+            threshold,
+            tail,
+            sign_policy=sign_policy,
+            min_cluster_size=min_cluster_size,
+        )
+
+    observed = compute(data, other)
+    clusters = clusters_for(observed)
+    rng = np.random.default_rng(seed)
+    null = np.zeros(n_permutations)
+    combined = None if other is None else np.vstack([data, other])
+    for i in range(n_permutations):
+        if combined is None:
+            perm = compute(
+                data * rng.choice(np.array([-1.0, 1.0]), size=(data.shape[0], 1)), None
+            )
+        else:
+            order = rng.permutation(combined.shape[0])
+            perm = compute(
+                combined[order[: data.shape[0]]], combined[order[data.shape[0] :]]
+            )
+        null[i] = max(
+            (cluster_mass(perm, c, tail) for c in clusters_for(perm)), default=0.0
+        )
+    p = np.array(
+        [
+            (1 + np.sum(null >= cluster_mass(observed, c, tail))) / (n_permutations + 1)
+            for c in clusters
+        ]
+    )
+    mask = np.zeros(data.shape[1], bool)
+    for c, pv in zip(clusters, p):
+        if pv < alpha:
+            mask[c] = True
+    return GraphClusterResult(observed, tuple(clusters), p, null, mask)
+
+
+def mne_cluster_test(
+    data: np.ndarray,
+    adjacency: sparse.spmatrix,
+    *,
+    other: np.ndarray | None = None,
+    n_permutations: int = 5000,
+    seed: int = 42,
+    tail: int = 0,
+    use_tfce: bool = False,
+    n_jobs: int = 1,
+) -> tuple:
+    """Thin MNE source-statistics adapter preserving MNE null conventions.
+
+    One-sample t/sign-flips when ``other`` is absent; MNE's default F/group
+    relabeling otherwise. Returns MNE's statistic, clusters, p values, H0 tuple.
+    MNE owns automatic exact enumeration at small N. With TFCE enabled, MNE
+    owns per-feature interpretation of the returned clusters. Imported lazily.
+    """
+    data, graph = _validate_graph(data, adjacency)
+    from mne.stats import (
+        spatio_temporal_cluster_1samp_test,
+        spatio_temporal_cluster_test,
+    )
+
+    kwargs = dict(
+        n_permutations=n_permutations,
+        threshold=dict(start=0.0, step=0.2) if use_tfce else None,
+        tail=tail,
+        adjacency=graph,
+        n_jobs=n_jobs,
+        seed=seed,
+        verbose=False,
+        buffer_size=None,
+    )
+    if other is None:
+        return spatio_temporal_cluster_1samp_test(data[:, None, :], **kwargs)
+    other, _ = _validate_graph(other, graph)
+    return spatio_temporal_cluster_test([data[:, None, :], other[:, None, :]], **kwargs)
+
+
+def rank_columns(matrix: np.ndarray) -> np.ndarray:
+    """Rank each feature across participants, omitting nonfinite observations."""
+    return np.apply_along_axis(stats.rankdata, 0, matrix, nan_policy="omit")
+
+
+def pearson_columns(
+    field: np.ndarray, response: np.ndarray, *, published_policy: bool = False
+) -> tuple[np.ndarray, np.ndarray]:
+    """Paired-column Pearson correlations with complete pairs per feature.
+
+    ``published_policy`` retains the original study handling of exactly perfect
+    correlations (p=1); the general default gives p=0 for finite |r|=1.
+    """
+    field, response = np.asarray(field, float), np.asarray(response, float)
+    if field.ndim != 2 or field.shape != response.shape:
+        raise ValueError("field and response must share participant × feature shape")
+    valid = np.isfinite(field) & np.isfinite(response)
+    n = valid.sum(axis=0)
+    x, y = np.where(valid, field, np.nan), np.where(valid, response, np.nan)
+    xc, yc = x - np.nanmean(x, axis=0, keepdims=True), y - np.nanmean(
+        y, axis=0, keepdims=True
+    )
+    numerator = np.nansum(xc * yc, axis=0)
+    denominator = np.sqrt(np.nansum(xc**2, axis=0) * np.nansum(yc**2, axis=0))
+    r = np.divide(
+        numerator,
+        denominator,
+        out=np.full(field.shape[1], np.nan),
+        where=denominator > 0,
+    )
+    t = r * np.sqrt(
+        np.divide(n - 2, 1 - r**2, out=np.zeros_like(r), where=(1 - r**2) > 0)
+    )
+    p = 2 * stats.t.sf(np.abs(t), df=np.maximum(n - 2, 1))
+    if not published_policy:
+        r = np.clip(r, -1.0, 1.0)
+        p[np.isfinite(r) & (np.abs(r) >= 1)] = 0.0
+    p[n < 4], r[n < 4] = np.nan, np.nan
+    return r, p
+
+
+def correlation_clusters(
+    r: np.ndarray,
+    p: np.ndarray,
+    graph: sparse.csr_matrix,
+    *,
+    p_threshold: float = 0.05,
+    min_vertices: int = 1,
+) -> list[dict[str, object]]:
+    """Sign-separated graph clusters and correlation-mass summaries."""
+    from scipy.sparse.csgraph import connected_components
+
+    r, p = np.asarray(r, dtype=float), np.asarray(p, dtype=float)
+    if r.ndim != 1 or p.shape != r.shape:
+        raise ValueError("correlation and p values must share a feature vector shape")
+    graph = _canonical_graph(graph, r.size)
+    clusters = []
+    for name, sign in (("positive", r > 0), ("negative", r < 0)):
+        mask = np.isfinite(p) & (p < p_threshold) & sign
+        if not mask.any():
+            continue
+        n, labels = connected_components(graph[mask][:, mask])
+        nodes = np.flatnonzero(mask)
+        for k in range(n):
+            c = nodes[labels == k]
+            if c.size < min_vertices:
+                continue
+            clusters.append(
+                dict(
+                    nodes=c,
+                    sign=name,
+                    n_vertices=int(c.size),
+                    cluster_mass_abs_r=float(np.nansum(np.abs(r[c]))),
+                    mean_r=float(np.nanmean(r[c])),
+                    max_abs_r=float(np.nanmax(np.abs(r[c]))),
+                    min_p=float(np.nanmin(p[c])),
+                )
+            )
+    return clusters
+
+
+def correlation_permutation_null(
+    field: np.ndarray,
+    response: np.ndarray,
+    graph: sparse.csr_matrix,
+    *,
+    n_permutations: int,
+    rng: np.random.Generator,
+    p_threshold: float = 0.05,
+    min_vertices: int = 1,
+    published_policy: bool = False,
+) -> np.ndarray:
+    """Whole-response-row permutations; pass preranked arrays for Spearman."""
+    null = np.zeros(n_permutations)
+    for i in range(n_permutations):
+        r, p = pearson_columns(
+            field,
+            response[rng.permutation(response.shape[0]), :],
+            published_policy=published_policy,
+        )
+        clusters = correlation_clusters(
+            r, p, graph, p_threshold=p_threshold, min_vertices=min_vertices
+        )
+        if clusters:
+            null[i] = max(float(c["cluster_mass_abs_r"]) for c in clusters)
+    return null
+
+
+def correlation_cluster_permutation(
+    field: np.ndarray,
+    response: np.ndarray,
+    adjacency: sparse.spmatrix,
+    *,
+    method: str = "spearman",
+    n_permutations: int = 5000,
+    seed: int = 42,
+    threshold_p: float = 0.05,
+    alpha: float = 0.05,
+    min_cluster_size: int = 1,
+) -> GraphClusterResult:
+    """Local field–response graph inference with sum-|rho| cluster mass.
+
+    Both inputs are participant × feature maps. Complete finite arrays are
+    required for Spearman so missingness cannot alter the rank population after
+    shuffling. Use explicit lower-level helpers for a historical NaN policy.
+    """
+    field, graph = _validate_graph(field, adjacency)
+    response = np.asarray(response, float)
+    if response.shape != field.shape or n_permutations < 1 or min_cluster_size < 1:
+        raise ValueError("invalid array shape or permutation/cluster count")
+    if (
+        method not in ("spearman", "pearson")
+        or not 0 < threshold_p < 1
+        or not 0 < alpha < 1
+    ):
+        raise ValueError("invalid method or threshold")
+    if method == "spearman":
+        if not np.isfinite(field).all() or not np.isfinite(response).all():
+            raise ValueError("Spearman permutation requires complete finite arrays")
+        field, response = rank_columns(field), rank_columns(response)
+    r, p = pearson_columns(field, response)
+    clusters = correlation_clusters(
+        r, p, graph, p_threshold=threshold_p, min_vertices=min_cluster_size
+    )
+    null = correlation_permutation_null(
+        field,
+        response,
+        graph,
+        n_permutations=n_permutations,
+        rng=np.random.default_rng(seed),
+        p_threshold=threshold_p,
+        min_vertices=min_cluster_size,
+    )
+    pv = np.array(
+        [
+            (1 + np.sum(null >= c["cluster_mass_abs_r"])) / (n_permutations + 1)
+            for c in clusters
+        ]
+    )
+    mask = np.zeros(field.shape[1], bool)
+    for c, value in zip(clusters, pv):
+        if value < alpha:
+            mask[c["nodes"]] = True
+    return GraphClusterResult(r, tuple(c["nodes"] for c in clusters), pv, null, mask)
+
+
+def triangle_adjacency(triangles: np.ndarray, n_nodes: int) -> sparse.csr_matrix:
+    edges = np.vstack(
+        [
+            triangles[:, [0, 1]],
+            triangles[:, [1, 2]],
+            triangles[:, [2, 0]],
+        ]
+    )
+    row = np.concatenate([edges[:, 0], edges[:, 1]])
+    col = np.concatenate([edges[:, 1], edges[:, 0]])
+    data = np.ones(row.shape[0], dtype=bool)
+    return sparse.coo_matrix((data, (row, col)), shape=(n_nodes, n_nodes)).tocsr()

--- a/tit/stats/robustness.py
+++ b/tit/stats/robustness.py
@@ -1,0 +1,131 @@
+"""Participant influence diagnostics; selected-region sensitivity is not validation."""
+
+from __future__ import annotations
+from collections.abc import Callable
+import numpy as np
+from .effects import rank_biserial
+
+MODIFIED_Z_OUTLIER = 3.5
+
+
+def modified_zscores(values: np.ndarray) -> np.ndarray:
+    """Median/MAD modified z-scores; falls back to mean/SD when MAD is zero."""
+    v = np.asarray(values, dtype=float)
+    median = np.nanmedian(v)
+    mad = np.nanmedian(np.abs(v - median))
+    if mad > 0:
+        return 0.6745 * (v - median) / mad
+    sd = np.nanstd(v)
+    if sd > 0:
+        return (v - np.nanmean(v)) / sd
+    return np.zeros_like(v)
+
+
+def describe(values: np.ndarray) -> dict[str, float]:
+    """Summary statistics for inter-individual variability."""
+    v = np.asarray(values, dtype=float)
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return {}
+    q1, q3 = np.percentile(v, [25, 75])
+    mean = float(v.mean())
+    sd = float(v.std(ddof=1)) if v.size > 1 else float("nan")
+    return {
+        "n": int(v.size),
+        "mean": mean,
+        "sd": sd,
+        "cv": float(sd / mean) if mean != 0 else float("nan"),
+        "median": float(np.median(v)),
+        "iqr": float(q3 - q1),
+        "min": float(v.min()),
+        "max": float(v.max()),
+    }
+
+
+def loso_subject_effects(values: np.ndarray, ids: list[str]) -> list[dict[str, object]]:
+    """Drop each subject in turn and recompute the cluster effect.
+
+    Returns one row per subject with the recomputed rank-biserial r and cluster
+    mean, plus the change relative to the full-sample effect. A result robust to
+    inter-individual variability shows small ``delta_r`` for every subject.
+    """
+    v = np.asarray(values, dtype=float)
+    n = v.size
+    full_r = rank_biserial(v)
+    full_mean = float(np.nanmean(v))
+    z = modified_zscores(v)
+    rows: list[dict[str, object]] = []
+    for i in range(n):
+        keep = np.delete(v, i)
+        loso_r = rank_biserial(keep)
+        loso_mean = float(np.nanmean(keep))
+        rows.append(
+            {
+                "dropped_subject": ids[i],
+                "subject_value": float(v[i]),
+                "modified_z": float(z[i]),
+                "is_outlier": bool(abs(z[i]) > MODIFIED_Z_OUTLIER),
+                "loso_rank_biserial_r": loso_r,
+                "loso_mean_change": loso_mean,
+                "delta_r": (
+                    float(loso_r - full_r)
+                    if np.isfinite(loso_r) and np.isfinite(full_r)
+                    else float("nan")
+                ),
+                "delta_mean": float(loso_mean - full_mean),
+            }
+        )
+    return rows
+
+
+def loso_summary(
+    rows: list[dict[str, object]], full_r: float, full_mean: float
+) -> dict[str, object]:
+    """Collapse per-subject LOSO rows into a one-line robustness verdict."""
+    loso_r = np.array([r["loso_rank_biserial_r"] for r in rows], dtype=float)
+    loso_m = np.array([r["loso_mean_change"] for r in rows], dtype=float)
+    deltas = np.abs([r["delta_r"] for r in rows])
+    worst = int(np.nanargmax(deltas)) if np.isfinite(deltas).any() else -1
+    return {
+        "full_rank_biserial_r": full_r,
+        "full_mean_change": full_mean,
+        "loso_r_min": float(np.nanmin(loso_r)),
+        "loso_r_max": float(np.nanmax(loso_r)),
+        "loso_mean_min": float(np.nanmin(loso_m)),
+        "loso_mean_max": float(np.nanmax(loso_m)),
+        "max_abs_delta_r": (
+            float(np.nanmax(deltas)) if np.isfinite(deltas).any() else float("nan")
+        ),
+        "most_influential_subject": (
+            rows[worst]["dropped_subject"] if worst >= 0 else ""
+        ),
+        "n_outliers": int(sum(1 for r in rows if r["is_outlier"])),
+    }
+
+
+def leave_one_out(
+    data: np.ndarray,
+    statistic: Callable[[np.ndarray], float],
+    *,
+    subject_ids: list[str] | None = None,
+) -> list[dict]:
+    """Recompute a scalar callback after omitting each participant row.
+
+    A callback can recompute a fixed-ROI effect or run a complete estimator.
+    Those are different procedures; callers must label them explicitly.
+    """
+    data = np.asarray(data)
+    if data.ndim < 1 or data.shape[0] < 3:
+        raise ValueError("at least three participant rows are required")
+    ids = [str(i) for i in range(len(data))] if subject_ids is None else subject_ids
+    if len(ids) != len(data) or len(set(ids)) != len(ids):
+        raise ValueError("one unique subject ID is required per row")
+    full = float(statistic(data))
+    return [
+        dict(
+            dropped_subject=ids[i],
+            estimate=float(statistic(np.delete(data, i, axis=0))),
+            full_estimate=full,
+        )
+        for i in range(len(data))
+    ]


### PR DESCRIPTION
EEG studies can now call shared TI-Toolbox functions for channel/event preparation, recording-aligned forward models, inverse windows, carrier projection, atlas reduction, graph permutation tests, associations and participant influence. Cohort definitions, scientific contrasts and figure composition remain in the downstream study; an output-free notebook demonstrates the generic workflow.

The extracted APIs expose published compatibility policies explicitly. New-study defaults handle zero graph edges, undefined partial correlations and singular bootstrap draws. Forward inputs respect supplied recording geometry; projection cache reuse checks input and runtime provenance and recovers from interrupted archives. The original BSD study attribution is retained in the package.

Validation: 4,886 host tests passed (48 environment skips); 40 real-library numerical/parity tests passed, including frozen `v1.0-preliminary` comparisons in two downstream checkouts. The synthetic notebook ran in a real Jupyter kernel. Route/contract guards, wheel packaging and Jekyll build passed.

This remains a draft pending approved participant-data/FEM reproduction and compatible Linux container acceptance. No manuscript result or released container image has been regenerated. The local SimNIBS installation combines MNE1.5 and NumPy2, so reconstruction tests used the study's real MNE1.12.1 interpreter; this is documented in the testing guide.
